### PR TITLE
Eventsレコードは、1profileにつき、２つまでに限定する

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,6 +3,8 @@ class Event < ApplicationRecord
 
   enum notification_enabled: { off: false, on: true }
 
+  validate :check_number_of_events
+
   def is_ready_to_notify?
     date.present? && notification_timing.present? && notification_enabled?
   end
@@ -17,5 +19,11 @@ class Event < ApplicationRecord
 
   def change_utc_to_jst(datetime)
     datetime + 9.hours
+  end
+
+  def check_number_of_events
+    if profile&.events.count > 1
+      errors.add(:events, "大切な日は１つまでしか登録できません")
+    end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,7 +3,7 @@ class Event < ApplicationRecord
 
   enum notification_enabled: { off: false, on: true }
 
-  validate :check_number_of_events
+  validate :check_number_of_events, on: :create
 
   def is_ready_to_notify?
     date.present? && notification_timing.present? && notification_enabled?
@@ -22,7 +22,7 @@ class Event < ApplicationRecord
   end
 
   def check_number_of_events
-    if profile&.events.count > 1
+    if profile&.events.count == 2
       errors.add(:events, "大切な日は１つまでしか登録できません")
     end
   end


### PR DESCRIPTION
### 概要
Eventsレコードは、1profileにつき、２つまでに限定する

---
### 背景・目的
３つ以上のeventsの登録は、ユーザーにとって不要だと考えるため
フォームには、２つのevents登録欄しか表示しないが、念のためモデル側でもバリエーションを掛けておく

---
### 内容
- [x] profileに紐づいたeventsのレコード数を確認する
- [x] eventsレコードにバリデーションをかける

---
### 対応しないこと
- [ ] 

---
### 補足