### PR TITLE
AI提案メッセージのコピーボタン設置

### DIFF
--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="clipboard"
+export default class extends Controller {
+  static targets = [ "source", "copy_button" ]
+
+  copy() {
+    navigator.clipboard.writeText(this.sourceTarget.value)
+    this.copy_buttonTarget.innerHTML = '<button type="button"></button> コピーしました！'
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application"
 
+import ClipboardController from "./clipboard_controller"
+application.register("clipboard", ClipboardController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/app/views/openai_api/chat.html.erb
+++ b/app/views/openai_api/chat.html.erb
@@ -1,8 +1,13 @@
 <%= @message %>
 
-<%= form_with url: "#", local: true do |form| %>
-  <div>
-    <%= form.label :message, "編集する" %><br>
-    <%= form.text_area :message, value: @message, rows: 2, cols: 100 %>
-  </div>
-<% end %>
+<div data-controller="clipboard" >
+  <%= form_with url: "#", local: true do |form| %>
+    <div>
+      <%= form.label :message, "編集する" %><br>
+      <%= form.text_area :message, value: @message, rows: 2, cols: 100, data: { clipboard_target: "source" } %>
+    </div>
+  <% end %>
+  <button type="button", data-action= "clipboard#copy", data-clipboard-target= "copy_button" >
+  コピーする
+  </button>
+</div>


### PR DESCRIPTION
### 概要
AI提案メッセージのコピー機能の実装

---
### 内容
- [x] コピーボタンを設置し、ワンクリックでメッセージをコピーできるようにする

---
### 補足
HotwireのStimulusを使用

This PR close #61 