### PR TITLE
新規登録、ログイン

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ gem "bootsnap", require: false
 # To use OpenAI API
 gem "ruby-openai"
 
+# For sign-up, login
+gem 'sorcery'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
+    bcrypt (3.1.20)
     bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.18.3)
@@ -116,6 +117,7 @@ GEM
       net-http
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashie (5.0.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -127,6 +129,8 @@ GEM
       activesupport (>= 5.0.0)
     jsbundling-rails (1.3.0)
       railties (>= 6.0.0)
+    jwt (2.8.2)
+      base64
     logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -142,6 +146,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.24.1)
     msgpack (1.7.2)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     multipart-post (2.4.1)
     mutex_m (0.2.0)
     mysql2 (0.5.6)
@@ -169,6 +175,19 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
+    oauth (1.1.0)
+      oauth-tty (~> 1.0, >= 1.0.1)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
+    oauth-tty (1.0.5)
+      version_gem (~> 1.1, >= 1.1.1)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -239,6 +258,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
+    sorcery (0.17.0)
+      bcrypt (~> 3.1)
+      oauth (>= 0.6)
+      oauth2 (~> 2.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -259,6 +285,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uri (0.13.0)
+    version_gem (1.1.4)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -296,6 +323,7 @@ DEPENDENCIES
   rails (~> 7.1.3, >= 7.1.3.4)
   ruby-openai
   selenium-webdriver
+  sorcery
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,4 +1,6 @@
 class AnswersController < ApplicationController
+  skip_before_action :require_login
+
   def create
     save_in_session(answer_params)
     

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :require_login
+
+  private
+
+  def not_authenticated
+    redirect_to login_path
+  end
 end

--- a/app/controllers/introductions_controller.rb
+++ b/app/controllers/introductions_controller.rb
@@ -1,4 +1,6 @@
 class IntroductionsController < ApplicationController
+  skip_before_action :require_login
+
   def show
     @page_number = params[:id]
   end

--- a/app/controllers/openai_api_controller.rb
+++ b/app/controllers/openai_api_controller.rb
@@ -1,4 +1,5 @@
 class OpenaiApiController < ApplicationController
+  skip_before_action :require_login
   before_action :set_cliant, :set_prompt
 
   # レスポンスを返すメソッド

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,4 +1,5 @@
 class QuestionsController < ApplicationController
+  skip_before_action :require_login
   def show
     @question = Question.find_by(number: params[:id])
     @answers = @question.answers.order(number: :asc)

--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,3 +1,5 @@
 class TopController < ApplicationController
+  skip_before_action :require_login
+
   def index; end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,0 +1,20 @@
+class UserSessionsController < ApplicationController
+  skip_before_action :require_login, only: %i[new create]
+
+  def new; end
+
+  def create
+    @user = login(params[:email], params[:password])
+
+    if @user
+      redirect_to root_path
+    else
+      render :new
+    end
+  end
+
+  def destroy
+    logout
+    redirect_to root_path, status: :see_other
+  end
+end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -10,7 +10,7 @@ class UserSessionsController < ApplicationController
       flash[:success] = 'ログインしました'
       redirect_to root_path
     else
-      flash.now[:danger] = 'ログインに失敗しました'
+      flash.now[:danger] = 'メールアドレスまたはパスワードが正しくありません'
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,13 +7,16 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
+      flash[:success] = 'ログインしました'
       redirect_to root_path
     else
-      render :new
+      flash.now[:danger] = 'ログインに失敗しました'
+      render :new, status: :unprocessable_entity
     end
   end
 
   def destroy
+    flash[:success] = 'ログアウトしました'
     logout
     redirect_to root_path, status: :see_other
   end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -16,8 +16,8 @@ class UserSessionsController < ApplicationController
   end
 
   def destroy
-    flash[:success] = 'ログアウトしました'
     logout
+    flash[:success] = 'ログアウトしました'
     redirect_to root_path, status: :see_other
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,6 +19,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation, :line_user_id, :notification_enabled)
+    params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,22 @@
+class UsersController < ApplicationController
+  skip_before_action :require_login, only: %i[new create]
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to root_path
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation, :line_user_id, :notification_enabled)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,9 +8,11 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      flash[:success] = 'ユーザー登録が完了しました'
       redirect_to root_path
     else
