### PR TITLE
AI質問　複数選択で選ばなかった場合のエラー対処

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,20 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+
+document.addEventListener("DOMContentLoaded", function() {
+  const form = document.querySelector("#ai_questions");
+  form.addEventListener("submit", function(event) {
+    // チェックボックスの選択状況を確認する
+    const checkboxes = form.querySelectorAll('input[type="checkbox"]');
+    if (checkboxes.length === 0) {
+      return;
+    }
+
+    const isChecked = Array.from(checkboxes).some(checkbox => checkbox.checked);
+    if (!isChecked) {
+      alert("少なくとも1つ選択してください。");
+      event.preventDefault(); // フォーム送信をキャンセル
+    }
+  });
+});

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,12 +1,13 @@
 <div class="flex items-center justify-center min-h-screen">
   <div class="border-white border-2 rounded-md p-10">
-    <div class="text-center mb-5 text-2xl text-white">
-      <%= @question.text %>
-    </div>
 
     <div class="flex items-center justify-center">
       <%= form_with url: answers_path, method: :post, data: { turbo: false }, id: 'ai_questions' do |form| %>
         <% if @question.number.to_i == 2 %>
+          <div class="flex flex-col text-center mb-5 text-2xl text-white">
+            <h1><%= @question.text %></h1>
+            <h2 class="text-base mt-2">※複数選択可</h2>
+          </div>
           <% @answers.each do |answer| %>
             <div class="flex items-center mb-2 text-white text-xl gap-2">
               <%= form.check_box "answer[question#{@question.number}]", { multiple: true }, answer.value, nil %>
@@ -17,6 +18,9 @@
             <%= form.submit '次へ', class:"btn bg-white rounded-md text-black border-none shadow-2xl hover:bg-white" %>
           </div>
         <% else %>
+          <div class="text-center mb-5 text-2xl text-white">
+            <%= @question.text %>
+          </div>
           <% @answers.each do |answer| %>
             <div class="flex items-center mb-2 text-white text-xl gap-2">
               <%= form.radio_button "answer[question#{@question.number}]", answer.value, required: :true %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -5,7 +5,7 @@
     </div>
 
     <div class="flex items-center justify-center">
-      <%= form_with url: answers_path, method: :post, data: { turbo: false } do |form| %>
+      <%= form_with url: answers_path, method: :post, data: { turbo: false }, id: 'ai_questions' do |form| %>
         <% if @question.number.to_i == 2 %>
           <% @answers.each do |answer| %>
             <div class="flex items-center mb-2 text-white text-xl gap-2">


### PR DESCRIPTION
### 概要
AI質問　複数選択で選ばなかった場合のエラー対処

---
### 背景・目的
- 複数選択ができる質問に対して、何も選択せずに回答すると、エラーが発生する（原因：キーと値がparamsに入らないため）

---

### 内容
- [x] 複数選択ができる質問に対して、何も選択せずに回答すると、1つ以上を選ぶようにメッセージを出す
- [x] 複数選択可能である旨の文言を、質問２に付け加える

---
### 対応しないこと
- [ ] 

---
### 補足

This PR close #94 
