### PR TITLE
ユーザーが通知を受けとるタイミングを設定できるようにする

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,8 +7,7 @@ class EventsController < ApplicationController
 
   def update_all
     @form = Form::EventCollection.new(event_params)
-    binding.pry
-    if @form.save
+    if @form.update
       flash[:success] = '保存しました'
       redirect_to root_path
     else
@@ -20,6 +19,6 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:form_event_collection).permit(events_attributes: [:id, :name, :date, :notification_timing, :notification_enabled])
+    params.require(:form_event_collection).permit(events_attributes: [:id, :name, :date, :notification_timing, :notification_enabled, :profile_id])
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,25 @@
+class EventsController < ApplicationController
+
+  def index
+    @profile = current_user.profiles.find(params[:profile_id])
+    @form = Form::EventCollection.new(events: @profile.events)
+  end
+
+  def update_all
+    @form = Form::EventCollection.new(event_params)
+    binding.pry
+    if @form.save
+      flash[:success] = '保存しました'
+      redirect_to root_path
+    else
+      flash.now[:success] = '保存できませんでした'
+      render :index, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def event_params
+    params.require(:form_event_collection).permit(events_attributes: [:id, :name, :date, :notification_timing, :notification_enabled])
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,7 +9,7 @@ class EventsController < ApplicationController
     @form = Form::EventCollection.new(event_params)
     if @form.update
       flash[:success] = '保存しました'
-      redirect_to root_path
+      redirect_to profile_events_path(@form.events.first.profile_id)
     else
       flash.now[:success] = '保存できませんでした'
       render :index, status: :unprocessable_entity

--- a/app/models/form/base.rb
+++ b/app/models/form/base.rb
@@ -1,0 +1,5 @@
+class Form::Base
+  include ActiveModel::Model
+  include ActiveModel::Callbacks
+  include ActiveModel::Validations::Callbacks
+end

--- a/app/models/form/event_collection.rb
+++ b/app/models/form/event_collection.rb
@@ -1,0 +1,22 @@
+class Form::EventCollection < Form::Base
+  attr_accessor :events
+  FORM_COUNT = 2
+
+  def initialize(attributes = {})
+    super attributes
+
+    if attributes[:events]
+      self.events = FORM_COUNT.times.map { Event.new() } unless self.events.present?
+    end
+  end
+
+  def events_attributes=(attributes)
+    self.events= attributes.map { |_, v| Event.new(v) }
+  end
+
+  def save
+    Event.transaction do
+      self.events.map(&:save!)
+    end
+  end
+end

--- a/app/models/form/event_collection.rb
+++ b/app/models/form/event_collection.rb
@@ -1,11 +1,8 @@
 class Form::EventCollection < Form::Base
   attr_accessor :events
-  FORM_COUNT = 2
 
   def initialize(attributes = {})
     super attributes
-
-    self.events = FORM_COUNT.times.map { Event.new() } unless self.events.present?
   end
 
   def events_attributes=(attributes)

--- a/app/models/form/event_collection.rb
+++ b/app/models/form/event_collection.rb
@@ -5,9 +5,7 @@ class Form::EventCollection < Form::Base
   def initialize(attributes = {})
     super attributes
 
-    if attributes[:events]
-      self.events = FORM_COUNT.times.map { Event.new() } unless self.events.present?
-    end
+    self.events = FORM_COUNT.times.map { Event.new() } unless self.events.present?
   end
 
   def events_attributes=(attributes)

--- a/app/models/form/event_collection.rb
+++ b/app/models/form/event_collection.rb
@@ -14,9 +14,12 @@ class Form::EventCollection < Form::Base
     self.events= attributes.map { |_, v| Event.new(v) }
   end
 
-  def save
+  def update
     Event.transaction do
-      self.events.map(&:save!)
+      self.events.each do |event|
+        existing_event = Event.find(event.id)
+        existing_event.update!(event.attributes.except("created_at", "updated_at"))
+      end
     end
   end
 end

