### PR TITLE
profiles CRUD操作の、N+1問題の解消

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -6,11 +6,11 @@ class ProfilesController < ApplicationController
   end
 
   def show
-    @profile = current_user.profiles.find(params[:id])
+    @profile = current_user.profiles.includes(:events).find(params[:id])
   end
 
   def index
-    @profiles = current_user.profiles.all.order(created_at: :desc)
+    @profiles = current_user.profiles.includes(:events).order(created_at: :desc)
   end
   
   def create
@@ -26,7 +26,7 @@ class ProfilesController < ApplicationController
   end
   
   def edit
-    @profile = current_user.profiles.find(params[:id])
+    @profile = current_user.profiles.includes(:events).find(params[:id])
   end
   
   def update


### PR DESCRIPTION
### 概要
profilesのCRUD操作のおける、N+1問題の解消

---
### 背景
accepts_nested_attributes_for :eventsをprofileモデルに設定していても、N+1問題は発生することが分かり、対応する

### 内容
- [x] showアクション
- [x] editアクション
- [x] indexアクション

---
### 補足

This PR close #80 