### PR TITLE
連絡帳　詳細ページ

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -5,6 +5,10 @@ class ProfilesController < ApplicationController
     @profile.events.build(name: '大切な日')
   end
 
+  def show
+    @profile = current_user.profiles.find(params[:id])
+  end
+
   def create
     @profile = current_user.profiles.new(profile_params)
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -14,7 +14,7 @@ class ProfilesController < ApplicationController
 
     if @profile.save
       flash[:success] = '連絡先を登録しました'
-      redirect_to root_path # profile_path(@profile)
+      redirect_to profile_path(@profile)
     else
       flash[:danger] = '連絡先を登録できませんでした'
       render :new, status: :unprocessable_entity

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,12 @@
+名前: <%= @profile.name %><br>
+ふりがな: <%= @profile.furigana %><br>
+<% @profile.events.each do |event| %>
+  <%= event.name %>
+  <%= event.date %><br>
+<% end %>
+電話番号: <%= @profile.phone %><br>
+メールアドレス: <%= @profile.email %><br>
+LINE名: <%= @profile.line_name %><br>
+出身地: <%= @profile.birthplace %><br>
+住所: <%= @profile.address %><br>
+職業: <%= @profile.occupation %><br>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,3 +1,9 @@
+<div>
+  <%= link_to 'アルバム', '#'%>
+  <%= link_to 'メモ', '#'%>
+  <%= link_to '通知設定', '#'%>
+</div>
+
 名前: <%= @profile.name %><br>
 ふりがな: <%= @profile.furigana %><br>
 <% @profile.events.each do |event| %>
@@ -10,3 +16,6 @@ LINE名: <%= @profile.line_name %><br>
 出身地: <%= @profile.birthplace %><br>
 住所: <%= @profile.address %><br>
 職業: <%= @profile.occupation %><br>
+
+<%= link_to '編集', edit_profile_path(@profile) %>
+<%= link_to '削除', profile_path(@profile), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } %>


### PR DESCRIPTION
### 概要

登録した連絡先の詳細ページが表示される

---
### 内容

- [x] 以下の情報が表示される
- profilesテーブル
  - name (string)
  - furigana (string)
  - phone (string)
  - email (string)
  - line_name (string)
  - birthplace (string)
  - address (string)
  - occupation (string)
- eventsテーブル
  - name (string)
  - date (date)
- Avatar画像（別issueにて、ActiveStorageで実装）

- [x] 詳細ページから以下の画面へ遷移できるようにする（一旦同期で実装する。将来的に非同期も検討）
  - [x] 編集
  - [x] アルバム
  - [x] メモ
  - [x] 通知設定

---
### 補足
This PR close #11 