-      render :new
+      flash.now[:danger] = 'ユーザー登録に失敗しました'
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,12 @@
+class User < ApplicationRecord
+  authenticates_with_sorcery!
+
+  validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
+  validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
+  validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
+  validates :first_name, presence: true, length: { maximum: 255 }
+  validates :last_name, presence: true, length: { maximum: 255 }
+  validates :email, presence: true, uniqueness: true
+  validates :line_user_id, uniqueness: true
+  validates :notification_enabled, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   validates :first_name, presence: true, length: { maximum: 255 }
   validates :last_name, presence: true, length: { maximum: 255 }
   validates :email, presence: true, uniqueness: true
-  validates :line_user_id, uniqueness: true
+  validates :line_user_id, uniqueness: true, allow_blank: true
   validates :notification_enabled, presence: true
 
   enum notification_enabled: { off: false, on: true }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,6 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true
   validates :line_user_id, uniqueness: true
   validates :notification_enabled, presence: true
+
+  enum notification_enabled: { off: false, on: true }
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,11 @@
   </head>
 
   <body>
-    <%= render 'shared/header' %>
+    <% if logged_in? %>
+      <%= render 'shared/header' %>
+    <% else %>
+      <%= render 'shared/before_login_header' %>
+    <% end %>
     <%= yield %>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,11 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
+
+    <%= render 'shared/flash_message' %>
+
     <%= yield %>
+
     <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -4,6 +4,7 @@
     <%= link_to "AIメッセージ作成", '#' %>
     <%= link_to "連絡帳", '#' %>
     <%= link_to "カレンダー", '#' %>
-    <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete } %>
+    <%= link_to "ログイン", login_path %>
+    <%= link_to "新規登録", new_user_path %>
   </div>
 </header>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if model.errors.any? %>
+  <div class= 'alert alert-danger'>
+    <ul>
+      <% model.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |message_type, message| %>
+  <div class="alert alert-<%= message_type %>">
+    <%= message %>
+  </div>
+<% end %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,0 +1,22 @@
+<div class="container">
+  <div class="row">
+    <div class=" col-md-10 col-lg-8 mx-auto">
+      <h1>ログイン</h1>
+      <%= form_with url: login_path do |f| %>
+        <div class="mb-3">
+          <%= f.label :email %>
+          <%= f.email_field :email, class: "form-control" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :password %>
+          <%= f.password_field :password, class: "form-control" %>
+        </div>
+        <%= f.submit "ログイン", class: "btn btn-primary" %>
+      <% end %>
+      <div class='text-center'>
+        <%= link_to '登録ページへ', new_user_path %>
+        <%= link_to 'パスワードをお忘れの方はこちら', '#' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,6 +3,8 @@
     <div class="col-md-10 col-lg-8 mx-auto">
       <h1>ユーザー登録</h1>
       <%= form_with model: @user do |f| %>
+      	<%= render 'shared/error_messages', model: f.object %>
+
         <div class="mb-3">
           <%= f.label :last_name, class: "form-label" %>
           <%= f.text_field :last_name, class: "form-control" %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -26,7 +26,7 @@
         <%= f.submit "登録", class: "btn btn-primary" %>
       <% end %>
       <div class='text-center'>