--- a/app/models/form/event_collection.rb
+++ b/app/models/form/event_collection.rb
@@ -9,7 +9,10 @@ class Form::EventCollection < Form::Base
   end
 
   def events_attributes=(attributes)
-    self.events= attributes.map { |_, v| Event.new(v) }
+    self.events = attributes.map do |_, v|
+      v[:notification_enabled] = ActiveRecord::Type::Boolean.new.cast(v[:notification_enabled])
+      Event.new(v)
+    end
   end
 
   def update

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -7,6 +7,7 @@
     <%# 通知<%=i.check_box :notification_enabled %>
     <%= i.hidden_field :date, value: i.object.date %>
     <%= i.hidden_field :name, value: i.object.name %>
+    <%= i.hidden_field :profile_id, value: i.object.profile_id %>
   <% end %>
 
   <%= f.submit '登録する' %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -3,8 +3,8 @@
 
   <%= f.fields_for :events do |i| %>
     <%= "#{i.object.name}の" %>
-    <%=i.select :notification_timing, [0,1,3,7,14,30,60], selected: i.object.notification_timing %>日前に、<br>
-    <%# 通知<%=i.check_box :notification_enabled %>
+    <%=i.select :notification_timing, [0,1,3,7,14,30,60], selected: i.object.notification_timing %>日前に、
+    通知<%=i.check_box :notification_enabled, checked: i.object.notification_enabled == "on" %><br>
     <%= i.hidden_field :date, value: i.object.date %>
     <%= i.hidden_field :name, value: i.object.name %>
     <%= i.hidden_field :profile_id, value: i.object.profile_id %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,18 @@
+<%= form_with model: @form, url: update_all_profile_events_path, method: :patch, data: { turbo: false } do |f| %>
+  <%= render 'shared/error_messages', model: f.object %>
+
+  <%= f.fields_for :events do |i| %>
+    <%= "#{i.object.name}の" %>
+    <%=i.select :notification_timing, [0,1,3,7,14,30,60], selected: i.object.notification_timing %>日前に、<br>
+    <%# 通知<%=i.check_box :notification_enabled %>
+    <%= i.hidden_field :date, value: i.object.date %>
+    <%= i.hidden_field :name, value: i.object.name %>
+  <% end %>
+
+  <%= f.submit '登録する' %>
+<% end %>
+
+<div>
+※通知機能を使うためには、LINEの友達登録が必要です。<br>
+友達登録はこちらから
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,7 +1,7 @@
 <div>
   <%= link_to 'アルバム', '#'%>
   <%= link_to 'メモ', '#'%>
-  <%= link_to '通知設定', '#'%>
+  <%= link_to '通知設定', profile_events_path(@profile) %>
 </div>
 
 名前: <%= @profile.name %><br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,13 @@ Rails.application.routes.draw do
   resources :questions, only: [:show]
   resources :answers, only: [:create]
   resources :users, only: [:new, :create]
-  resources :profiles
+  resources :profiles do
+    resources :events do
+      collection do
+        patch :update_all
+      end
+    end
+  end
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'


### PR DESCRIPTION
### 概要
連絡先のイベントに関するLINE通知タイミングを設定する

---
### 背景
個々のイベントに対してユーザーが通知のオンオフ、そして通知のタイミングを設定できるようにしたい。

---
### 内容
- [x] DBに登録されたeventの日付をもとに、通知を受け取るタイミングを設定できるようにする
　例）誕生日の「7日前」に通知を受けとる

  - 選択肢は以下の通り
    - 60日前
    - 30日前
    - 14日前
    - 7日前
    - 3日前
    - 1日前
    - 当日

- [x] 通知をオフに設定できるようにする（eventsテーブルのnotification_enabledにenumで設定）
- [x] 保存ボタンにより、設定を保存できるようにする
- [x] 保存したら「設定を保存しました」というフラッシュメッセージを表示する（画面遷移はしない）

---
### 実装しなかったこと
- profileが持てるeventレコード数を２つに限定したいが、これは別Issueで対応する

---
### 補足

This PR close #13 