### PR TITLE
メッセージ提案のための、質問・回答ページを表示し、回答内容をsessionに保持する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ group :development do
 
   # To find bug
   gem 'pry-rails'
+  gem 'pry-byebug'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,9 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+
+  # To find bug
+  gem 'pry-rails'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.3.0)
+    byebug (11.1.3)
     capybara (3.40.0)
       addressable
       matrix
@@ -171,6 +172,9 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
     psych (5.1.2)
@@ -286,6 +290,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   mysql2 (~> 0.5)
+  pry-byebug
   pry-rails
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -136,6 +137,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.24.1)
     msgpack (1.7.2)
@@ -166,6 +168,11 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.11)
+      pry (>= 0.13.0)
     psych (5.1.2)
       stringio
     public_suffix (6.0.0)
@@ -279,6 +286,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   mysql2 (~> 0.5)
+  pry-rails
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
   ruby-openai

--- a/app/controllers/q_and_a_controller.rb
+++ b/app/controllers/q_and_a_controller.rb
@@ -6,30 +6,26 @@ class QAndAController < ApplicationController
   def question3;end
 
   def answer1
-    key = q_and_a_params.keys.first.to_sym
-    value = q_and_a_params.values.join
-    session[key] = value
+    save_in_session(q_and_a_params)
     redirect_to question2_path
   end
   
   def answer2
-    key = q_and_a_params.keys.first.to_sym
-    value = q_and_a_params.values.join
-    session[key] = value
+    save_in_session(q_and_a_params)
     redirect_to question3_path
   end
   
   def answer3
-    key = q_and_a_params.keys.first.to_sym
-    value = q_and_a_params.values.join
-    session[key] = value
+    save_in_session(q_and_a_params)
   end
 
   private
 
-  # def set_q_and_a_form
-  #   @q_and_a_form = QAndAForm.new(session)
-  # end
+  def save_in_session(q_and_a)
+    q_and_a.each do |key, value|
+      session[key.to_sym] = value
+    end
+  end
 
   def q_and_a_params
     params.require(:answer).permit(:question1, :question2, :question3)

--- a/app/controllers/q_and_a_controller.rb
+++ b/app/controllers/q_and_a_controller.rb
@@ -1,0 +1,37 @@
+class QAndAController < ApplicationController
+  # before_action :set_q_and_a_form
+
+  def question1;end
+  def question2;end
+  def question3;end
+
+  def answer1
+    key = q_and_a_params.keys.first.to_sym
+    value = q_and_a_params.values.join
+    session[key] = value
+    redirect_to question2_path
+  end
+  
+  def answer2
+    key = q_and_a_params.keys.first.to_sym
+    value = q_and_a_params.values.join
+    session[key] = value
+    redirect_to question3_path
+  end
+  
+  def answer3
+    key = q_and_a_params.keys.first.to_sym
+    value = q_and_a_params.values.join
+    session[key] = value
+  end
+
+  private
+
+  # def set_q_and_a_form
+  #   @q_and_a_form = QAndAForm.new(session)
+  # end
+
+  def q_and_a_params
+    params.require(:answer).permit(:question1, :question2, :question3)
+  end
+end

--- a/app/views/q_and_a/question1.html.erb
+++ b/app/views/q_and_a/question1.html.erb
@@ -1,13 +1,18 @@
 <%= form_with url: answer1_path, method: :post, data: { turbo: false } do |form| %>
-  <%= form.radio_button 'answer[question1]', 'friend' %>
-  <%= form.label :answer_question1_friend, '友だち' %><br>
+  <%= form.radio_button 'answer[question1]', 'friend', required: true %>
+  <%= form.label 'answer[question1]_friend', '友だち' %><br>
+
   <%= form.radio_button 'answer[question1]', 'family' %>
-  <%= form.label :answer_question1_family, '家族' %><br>
+  <%= form.label 'answer[question1]_family', '家族' %><br>
+
   <%= form.radio_button 'answer[question1]', 'work' %>
-  <%= form.label :answer_question1_work, '仕事関係' %><br>
+  <%= form.label 'answer[question1]_work', '仕事関係' %><br>
+
   <%= form.radio_button 'answer[question1]', 'acquaintance' %>