-        <%# <%= link_to 'ログインページへ', login_path %>
+        <%= link_to 'ログインページへ', login_path %>
       </div>
     </div>
   </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,33 @@
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 col-lg-8 mx-auto">
+      <h1>ユーザー登録</h1>
+      <%= form_with model: @user do |f| %>
+        <div class="mb-3">
+          <%= f.label :last_name, class: "form-label" %>
+          <%= f.text_field :last_name, class: "form-control" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :first_name, class: "form-label" %>
+          <%= f.text_field :first_name, class: "form-control" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :email, class: "form-label" %>
+          <%= f.email_field :email, class: "form-control" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :password, class: "form-label" %>
+          <%= f.password_field :password, class: "form-control" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :password_confirmation, class: "form-label" %>
+          <%= f.password_field :password_confirmation, class: "form-control" %>
+        </div>
+        <%= f.submit "登録", class: "btn btn-primary" %>
+      <% end %>
+      <div class='text-center'>
+        <%# <%= link_to 'ログインページへ', login_path %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -1,0 +1,567 @@
+# The first thing you need to configure is which modules you need in your app.
+# The default is nothing which will include only core features (password encryption, login/logout).
+#
+# Available submodules are: :user_activation, :http_basic_auth, :remember_me,
+# :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
+# :magic_login, :external
+Rails.application.config.sorcery.submodules = []
+
+# Here you can configure each submodule's features.
+Rails.application.config.sorcery.configure do |config|
+  # -- core --
+  # What controller action to call for non-authenticated users. You can also
+  # override the 'not_authenticated' method of course.
+  # Default: `:not_authenticated`
+  #
+  # config.not_authenticated_action =
+
+  # When a non logged-in user tries to enter a page that requires login, save
+  # the URL he wants to reach, and send him there after login, using 'redirect_back_or_to'.
+  # Default: `true`
+  #
+  # config.save_return_to_url =
+
+  # Set domain option for cookies; Useful for remember_me submodule.
+  # Default: `nil`
+  #
+  # config.cookie_domain =
+
+  # Allow the remember_me cookie to be set through AJAX
+  # Default: `true`
+  #
+  # config.remember_me_httponly =
+
+  # Set token randomness. (e.g. user activation tokens)
+  # The length of the result string is about 4/3 of `token_randomness`.
+  # Default: `15`
+  #
+  # config.token_randomness =
+
+  # -- session timeout --
+  # How long in seconds to keep the session alive.
+  # Default: `3600`
+  #
+  # config.session_timeout =
+
+  # Use the last action as the beginning of session timeout.
+  # Default: `false`
+  #
+  # config.session_timeout_from_last_action =
+
+  # Invalidate active sessions. Requires an `invalidate_sessions_before` timestamp column
+  # Default: `false`
+  #
+  # config.session_timeout_invalidate_active_sessions_enabled =
+
+  # -- http_basic_auth --
+  # What realm to display for which controller name. For example {"My App" => "Application"}
+  # Default: `{"application" => "Application"}`
+  #
+  # config.controller_to_realm_map =
+
+  # -- activity logging --
+  # Will register the time of last user login, every login.
+  # Default: `true`
+  #
+  # config.register_login_time =
+
+  # Will register the time of last user logout, every logout.
+  # Default: `true`
+  #
+  # config.register_logout_time =
+
+  # Will register the time of last user action, every action.
+  # Default: `true`
+  #
+  # config.register_last_activity_time =
+
+  # -- external --
+  # What providers are supported by this app
+  # i.e. [:twitter, :facebook, :github, :linkedin, :xing, :google, :liveid, :salesforce, :slack, :line].
+  # Default: `[]`
+  #
+  # config.external_providers =
+
+  # You can change it by your local ca_file. i.e. '/etc/pki/tls/certs/ca-bundle.crt'
+  # Path to ca_file. By default use a internal ca-bundle.crt.
+  # Default: `'path/to/ca_file'`
+  #
+  # config.ca_file =
+
+  # Linkedin requires r_emailaddress scope to fetch user's email address.
+  # You can skip including the email field if you use an intermediary signup form. (using build_from method).
+  # The r_emailaddress scope is only necessary if you are using the create_from method directly.
+  #
+  # config.linkedin.key = ""
+  # config.linkedin.secret = ""
+  # config.linkedin.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=linkedin"
+  # config.linkedin.user_info_mapping = {
+  #   first_name: 'localizedFirstName',
+  #   last_name:  'localizedLastName',
+  #   email:      'emailAddress'
+  # }
+  # config.linkedin.scope = "r_liteprofile r_emailaddress"
+  #
+  #
+  # For information about XING API:
+  # - user info fields go to https://dev.xing.com/docs/get/users/me
+  #
+  # config.xing.key = ""
+  # config.xing.secret = ""
+  # config.xing.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=xing"
+  # config.xing.user_info_mapping = {first_name: "first_name", last_name: "last_name"}
+  #
+  #
+  # Twitter will not accept any requests nor redirect uri containing localhost,
+  # Make sure you use 0.0.0.0:3000 to access your app in development
+  #
+  # config.twitter.key = ""
+  # config.twitter.secret = ""
+  # config.twitter.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=twitter"
+  # config.twitter.user_info_mapping = {:email => "screen_name"}
+  #
+  # config.facebook.key = ""
+  # config.facebook.secret = ""
+  # config.facebook.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=facebook"
+  # config.facebook.user_info_path = "me?fields=email"
+  # config.facebook.user_info_mapping = {:email => "email"}
+  # config.facebook.access_permissions = ["email"]
+  # config.facebook.display = "page"
+  # config.facebook.api_version = "v2.3"
+  # config.facebook.parse = :json
+  #
+  # config.instagram.key = ""
+  # config.instagram.secret = ""
+  # config.instagram.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=instagram"
+  # config.instagram.user_info_mapping = {:email => "username"}
+  # config.instagram.access_permissions = ["basic", "public_content", "follower_list", "comments", "relationships", "likes"]
+  #
+  # config.github.key = ""
+  # config.github.secret = ""
+  # config.github.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=github"
+  # config.github.user_info_mapping = {:email => "name"}
+  # config.github.scope = ""
+  #
+  # config.paypal.key = ""
+  # config.paypal.secret = ""
+  # config.paypal.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=paypal"
+  # config.paypal.user_info_mapping = {:email => "email"}
+  #
+  # config.wechat.key = ""
+  # config.wechat.secret = ""
+  # config.wechat.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=wechat"
+  #
+  # For Auth0, site is required and should match the domain provided by Auth0.
+  #
+  # config.auth0.key = ""
+  # config.auth0.secret = ""
+  # config.auth0.callback_url = "https://0.0.0.0:3000/oauth/callback?provider=auth0"
+  # config.auth0.site = "https://example.auth0.com"
+  #
+  # config.google.key = ""
+  # config.google.secret = ""
+  # config.google.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=google"
+  # config.google.user_info_mapping = {:email => "email", :username => "name"}
+  # config.google.scope = "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile"
+  #
+  # For Microsoft Graph, the key will be your App ID, and the secret will be your app password/public key.
+  # The callback URL "can't contain a query string or invalid special characters"
+  # See: https://docs.microsoft.com/en-us/azure/active-directory/active-directory-v2-limitations#restrictions-on-redirect-uris
+  # More information at https://graph.microsoft.io/en-us/docs
+  #
+  # config.microsoft.key = ""
+  # config.microsoft.secret = ""
+  # config.microsoft.callback_url = "http://0.0.0.0:3000/oauth/callback/microsoft"
+  # config.microsoft.user_info_mapping = {:email => "userPrincipalName", :username => "displayName"}
+  # config.microsoft.scope = "openid email https://graph.microsoft.com/User.Read"
+  #
+  # config.vk.key = ""
+  # config.vk.secret = ""
+  # config.vk.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=vk"
+  # config.vk.user_info_mapping = {:login => "domain", :name => "full_name"}
+  # config.vk.api_version = "5.71"
+  #
+  # config.slack.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=slack"
+  # config.slack.key = ''
+  # config.slack.secret = ''
+  # config.slack.user_info_mapping = {email: 'email'}
+  #
+  # To use liveid in development mode you have to replace mydomain.com with
+  # a valid domain even in development. To use a valid domain in development
+  # simply add your domain in your /etc/hosts file in front of 127.0.0.1
+  #
+  # config.liveid.key = ""
+  # config.liveid.secret = ""
+  # config.liveid.callback_url = "http://mydomain.com:3000/oauth/callback?provider=liveid"
+  # config.liveid.user_info_mapping = {:username => "name"}
+
+  # For information about JIRA API:
+  # https://developer.atlassian.com/display/JIRADEV/JIRA+REST+API+Example+-+OAuth+authentication
+  # To obtain the consumer key and the public key you can use the jira-ruby gem https://github.com/sumoheavy/jira-ruby
+  # or run openssl req -x509 -nodes -newkey rsa:1024 -sha1 -keyout rsakey.pem -out rsacert.pem to obtain the public key
+  # Make sure you have configured the application link properly
+
+  # config.jira.key = "1234567"
+  # config.jira.secret = "jiraTest"
+  # config.jira.site = "http://localhost:2990/jira/plugins/servlet/oauth"
+  # config.jira.signature_method =  "RSA-SHA1"
+  # config.jira.private_key_file = "rsakey.pem"
+
+  # For information about Salesforce API:
+  # https://developer.salesforce.com/signup &
+  # https://www.salesforce.com/us/developer/docs/api_rest/
+  # Salesforce callback_url must be https. You can run the following to generate self-signed ssl cert:
+  # openssl req -new -newkey rsa:2048 -sha1 -days 365 -nodes -x509 -keyout server.key -out server.crt
+  # Make sure you have configured the application link properly
+  # config.salesforce.key = '123123'
+  # config.salesforce.secret = 'acb123'
+  # config.salesforce.callback_url = "https://127.0.0.1:9292/oauth/callback?provider=salesforce"
+  # config.salesforce.scope = "full"
+  # config.salesforce.user_info_mapping = {:email => "email"}
+
+  # config.line.key = ""
+  # config.line.secret = ""
+  # config.line.callback_url = "http://mydomain.com:3000/oauth/callback?provider=line"
+  # config.line.scope = "profile"
+  # config.line.bot_prompt = "normal"
+  # config.line.user_info_mapping = {name: 'displayName'}
+
+  
+  # For information about Discord API
+  # https://discordapp.com/developers/docs/topics/oauth2
+  # config.discord.key = "xxxxxx"
+  # config.discord.secret = "xxxxxx"
+  # config.discord.callback_url = "http://localhost:3000/oauth/callback?provider=discord"
+  # config.discord.scope = "email guilds"
+
+  # For information about Battlenet API
+  # https://develop.battle.net/documentation/guides/using-oauth
+  # config.battlenet.site = "https://eu.battle.net/" #See Website for other Regional Domains
+  # config.battlenet.key = "xxxxxx"
+  # config.battlenet.secret = "xxxxxx"
+  # config.battlenet.callback_url = "http://localhost:3000/oauth/callback?provider=battlenet"
+  # config.battlenet.scope = "openid"
+  # --- user config ---
+  config.user_config do |user|
+    # -- core --
+    # Specify username attributes, for example: [:username, :email].
+    # Default: `[:email]`
+    #
+    # user.username_attribute_names =
+
+    # Change *virtual* password attribute, the one which is used until an encrypted one is generated.
+    # Default: `:password`
+    #
+    # user.password_attribute_name =
+
+    # Downcase the username before trying to authenticate, default is false
+    # Default: `false`
+    #
+    # user.downcase_username_before_authenticating =
+
+    # Change default email attribute.
+    # Default: `:email`
+    #
+    # user.email_attribute_name =
+
+    # Change default crypted_password attribute.
+    # Default: `:crypted_password`
+    #
+    # user.crypted_password_attribute_name =
+
+    # What pattern to use to join the password with the salt
+    # Default: `""`
+    #
+    # user.salt_join_token =
+
+    # Change default salt attribute.
+    # Default: `:salt`
+    #
+    # user.salt_attribute_name =
+
+    # How many times to apply encryption to the password.
+    # Default: 1 in test env, `nil` otherwise
+    #
+    user.stretches = 1 if Rails.env.test?
+
+    # Encryption key used to encrypt reversible encryptions such as AES256.
+    # WARNING: If used for users' passwords, changing this key will leave passwords undecryptable!
+    # Default: `nil`
+    #
+    # user.encryption_key =
+
+    # Use an external encryption class.
+    # Default: `nil`
+    #
+    # user.custom_encryption_provider =
+
+    # Encryption algorithm name. See 'encryption_algorithm=' for available options.
+    # Default: `:bcrypt`
+    #
+    # user.encryption_algorithm =
+
+    # Make this configuration inheritable for subclasses. Useful for ActiveRecord's STI.
+    # Default: `false`
+    #
+    # user.subclasses_inherit_config =
+
+    # -- remember_me --
+    # change default remember_me_token attribute.
+    # Default: `:remember_me_token`
+    #
+    # user.remember_me_token_attribute_name =
+
+    # change default remember_me_token_expires_at attribute.
+    # Default: `:remember_me_token_expires_at`
+    #
+    # user.remember_me_token_expires_at_attribute_name =
+
+    # How long in seconds the session length will be
+    # Default: `60 * 60 * 24 * 7`
+    #
+    # user.remember_me_for =
+
+    # When true, sorcery will persist a single remember me token for all
+    # logins/logouts (to support remembering on multiple browsers simultaneously).
+    # Default: false
+    #
+    # user.remember_me_token_persist_globally =
+
+    # -- user_activation --
+    # The attribute name to hold activation state (active/pending).
+    # Default: `:activation_state`
+    #
+    # user.activation_state_attribute_name =
+
+    # The attribute name to hold activation code (sent by email).
+    # Default: `:activation_token`
+    #
+    # user.activation_token_attribute_name =
+
+    # The attribute name to hold activation code expiration date.
+    # Default: `:activation_token_expires_at`
+    #
+    # user.activation_token_expires_at_attribute_name =
+
+    # How many seconds before the activation code expires. nil for never expires.
+    # Default: `nil`
+    #
+    # user.activation_token_expiration_period =
+
+    # REQUIRED:
+    # User activation mailer class.
+    # Default: `nil`
+    #
+    # user.user_activation_mailer =
+
+    # When true, sorcery will not automatically
+    # send the activation details email, and allow you to
+    # manually handle how and when the email is sent.
+    # Default: `false`
+    #
+    # user.activation_mailer_disabled =
+
+    # Method to send email related
+    # options: `:deliver_later`, `:deliver_now`, `:deliver`
+    # Default: :deliver (Rails version < 4.2) or :deliver_now (Rails version 4.2+)
+    #
+    # user.email_delivery_method =
+
+    # Activation needed email method on your mailer class.
+    # Default: `:activation_needed_email`
+    #
+    # user.activation_needed_email_method_name =
+
+    # Activation success email method on your mailer class.
+    # Default: `:activation_success_email`
+    #
+    # user.activation_success_email_method_name =
+
+    # Do you want to prevent users who did not activate by email from logging in?
+    # Default: `true`
+    #
+    # user.prevent_non_active_users_to_login =
+
+    # -- reset_password --
+    # Password reset token attribute name.
+    # Default: `:reset_password_token`
+    #
+    # user.reset_password_token_attribute_name =
+
+    # Password token expiry attribute name.
+    # Default: `:reset_password_token_expires_at`
+    #
+    # user.reset_password_token_expires_at_attribute_name =
+
+    # When was password reset email sent. Used for hammering protection.
+    # Default: `:reset_password_email_sent_at`
+    #
+    # user.reset_password_email_sent_at_attribute_name =
+
+    # REQUIRED:
+    # Password reset mailer class.
+    # Default: `nil`
+    #
+    # user.reset_password_mailer =
+
+    # Reset password email method on your mailer class.
+    # Default: `:reset_password_email`
+    #
+    # user.reset_password_email_method_name =
+
+    # When true, sorcery will not automatically
+    # send the password reset details email, and allow you to
+    # manually handle how and when the email is sent
+    # Default: `false`
+    #
+    # user.reset_password_mailer_disabled =
+
+    # How many seconds before the reset request expires. nil for never expires.
+    # Default: `nil`
+    #
+    # user.reset_password_expiration_period =
+
+    # Hammering protection: how long in seconds to wait before allowing another email to be sent.
+    # Default: `5 * 60`
+    #
+    # user.reset_password_time_between_emails =
+
+    # Access counter to a reset password page attribute name
+    # Default: `:access_count_to_reset_password_page`
+    #
+    # user.reset_password_page_access_count_attribute_name =
+
+    # -- magic_login --
+    # Magic login code attribute name.
+    # Default: `:magic_login_token`
+    #
+    # user.magic_login_token_attribute_name =
+
+    # Magic login expiry attribute name.
+    # Default: `:magic_login_token_expires_at`
+    #
+    # user.magic_login_token_expires_at_attribute_name =
+
+    # When was magic login email sent — used for hammering protection.
+    # Default: `:magic_login_email_sent_at`
+    #
+    # user.magic_login_email_sent_at_attribute_name =
+
+    # REQUIRED:
+    # Magic login mailer class.
+    # Default: `nil`
+    #
+    # user.magic_login_mailer_class =
+
+    # Magic login email method on your mailer class.
+    # Default: `:magic_login_email`
+    #
+    # user.magic_login_email_method_name =
+
+    # When true, sorcery will not automatically
+    # send magic login details email, and allow you to
+    # manually handle how and when the email is sent
+    # Default: `true`
+    #
+    # user.magic_login_mailer_disabled =
+
+    # How many seconds before the request expires. nil for never expires.
+    # Default: `nil`
+    #
+    # user.magic_login_expiration_period =
+
+    # Hammering protection: how long in seconds to wait before allowing another email to be sent.
+    # Default: `5 * 60`
+    #
+    # user.magic_login_time_between_emails =
+
+    # -- brute_force_protection --
+    # Failed logins attribute name.
+    # Default: `:failed_logins_count`
+    #
+    # user.failed_logins_count_attribute_name =
+
+    # This field indicates whether user is banned and when it will be active again.
+    # Default: `:lock_expires_at`
+    #
+    # user.lock_expires_at_attribute_name =
+
+    # How many failed logins are allowed.
+    # Default: `50`
+    #
+    # user.consecutive_login_retries_amount_limit =
+
+    # How long the user should be banned, in seconds. 0 for permanent.
+    # Default: `60 * 60`
+    #
+    # user.login_lock_time_period =
+
+    # Unlock token attribute name
+    # Default: `:unlock_token`
+    #
+    # user.unlock_token_attribute_name =
+
+    # Unlock token mailer method
+    # Default: `:send_unlock_token_email`
+    #
+    # user.unlock_token_email_method_name =
+
+    # When true, sorcery will not automatically
+    # send email with the unlock token
+    # Default: `false`
+    #
+    # user.unlock_token_mailer_disabled = true
+
+    # REQUIRED:
+    # Unlock token mailer class.
+    # Default: `nil`
+    #
+    # user.unlock_token_mailer =
+
+    # -- activity logging --
+    # Last login attribute name.
+    # Default: `:last_login_at`
+    #
+    # user.last_login_at_attribute_name =
+
+    # Last logout attribute name.
+    # Default: `:last_logout_at`
+    #
+    # user.last_logout_at_attribute_name =
+
+    # Last activity attribute name.
+    # Default: `:last_activity_at`
+    #
+    # user.last_activity_at_attribute_name =
+
+    # How long since user's last activity will they be considered logged out?
+    # Default: `10 * 60`
+    #
+    # user.activity_timeout =
+
+    # -- external --
+    # Class which holds the various external provider data for this user.
+    # Default: `nil`
+    #
+    # user.authentications_class =
+
+    # User's identifier in the `authentications` class.
+    # Default: `:user_id`
+    #
+    # user.authentications_user_id_attribute_name =
+
+    # Provider's identifier in the `authentications` class.
+    # Default: `:provider`
+    #
+    # user.provider_attribute_name =
+
+    # User's external unique identifier in the `authentications` class.
+    # Default: `:uid`
+    #
+    # user.provider_uid_attribute_name =
+  end
+
+  # This line must come after the 'user config' block.
+  # Define which model authenticates with sorcery.
+  config.user_class = "User"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,6 @@ Rails.application.routes.draw do
   resources :users, only: [:new, :create]
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
+  delete 'logout', to: 'user_sessions#destroy'
   get 'openai', to: 'openai_api#chat'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@ Rails.application.routes.draw do
   resources :introductions, only: [:show]
   resources :questions, only: [:show]
   resources :answers, only: [:create]
