### PR TITLE
LINE友達登録から、LINE IDを取得し、DBに保存する

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -13,12 +13,7 @@ class LineBotController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
-          # message = {
-          #   type: 'text',
-          #   text: event['source']['userId']
-          # }
-          # client.reply_message(event['replyToken'], message)
-          
+
           @email = event.message['text'].match(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i)&.to_s
           @line_id = event['source']['userId']
           @user = User.find_by(email: @email)

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -15,7 +15,7 @@ class LineBotController < ApplicationController
         when Line::Bot::Event::MessageType::Text
           message = {
             type: 'text',
-            text: event.source['userId']
+            text: event['source']['userId']
           }
           client.reply_message(event['replyToken'], message)
           

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -17,21 +17,27 @@ class LineBotController < ApplicationController
       when Line::Bot::Event::Message # eventのtype(message, follow, unfollow)の内、messageを指定する
         case event.type
         when Line::Bot::Event::MessageType::Text # massageの中身がテキストだったとき
-          @email = event.message['text'].match(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i)&.to_s
-          @line_id = event.source['userId']
-          @user = User.find_by(email: @email)
+          message = {
+            type: 'text',
+            text: event.message['text']
+          }
+          client.reply_message(event['replyToken'], message)
 
-          if  @user && @user.update(line_user_id: @line_id)
-            client.reply_message(event['replyToken'], { 
-              type: 'text',
-              text: "アプリと連携ができました。大切な日に合わせてリマインド通知を受け取ることができます"
-            })
-          else
-            client.reply_message(event['replyToken'], {
-              type: 'text',
-              text: "アプリ連携に失敗しました。アプリに登録しているメールアドレスと一致しているか確認してください"
-            })
-          end
+          # @email = event.message['text'].match(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i)&.to_s
+          # @line_id = event.source['userId']
+          # @user = User.find_by(email: @email)
+
+          # if  @user && @user.update(line_user_id: @line_id)
+          #   client.reply_message(event['replyToken'], { 
+          #     type: 'text',
+          #     text: "アプリと連携ができました。大切な日に合わせてリマインド通知を受け取ることができます"
+          #   })
+          # else
+          #   client.reply_message(event['replyToken'], {
+          #     type: 'text',
+          #     text: "アプリ連携に失敗しました。アプリに登録しているメールアドレスと一致しているか確認してください"
+          #   })
+          # end
         end
       end
     end

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -13,27 +13,27 @@ class LineBotController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
-          message = {
-            type: 'text',
-            text: event['source']['userId']
-          }
-          client.reply_message(event['replyToken'], message)
+          # message = {
+          #   type: 'text',
+          #   text: event['source']['userId']
+          # }
+          # client.reply_message(event['replyToken'], message)
           
-          # @email = event.message['text'].match(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i)&.to_s
-          # @line_id = event.source['userId']
-          # @user = User.find_by(email: @email)
+          @email = event.message['text'].match(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i)&.to_s
+          @line_id = event['source']['userId']
+          @user = User.find_by(email: @email)
 
-          # if  @user && @user.update(line_user_id: @line_id)
-          #   client.reply_message(event['replyToken'], { 
-          #     type: 'text',
-          #     text: "アプリと連携ができました。大切な日に合わせてリマインド通知を受け取ることができます"
-          #   })
-          # else
-          #   client.reply_message(event['replyToken'], {
-          #     type: 'text',
-          #     text: "アプリ連携に失敗しました。アプリに登録しているメールアドレスと一致しているか確認してください"
-          #   })
-          # end
+          if  @user && @user.update(line_user_id: @line_id)
+            client.reply_message(event['replyToken'], { 
+              type: 'text',
+              text: "アプリと連携ができました。大切な日に合わせてリマインド通知を受け取ることができます"
+            })
+          else
+            client.reply_message(event['replyToken'], {
+              type: 'text',
+              text: "アプリ連携に失敗しました。アプリに登録しているメールアドレスと一致しているか確認してください"
+            })
+          end
         end
       end
     end

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -15,7 +15,7 @@ class LineBotController < ApplicationController
         when Line::Bot::Event::MessageType::Text
           message = {
             type: 'text',
-            text: event.message['text'].match(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i)&.to_s
+            text: event.source['userId']
           }
           client.reply_message(event['replyToken'], message)
           

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -10,15 +10,15 @@ class LineBotController < ApplicationController
     
     events.each do |event|
       case event
