### PR TITLE
連絡帳に関連するテーブルとモデルを作成

### DIFF
--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,0 +1,3 @@
+class Album < ApplicationRecord
+  belongs_to :profile
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,3 +1,5 @@
 class Event < ApplicationRecord
   belongs_to :profile
+
+  enum notification_enabled: { off: false, on: true }
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,3 @@
+class Event < ApplicationRecord
+  belongs_to :profile
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,3 @@
+class Group < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,3 +1,5 @@
 class Group < ApplicationRecord
   belongs_to :user
+  has_many :groups_profiles, dependent: :destroy
+  has_many :profiles, through :groups_profiles
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,5 @@
 class Group < ApplicationRecord
   belongs_to :user
   has_many :groups_profiles, dependent: :destroy
-  has_many :profiles, through :groups_profiles
+  has_many :profiles, through: :groups_profiles
 end

--- a/app/models/groups_profile.rb
+++ b/app/models/groups_profile.rb
@@ -1,0 +1,4 @@
+class GroupsProfile < ApplicationRecord
+  belongs_to :group
+  belongs_to :profile
+end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,3 @@
+class Note < ApplicationRecord
+  belongs_to :profile
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,3 @@
+class Profile < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,7 +1,7 @@
 class Profile < ApplicationRecord
   belongs_to :user
   has_many :groups_profiles, dependent: :destroy
-  has_many :groups, through :groups_profiles
+  has_many :groups, through: :groups_profiles
   has_many :albums, dependent: :destroy
   has_one :note, dependent: :destroy
   has_many :events, dependent: :destroy

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,3 +1,5 @@
 class Profile < ApplicationRecord
   belongs_to :user
+  has_many :groups_profiles, dependent: :destroy
+  has_many :groups, through :groups_profiles
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -2,4 +2,5 @@ class Profile < ApplicationRecord
   belongs_to :user
   has_many :groups_profiles, dependent: :destroy
   has_many :groups, through :groups_profiles
+  has_many :albums, dependent: :destroy
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -4,4 +4,5 @@ class Profile < ApplicationRecord
   has_many :groups, through :groups_profiles
   has_many :albums, dependent: :destroy
   has_one :note, dependent: :destroy
+  has_many :events, dependent: :destroy
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -3,4 +3,5 @@ class Profile < ApplicationRecord
   has_many :groups_profiles, dependent: :destroy
   has_many :groups, through :groups_profiles
   has_many :albums, dependent: :destroy
+  has_one :note, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  has_many :profiles, dependent: :destroy
+
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
 
   has_many :profiles, dependent: :destroy
+  has_many :groups, dependent: :destroy
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/db/migrate/20240716092954_create_profiles.rb
+++ b/db/migrate/20240716092954_create_profiles.rb
@@ -1,0 +1,18 @@
+class CreateProfiles < ActiveRecord::Migration[7.1]
+  def change
+    create_table :profiles do |t|
+      t.string :name
+      t.string :furigana
+      t.string :phone
+      t.string :email
+      t.string :line_name
+      t.string :birthplace
+      t.string :address
+      t.string :occupation
+
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240716094904_create_groups.rb
+++ b/db/migrate/20240716094904_create_groups.rb
@@ -1,0 +1,10 @@
+class CreateGroups < ActiveRecord::Migration[7.1]
+  def change
+    create_table :groups do |t|
+      t.string :name
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240716095603_create_groups_profiles.rb
+++ b/db/migrate/20240716095603_create_groups_profiles.rb
@@ -1,0 +1,10 @@
+class CreateGroupsProfiles < ActiveRecord::Migration[7.1]
+  def change
+    create_table :groups_profiles do |t|
+      t.references :group, null: false, foreign_key: true
+      t.references :profile, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240716100844_create_albums.rb
+++ b/db/migrate/20240716100844_create_albums.rb
@@ -1,0 +1,12 @@
+class CreateAlbums < ActiveRecord::Migration[7.1]
+  def change
+    create_table :albums do |t|
+      t.date :date
+      t.string :title
+      t.text :diary
+      t.references :profile, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240716101301_create_notes.rb
+++ b/db/migrate/20240716101301_create_notes.rb
@@ -1,0 +1,10 @@
+class CreateNotes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :notes do |t|
+      t.text :content
+      t.references :profile, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240716102044_create_events.rb
+++ b/db/migrate/20240716102044_create_events.rb
@@ -1,0 +1,13 @@
+class CreateEvents < ActiveRecord::Migration[7.1]
+  def change
+    create_table :events do |t|
+      t.string :name
+      t.date :date
+      t.integer :notification_timing
+      t.boolean :notification_enabled
+      t.references :profile, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240717031319_add_null_false_and_default_to_notification_enabled_in_events.rb
+++ b/db/migrate/20240717031319_add_null_false_and_default_to_notification_enabled_in_events.rb
@@ -1,0 +1,5 @@
+class AddNullFalseAndDefaultToNotificationEnabledInEvents < ActiveRecord::Migration[7.1]
+  def change
+    change_column :events, :notification_enabled, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_16_100844) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_16_101301) do
   create_table "albums", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.date "date"
     t.string "title"
@@ -45,6 +45,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_100844) do
     t.datetime "updated_at", null: false
     t.index ["group_id"], name: "index_groups_profiles_on_group_id"
     t.index ["profile_id"], name: "index_groups_profiles_on_profile_id"
+  end
+
+  create_table "notes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.text "content"
+    t.bigint "profile_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["profile_id"], name: "index_notes_on_profile_id"
   end
 
   create_table "profiles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -86,5 +94,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_100844) do
   add_foreign_key "groups", "users"
   add_foreign_key "groups_profiles", "groups"
   add_foreign_key "groups_profiles", "profiles"