+  resources :users, only: [:new, :create]
   get 'openai', to: 'openai_api#chat'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,7 @@ Rails.application.routes.draw do
   resources :questions, only: [:show]
   resources :answers, only: [:create]
   resources :users, only: [:new, :create]
+  get 'login', to: 'user_sessions#new'
+  post 'login', to: 'user_sessions#create'
   get 'openai', to: 'openai_api#chat'
 end

--- a/db/migrate/20240716055008_sorcery_core.rb
+++ b/db/migrate/20240716055008_sorcery_core.rb
@@ -1,0 +1,15 @@
+class SorceryCore < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string :email,                 null: false, index: { unique: true }
+      t.string :crypted_password
+      t.string :salt
+      t.string :first_name,            null: false
+      t.string :last_name,             null: false
+      t.string :line_user_id,                       index: { unique: true }
+      t.boolean :notification_enabled, null: false, default: true
+
+      t.timestamps                     null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_15_053506) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_16_055008) do
   create_table "answers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "text", null: false
     t.string "value", null: false
@@ -23,6 +23,20 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_15_053506) do
   create_table "questions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "text", null: false
     t.integer "number", null: false
+  end
+
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "crypted_password"
+    t.string "salt"
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.string "line_user_id"
+    t.boolean "notification_enabled", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["line_user_id"], name: "index_users_on_line_user_id", unique: true
   end
 
   add_foreign_key "answers", "questions"