-      when Line::Bot::Event::Message # eventのtype(message, follow, unfollow)の内、messageを指定する
+      when Line::Bot::Event::Message
         case event.type
-        when Line::Bot::Event::MessageType::Text # massageの中身がテキストだったとき
+        when Line::Bot::Event::MessageType::Text
           message = {
             type: 'text',
-            text: event.message['text']
+            text: event.message['text'].match(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i)&.to_s
           }
           client.reply_message(event['replyToken'], message)
-
+          
           # @email = event.message['text'].match(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i)&.to_s
           # @line_id = event.source['userId']
           # @user = User.find_by(email: @email)

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -1,0 +1,40 @@
+class LineBotController < ApplicationController
+  # callbackアクションのCSRFトークン認証を無効
+  protect_from_forgery :except => [:line_id_registration]
+    
+  # LINEから呼び出されるアクション
+  def line_id_registration
+    # リクエストのbody（StringIOクラス）を文字列（Stringクラス）に変更
+    body = request.body.read
+    # parse_events_fromはline-bot-apiのオリジナルメソッド
+    # clientは以下で定義したプライベートアクション（が返したインスタンス）
+    events = client.parse_events_from(body)
+    
+    # eventsは配列に入っているので、eachでアクセス。events[0]でもだいたい同じ。
+    events.each do |event|
+      case event
+      when Line::Bot::Event::Message # eventのtype(message, follow, unfollow)の内、messageを指定する
+        case event.type
+        when Line::Bot::Event::MessageType::Text # massageの中身がテキストだったとき
+          @email = event.message['text'].hoge # メールアドレス形式かどうか判別し、メールアドレスだけ抜き出す
+          @line_id = event.source['userId']
+          @user = User.find_by(email: @email)
+          if @user.save(line_user_id: @line_id)
+            client.reply_message(even['replyToken'], "アプリと連携ができました。アプリ上で設定を行うことで、大切な日に合わせてリマインド通知を受け取ることができます")
+          else
+            client.reply_message(even['replyToken'], "アプリ連携に失敗しました。アプリに登録しているメールアドレスと一致しているか確認してください")
+          end
+        end
+      end
+    end
+  end
+
+  private
+
+  def client
+    @client ||= Line::Bot::Client.new { |config|
+      config.channel_secret = ENV['LINE_CHANNEL_SECRET']
+      config.channel_token = ENV['LINE_CHANNEL_TOKEN']
+    }
+  end
+end

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -1,17 +1,13 @@
 class LineBotController < ApplicationController
-  # アクションのCSRFトークン認証を無効
+  skip_before_action :require_login
+
   protect_from_forgery :except => [:line_id_registration]
     
-  # LINEから呼び出されるアクション
   def line_id_registration
-    # リクエストのbody（StringIOクラス）を文字列（Stringクラス）に変更
     body = request.body.read
 
-    # parse_events_fromはline-bot-apiのオリジナルメソッド
-    # clientは以下で定義したプライベートアクション（が返したインスタンス）
     events = client.parse_events_from(body)
     
-    # eventsは配列に入っているので、eachでアクセス。events[0]でもだいたい同じ。
     events.each do |event|
       case event
       when Line::Bot::Event::Message # eventのtype(message, follow, unfollow)の内、messageを指定する

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
   get 'openai', to: 'openai_api#chat'
+  post '/' => 'line_bot#line_id_registration'
 end


### PR DESCRIPTION
### 概要
LINE友達登録から、LINE IDを取得し、DBに保存する

---
### 背景
誕生日や大切な日のリマインド通知を送る為に、LINE IDを取得する必要がある為。

---
### 内容
- [x] LINEメッセージからemailアドレスをユーザーに手動で送ってもらい、DBのユーザー情報と突き合わせ、LINE IDを保存する
- [x] LINE IDの保存の成功したら、LINE上でその旨のメッセージを送る
- [x] LINE IDの保存が失敗したら、LINE上でその旨のメッセージを送る

---
### 補足
- ユーザーがわざわざメールアドレスを送らなければいけない手間があるものの、MVPに向けてはこの実装で進む
- 本リリースでは、LINE認証から、ユーザーとLINE IDを紐づけて保存するようにアップデートする