-  <%= form.label :answer_question1_acquaintance, 'ちょっとした知り合い' %><br>
+  <%= form.label 'answer[question1]_acquaintance', 'ちょっとした知り合い' %><br>
+
   <%= form.radio_button 'answer[question1]', 'others' %>
-  <%= form.label :answer_question1_others, 'そのほか' %><br>
+  <%= form.label 'answer[question1]_others', 'そのほか' %><br>
+  
   <%= form.submit '次へ' %>
 <% end %>

--- a/app/views/q_and_a/question1.html.erb
+++ b/app/views/q_and_a/question1.html.erb
@@ -1,0 +1,13 @@
+<%= form_with url: answer1_path, method: :post, data: { turbo: false } do |form| %>
+  <%= form.radio_button 'answer[question1]', 'friend' %>
+  <%= form.label :answer_question1_friend, '友だち' %><br>
+  <%= form.radio_button 'answer[question1]', 'family' %>
+  <%= form.label :answer_question1_family, '家族' %><br>
+  <%= form.radio_button 'answer[question1]', 'work' %>
+  <%= form.label :answer_question1_work, '仕事関係' %><br>
+  <%= form.radio_button 'answer[question1]', 'acquaintance' %>
+  <%= form.label :answer_question1_acquaintance, 'ちょっとした知り合い' %><br>
+  <%= form.radio_button 'answer[question1]', 'others' %>
+  <%= form.label :answer_question1_others, 'そのほか' %><br>
+  <%= form.submit '次へ' %>
+<% end %>

--- a/app/views/q_and_a/question2.html.erb
+++ b/app/views/q_and_a/question2.html.erb
@@ -1,0 +1,15 @@
+<%= form_with url: answer2_path, method: :post, data: { turbo: false } do |form| %>
+  <%= form.radio_button 'answer[question2]', 'select2_1' %>
+  <%= form.label :answer_question2_select2_1, '最近どうしてる？' %><br>
+  <%= form.radio_button 'answer[question2]', 'select2_2' %>
+  <%= form.label :answer_question2_select2_2, '仕事は順調？' %><br>
+  <%= form.radio_button 'answer[question2]', 'select2_3' %>
+  <%= form.label :answer_question2_select2_3, '今どこに住んでいるの？' %><br>
+  <%= form.radio_button 'answer[question2]', 'select2_4' %>
+  <%= form.label :answer_question2_select2_4, '久しぶりに会いたい' %><br>
+  <%= form.radio_button 'answer[question2]', 'select2_5' %>
+  <%= form.label :answer_question2_select2_5, 'ご飯でもいこう' %><br>
+  <%= form.radio_button 'answer[question2]', 'select2_6' %>
+  <%= form.label :answer_question2_select2_6, '遊びにいこう' %><br>
+  <%= form.submit '次へ' %>
+<% end %>

--- a/app/views/q_and_a/question2.html.erb
+++ b/app/views/q_and_a/question2.html.erb
@@ -1,15 +1,21 @@
 <%= form_with url: answer2_path, method: :post, data: { turbo: false } do |form| %>
-  <%= form.radio_button 'answer[question2]', 'select2_1' %>
-  <%= form.label :answer_question2_select2_1, '最近どうしてる？' %><br>
-  <%= form.radio_button 'answer[question2]', 'select2_2' %>
-  <%= form.label :answer_question2_select2_2, '仕事は順調？' %><br>
-  <%= form.radio_button 'answer[question2]', 'select2_3' %>
-  <%= form.label :answer_question2_select2_3, '今どこに住んでいるの？' %><br>
-  <%= form.radio_button 'answer[question2]', 'select2_4' %>
-  <%= form.label :answer_question2_select2_4, '久しぶりに会いたい' %><br>
-  <%= form.radio_button 'answer[question2]', 'select2_5' %>
-  <%= form.label :answer_question2_select2_5, 'ご飯でもいこう' %><br>
-  <%= form.radio_button 'answer[question2]', 'select2_6' %>
-  <%= form.label :answer_question2_select2_6, '遊びにいこう' %><br>
+  <%= form.radio_button 'answer[question2]', 'life', required: true %>
+  <%= form.label 'answer[question2]_life', '最近どうしてる？' %><br>
+
+  <%= form.radio_button 'answer[question2]', 'work' %>
+  <%= form.label 'answer[question2]_work', '仕事は順調？' %><br>
+
+  <%= form.radio_button 'answer[question2]', 'place' %>
+  <%= form.label 'answer[question2]_place', '今どこに住んでいるの？' %><br>
+
+  <%= form.radio_button 'answer[question2]', 'meet' %>
+  <%= form.label 'answer[question2]_meet', '久しぶりに会いたい' %><br>
+
+  <%= form.radio_button 'answer[question2]', 'eat' %>
+  <%= form.label 'answer[question2]_eat', 'ご飯でもいこう' %><br>
+
+  <%= form.radio_button 'answer[question2]', 'play' %>
+  <%= form.label 'answer[question2]_play', '遊びにいこう' %><br>
+
   <%= form.submit '次へ' %>
 <% end %>

