### PR TITLE
Answersテーブルのvalueにユニーク制約をかける

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,3 +1,4 @@
 class Answer < ApplicationRecord
   belongs_to :question
+  validates :value, uniqueness: true
 end

--- a/db/migrate/20240715053506_add_index_to_answers_value.rb
+++ b/db/migrate/20240715053506_add_index_to_answers_value.rb
@@ -1,0 +1,5 @@
+class AddIndexToAnswersValue < ActiveRecord::Migration[7.1]
+  def change
+    add_index :answers, :value, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_13_040141) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_15_053506) do
   create_table "answers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "text", null: false
     t.string "value", null: false
     t.integer "number", null: false
     t.bigint "question_id", null: false
     t.index ["question_id"], name: "index_answers_on_question_id"
+    t.index ["value"], name: "index_answers_on_value", unique: true
   end
 
   create_table "questions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,7 @@ Answer.create!(
     { text: "そのほか", value: "others", number: "5", question: question1 },
 
     { text: "最近どうしてる？", value: "life", number: "1", question: question2 },
-    { text: "仕事は順調？", value: "work", number: "2", question: question2 },
+    { text: "仕事は順調？", value: "job", number: "2", question: question2 },
     { text: "今どこに住んでいるの？", value: "place", number: "3", question: question2 },
     { text: "久しぶりに会いたい", value: "meet", number: "4", question: question2 },
     { text: "ご飯でもいこう", value: "eat", number: "5", question: question2 },

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,7 +20,7 @@ Answer.create!(
 
     { text: "男性", value: "male", number: "1", question: question3 },
     { text: "女性", value: "female", number: "2", question: question3 },
-    { text: "そのほか", value: "others", number: "3", question: question3 },
+    { text: "そのほか", value: "other_gender", number: "3", question: question3 },
     { text: "答えたくない", value: "no_comment", number: "4", question: question3 },
   ]
 )


### PR DESCRIPTION
### 概要
Answersテーブルのvalueにユニーク制約をかける

---
### 目的
APIに渡すテキスト文をAnswersテーブルから取得するために、valueカラムでレコードの検索をかける処理になっている。
したがって、valueカラムのデータが複数のレコードで同一の場合、正しいテキスト文を取得できない。

```
  def answers
    @answers = (1..3).map do |i|
      Answer.find_by(value: session["question#{i}".to_sym])&.text
    end
  end
```

### 内容
- [x] Answersテーブルのvalueにユニーク制約をかける
- [x] Answerモデルにユニーク制約かける
- [x] レコードを精査し、重複を解消し、seedで再保存する


---
### 補足
This PR close #64 