### PR DESCRIPTION
### 概要
sorceryを使い、ユーザー新規登録、ログイン機能を実装する

---
### 新規登録
- [x] sorceryの導入
- [x] usersテーブルの作成（カラムは以下の通り）
  -  first_name (string)
  -  last_name (string)
  -  email (string)
  -  line_user_id (string)
  -  notifications_enabled (boolean)
  ##### 自動的に作成されるもの
    -   crypted_password (string)
    -   salt (string) 
    -   created_at timestamp

- [x] カラムに制約を付ける
  - first_name：nullを許容しない
  - last_name：nullを許容しない
  - email：nullを許容しない、ユニークであること
  - notifications_enabled：nullを許容しない
  - line_user_id: ユニークであること

- [x] notifications_enabledにenumをつける
  - default：true
  - off : false, on :true

- [x] 新規登録後、ログイン状態にし、トップページに遷移させる
- [x] ログイン状態により、ヘッダーを出し分ける
- [x] 新規登録成功時「新規登録しました」、失敗時にはエラー原因を含むエラーメッセージを表示する
- [x] ログインを求めないページは、skip_before_actionを設定する

### ログイン
- [x] sorceryを使い、メールアドレスと、パスワードでログインできるようにする
- [x] ログイン後は、「ログインしました」というフラッシュメッセージを表示する
- [x] ログイン失敗時には、エラーメッセージを表示する
---
### 補足

This PR close #16 