--- a/app/views/q_and_a/question3.html.erb
+++ b/app/views/q_and_a/question3.html.erb
@@ -1,0 +1,11 @@
+<%= form_with url: answer3_path, method: :post, data: { turbo: false } do |form| %>
+  <%= form.radio_button 'answer[question3]', 'select3_1' %>
+  <%= form.label :answer_question3_select3_1, '男性' %><br>
+  <%= form.radio_button 'answer[question3]', 'select3_2' %>
+  <%= form.label :answer_question3_select3_2, '女性' %><br>
+  <%= form.radio_button 'answer[question3]', 'select3_3' %>
+  <%= form.label :answer_question3_select3_3, 'そのほか' %><br>
+  <%= form.radio_button 'answer[question3]', 'select3_4' %>
+  <%= form.label :answer_question3_select3_4, '答えたくない' %><br>
+  <%= form.submit '次へ' %>
+<% end %>

--- a/app/views/q_and_a/question3.html.erb
+++ b/app/views/q_and_a/question3.html.erb
@@ -1,11 +1,15 @@
 <%= form_with url: answer3_path, method: :post, data: { turbo: false } do |form| %>
-  <%= form.radio_button 'answer[question3]', 'select3_1' %>
-  <%= form.label :answer_question3_select3_1, '男性' %><br>
-  <%= form.radio_button 'answer[question3]', 'select3_2' %>
-  <%= form.label :answer_question3_select3_2, '女性' %><br>
-  <%= form.radio_button 'answer[question3]', 'select3_3' %>
-  <%= form.label :answer_question3_select3_3, 'そのほか' %><br>
-  <%= form.radio_button 'answer[question3]', 'select3_4' %>
-  <%= form.label :answer_question3_select3_4, '答えたくない' %><br>
+  <%= form.radio_button 'answer[question3]', 'male', required: true %>
+  <%= form.label 'answer[question3]_male', '男性' %><br>
+
+  <%= form.radio_button 'answer[question3]', 'female' %>
+  <%= form.label 'answer[question3]_female', '女性' %><br>
+
+  <%= form.radio_button 'answer[question3]', 'others' %>
+  <%= form.label 'answer[question3]_others', 'そのほか' %><br>
+
+  <%= form.radio_button 'answer[question3]', 'no_comment' %>
+  <%= form.label 'answer[question3]_no_comment', '答えたくない' %><br>
+  
   <%= form.submit '次へ' %>
 <% end %>

--- a/config/initializers/pry.rb
+++ b/config/initializers/pry.rb
@@ -1,0 +1,2 @@
+Pry.config.input = STDIN
+Pry.config.output = STDOUT

--- a/config/initializers/pry.rb
+++ b/config/initializers/pry.rb
@@ -1,2 +1,4 @@
-Pry.config.input = STDIN
-Pry.config.output = STDOUT
+if Rails.env.development?
+  Pry.config.input = STDIN
+  Pry.config.output = STDOUT
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,9 @@
 Rails.application.routes.draw do
   root 'top#index'
+  get 'question1', to: 'q_and_a#question1'
+  get 'question2', to: 'q_and_a#question2'
+  get 'question3', to: 'q_and_a#question3'
+  post 'answer1', to: 'q_and_a#answer1'
+  post 'answer2', to: 'q_and_a#answer2'
+  post 'answer3', to: 'q_and_a#answer3'
 end


### PR DESCRIPTION
### 概要
メッセージ提案のための、質問・回答ページを表示し、回答内容をsessionに保持する。

---
### 内容
- [x] ３つの質問を、選択肢と合わせて表示する
- [x] 回答内容を、セッションに保持する

---
### 補足
- 関連issue
This PR will close #8 