+  add_foreign_key "notes", "profiles"
   add_foreign_key "profiles", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_16_101301) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_16_102044) do
   create_table "albums", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.date "date"
     t.string "title"
@@ -28,6 +28,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_101301) do
     t.bigint "question_id", null: false
     t.index ["question_id"], name: "index_answers_on_question_id"
     t.index ["value"], name: "index_answers_on_value", unique: true
+  end
+
+  create_table "events", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
+    t.date "date"
+    t.integer "notification_timing"
+    t.boolean "notification_enabled"
+    t.bigint "profile_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["profile_id"], name: "index_events_on_profile_id"
   end
 
   create_table "groups", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -91,6 +102,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_101301) do
 
   add_foreign_key "albums", "profiles"
   add_foreign_key "answers", "questions"
+  add_foreign_key "events", "profiles"
   add_foreign_key "groups", "users"
   add_foreign_key "groups_profiles", "groups"
   add_foreign_key "groups_profiles", "profiles"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_16_095603) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_16_100844) do
+  create_table "albums", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.date "date"
+    t.string "title"
+    t.text "diary"
+    t.bigint "profile_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["profile_id"], name: "index_albums_on_profile_id"
+  end
+
   create_table "answers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "text", null: false
     t.string "value", null: false
@@ -71,6 +81,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_095603) do
     t.index ["line_user_id"], name: "index_users_on_line_user_id", unique: true
   end
 
+  add_foreign_key "albums", "profiles"
   add_foreign_key "answers", "questions"
   add_foreign_key "groups", "users"
   add_foreign_key "groups_profiles", "groups"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_16_092954) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_16_094904) do
   create_table "answers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "text", null: false
     t.string "value", null: false
@@ -18,6 +18,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_092954) do
     t.bigint "question_id", null: false
     t.index ["question_id"], name: "index_answers_on_question_id"
     t.index ["value"], name: "index_answers_on_value", unique: true
+  end
+
+  create_table "groups", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_groups_on_user_id"
   end
 
   create_table "profiles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -55,5 +63,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_092954) do
   end
 
   add_foreign_key "answers", "questions"
+  add_foreign_key "groups", "users"
   add_foreign_key "profiles", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_16_094904) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_16_095603) do
   create_table "answers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "text", null: false
     t.string "value", null: false
@@ -26,6 +26,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_094904) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_groups_on_user_id"
+  end
+
+  create_table "groups_profiles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "group_id", null: false
+    t.bigint "profile_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_groups_profiles_on_group_id"
+    t.index ["profile_id"], name: "index_groups_profiles_on_profile_id"
   end
 
   create_table "profiles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -64,5 +73,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_094904) do
 
   add_foreign_key "answers", "questions"
   add_foreign_key "groups", "users"
+  add_foreign_key "groups_profiles", "groups"
+  add_foreign_key "groups_profiles", "profiles"
   add_foreign_key "profiles", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_16_102044) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_17_031319) do
   create_table "albums", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.date "date"
     t.string "title"
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_102044) do
     t.string "name"
     t.date "date"
     t.integer "notification_timing"
-    t.boolean "notification_enabled"
+    t.boolean "notification_enabled", default: true, null: false
     t.bigint "profile_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_16_055008) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_16_092954) do
   create_table "answers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "text", null: false
     t.string "value", null: false
@@ -18,6 +18,21 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_055008) do
     t.bigint "question_id", null: false
     t.index ["question_id"], name: "index_answers_on_question_id"
     t.index ["value"], name: "index_answers_on_value", unique: true
+  end
+
+  create_table "profiles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
+    t.string "furigana"
+    t.string "phone"
+    t.string "email"
+    t.string "line_name"
+    t.string "birthplace"
+    t.string "address"
+    t.string "occupation"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
   create_table "questions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -40,4 +55,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_055008) do
   end
 
   add_foreign_key "answers", "questions"
+  add_foreign_key "profiles", "users"
 end


### PR DESCRIPTION
### 概要

連絡帳に関するテーブルを作成する。

---
### 内容

- [x] テーブルとカラムの作成
### profilesテーブル
#### attribute
-   name (string)
-   furigana (string)
-   phone (string)
-   email (string)
-   line_name (string)
-   birthplace (string)
-   address (string)
-   occupation (string)

#### 制約
なし

#### アソシエーション
- users:profiles=1対多
- profiles:group_profilesと1対多
- profiles:notesと1対多
- profiles:eventsと1対多
- profiles:albumsと1対多


### eventsテーブル
#### attribute

-   event_name (string)
-   date (date)
-   notification_timing  (integer)
-   notification_enabled (boolean)
    - default : 1
    -  0: off , 1: on

#### 制約
- notification_enabledに空欄を許さない
（dateが入っていなくて、timingとenabledにデータが入っている場合などは通知ができないが、これは別ロジックで対応する）

#### アソシエーション
- profiles:events＝一対多

### groupsテーブル
#### attribute
-   name (string)

#### 制約
なし

#### アソシエーション
- users : groups= 1対多
- groups : group_profilesと1対多

### groups_profilesテーブル
#### attribute
-   group_id (integer)
-   profile_id (integer)

#### 制約
なし

#### アソシエーション
- groups : group_profilesと1対多
- profiles : group_profilesと1対多

### albumsテーブル
#### attribute
- date (date)
- title (string)
- diary (text)

#### 制約
なし

#### アソシエーション
- profiles:albumsと1対多

### notesテーブル
#### attribute
- content (text)

#### 制約
なし

#### アソシエーション
- profiles:notesと1対1
---
### 補足
This PR close #10 