### PR TITLE
トップページの誤記を修正

### DIFF
--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -21,7 +21,7 @@
   <div class="w-1/2 flex-col justify-center items-center text-white text-center">
     <div>
       <h1 class="text-5xl sm:text-7xl mb-12 mt-44">つながりつづけよう</h1>
-      <h1 class="text-5xl sm:text-7xl mb-20">これかららも、ずっと</h1>
+      <h1 class="text-5xl sm:text-7xl mb-20">これからも、ずっと</h1>
       <p class="text-xl mb-10 text-center">ともだちの大切な日を登録して<br>リマインダー通知を受け取ろう</p>
     </div>
     <div>


### PR DESCRIPTION
### 概要
トップページのメッセージ誤記修正

---
### 背景・目的
TOPページ　セカンドビューの文言に誤記があったため（「これかららも」）

---
### 内容
- [x] 「これかららも、ずっと」　→　「これからも、ずっと」

---
### 対応しないこと
- [ ] 

---
### 補足
This PR close #116 