### PR TITLE
LINEログインの実装

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -17,12 +17,12 @@ class OauthsController < ApplicationController
       return
     end
 
+    if @user.nil?
+      logger.error "User not found from provider: #{provider}"
+      redirect_to root_path, alert: "Failed to login from #{provider.titleize}!"
+      return
+    end
     if @user = login_from(provider)
-      if @user.nil?
-        logger.error "User not found from provider: #{provider}"
-        redirect_to root_path, alert: "Failed to login from #{provider.titleize}!"
-        return
-      end
       redirect_to root_path, :notice => "Logged in from #{provider.titleize}!"
     else
       begin

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -1,0 +1,38 @@
+# app/controllers/oauths_controller.rb
+class OauthsController < ApplicationController
+  skip_before_action :require_login, raise: false
+
+  # sends the user on a trip to the provider,
+  # and after authorizing there back to the callback url.
+  def oauth
+    login_at(params[:provider])
+  end
+
+  def callback
+    provider = params[:provider]
+    if @user = login_from(provider)
+      redirect_to root_path, :notice => "Logged in from #{provider.titleize}!"
+    else
+      begin
+        @user = create_from(provider)
+        # NOTE: this is the place to add '@user.activate!' if you are using user_activation submodule
+
+        reset_session # protect from session fixation attack
+        auto_login(@user)
+        redirect_to root_path, :notice => "Logged in from #{provider.titleize}!"
+      rescue
+        redirect_to root_path, :alert => "Failed to login from #{provider.titleize}!"
+      end
+    end
+  end
+
+  #example for Rails 4: add private method below and use "auth_params[:provider]" in place of
+  #"params[:provider] above.
+
+    private
+
+    def auth_params
+        params.permit(:code, :provider, :error, :state)
+    end
+
+end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -17,6 +17,7 @@ class OauthsController < ApplicationController
       begin
         @user = create_from(provider)
         # NOTE: this is the place to add '@user.activate!' if you are using user_activation submodule
+        Rails.logger.debug "User created: #{@user.inspect}"
 
         reset_session # protect from session fixation attack
         auto_login(@user)

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -5,12 +5,24 @@ class OauthsController < ApplicationController
   # sends the user on a trip to the provider,
   # and after authorizing there back to the callback url.
   def oauth
-    login_at(params[:provider])
+    login_at(auth_params[:provider])
   end
 
   def callback
-    provider = params[:provider]
+    provider = auth_params[:provider]
+
+    if provider.nil?
+      logger.error "Provider is nil!"
+      redirect_to root_path, alert: "Invalid provider"
+      return
+    end
+
     if @user = login_from(provider)
+      if @user.nil?
+        logger.error "User not found from provider: #{provider}"
+        redirect_to root_path, alert: "Failed to login from #{provider.titleize}!"
+        return
+      end
       redirect_to root_path, :notice => "Logged in from #{provider.titleize}!"
     else
       begin

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -17,8 +17,6 @@ class OauthsController < ApplicationController
       begin
         @user = create_from(provider)
         # NOTE: this is the place to add '@user.activate!' if you are using user_activation submodule
-        Rails.logger.debug "User created: #{@user.inspect}"
-
         reset_session # protect from session fixation attack
         auto_login(@user)
         redirect_to root_path, :notice => "Logged in from #{provider.titleize}!"

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -11,17 +11,6 @@ class OauthsController < ApplicationController
   def callback
     provider = auth_params[:provider]
 
-    if provider.nil?
-      logger.error "Provider is nil!"
-      redirect_to root_path, alert: "Invalid provider"
-      return
-    end
-
-    if @user.nil?
-      logger.error "User not found from provider: #{provider}"
-      redirect_to root_path, alert: "Failed to login from #{provider.titleize}!"
-      return
-    end
     if @user = login_from(provider)
       redirect_to root_path, :notice => "Logged in from #{provider.titleize}!"
     else

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,0 +1,3 @@
+class Authentication < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,11 +10,11 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
-  validates :first_name, presence: true, length: { maximum: 255 }
-  validates :last_name, presence: true, length: { maximum: 255 }
-  validates :email, presence: true, uniqueness: true
+  # validates :first_name, presence: true, length: { maximum: 255 }
+  # validates :last_name, presence: true, length: { maximum: 255 }
+  # validates :email, presence: true, uniqueness: true
   validates :line_user_id, uniqueness: true, allow_blank: true
-  validates :notification_enabled, presence: true
+  # validates :notification_enabled, presence: true
 
   enum notification_enabled: { off: false, on: true }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,11 +10,11 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
-  # validates :first_name, presence: true, length: { maximum: 255 }
-  # validates :last_name, presence: true, length: { maximum: 255 }
-  # validates :email, presence: true, uniqueness: true
+  validates :first_name, presence: true, length: { maximum: 255 }
+  validates :last_name, presence: true, length: { maximum: 255 }
+  validates :email, presence: true, uniqueness: true
   validates :line_user_id, uniqueness: true, allow_blank: true
-  # validates :notification_enabled, presence: true
+  validates :notification_enabled, presence: true
 
   enum notification_enabled: { off: false, on: true }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  has_many :authentications, dependent: :destroy
+  accepts_nested_attributes_for :authentications
 
   has_many :profiles, dependent: :destroy
   has_many :groups, dependent: :destroy

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -17,4 +17,5 @@
     <%= link_to '新規登録', new_user_path %>
     <%# <%= link_to 'パスワードをお忘れの方はこちら', '#' %>
   </div>
+  <%= link_to 'Login with Line', auth_at_provider_path(provider: :line) %>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -30,4 +30,6 @@
   <div class='mt-5'>
     <%= link_to 'ログインページへ', login_path %>
   </div>
+
+  <%= link_to 'Login with Line', auth_at_provider_path(provider: :line) %>
 </div>

--- a/compose.yml
+++ b/compose.yml
@@ -32,6 +32,15 @@ services:
     depends_on:
       db:
         condition: service_healthy
+  ngrok:
+    image: ngrok/ngrok:latest
+    environment:
+      NGROK_AUTHTOKEN: ${NGROK_AUTH}
+    command: ["http", "web:3000"]
+    depends_on:
+      - web
+    ports:
+      - "4040:4040"
 volumes:
   mysql_data:
   bundle_data:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,7 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  #Allow ngrok
+  config.hosts.clear
 end

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -221,10 +221,10 @@ Rails.application.config.sorcery.configure do |config|
 
   config.line.key = ENV.fetch("LINE_CHANNEL_ID_LOGIN")
   config.line.secret = ENV.fetch("LINE_CHANNEL_SECRET_LOGIN")
-  config.line.callback_url = "https://powerful-sands-04341-a27c5520cc0b.herokuapp.com/oauth/callback?provider=line"
+  config.line.callback_url = Settings.sorcery[:line_callback_url]
   config.line.scope = "profile openid"
   config.line.bot_prompt = "aggressive"
-  config.line.user_info_mapping = {first_name: 'name', email: "email", line_user_id: "sub" }
+  config.line.user_info_mapping = { first_name: 'displayName', line_user_id: "userId" }
 
   # For information about Discord API
   # https://discordapp.com/developers/docs/topics/oauth2

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -221,8 +221,8 @@ Rails.application.config.sorcery.configure do |config|
 
   config.line.key = ENV.fetch("LINE_CHANNEL_ID_LOGIN")
   config.line.secret = ENV.fetch("LINE_CHANNEL_SECRET_LOGIN")
-  # config.line.callback_url = "https://powerful-sands-04341-a27c5520cc0b.herokuapp.com/oauth/callback"
-  config.line.scope = "profile"
+  config.line.callback_url = "https://powerful-sands-04341-a27c5520cc0b.herokuapp.com/oauth/callback"
+  config.line.scope = "profile%20openid"
   config.line.bot_prompt = "aggressive"
   config.line.user_info_mapping = {first_name: 'name', email: "email", line_user_id: "sub" }
 

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -221,7 +221,7 @@ Rails.application.config.sorcery.configure do |config|
 
   config.line.key = ENV.fetch("LINE_CHANNEL_ID_LOGIN")
   config.line.secret = ENV.fetch("LINE_CHANNEL_SECRET_LOGIN")
-  config.line.callback_url = "https://powerful-sands-04341-a27c5520cc0b.herokuapp.com/oauth/callback"
+  config.line.callback_url = "https://powerful-sands-04341-a27c5520cc0b.herokuapp.com/oauth/callback?provider=line"
   config.line.scope = "profile openid"
   config.line.bot_prompt = "aggressive"
   config.line.user_info_mapping = {first_name: 'name', email: "email", line_user_id: "sub" }

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -221,7 +221,7 @@ Rails.application.config.sorcery.configure do |config|
 
   config.line.key = ENV.fetch("LINE_CHANNEL_ID_LOGIN")
   config.line.secret = ENV.fetch("LINE_CHANNEL_SECRET_LOGIN")
-  config.line.callback_url = "https://powerful-sands-04341-a27c5520cc0b.herokuapp.com/"
+  config.line.callback_url = "https://powerful-sands-04341-a27c5520cc0b.herokuapp.com/oauth/callback"
   config.line.scope = "profile%20openid	"
   config.line.bot_prompt = "aggressive"
   config.line.user_info_mapping = {first_name: 'name', email: "email", line_user_id: "sub" }

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = []
+Rails.application.config.sorcery.submodules = [:external]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -80,7 +80,7 @@ Rails.application.config.sorcery.configure do |config|
   # i.e. [:twitter, :facebook, :github, :linkedin, :xing, :google, :liveid, :salesforce, :slack, :line].
   # Default: `[]`
   #
-  # config.external_providers =
+  config.external_providers = %i[line]
 
   # You can change it by your local ca_file. i.e. '/etc/pki/tls/certs/ca-bundle.crt'
   # Path to ca_file. By default use a internal ca-bundle.crt.
@@ -219,14 +219,13 @@ Rails.application.config.sorcery.configure do |config|
   # config.salesforce.scope = "full"
   # config.salesforce.user_info_mapping = {:email => "email"}
 
-  # config.line.key = ""
-  # config.line.secret = ""
-  # config.line.callback_url = "http://mydomain.com:3000/oauth/callback?provider=line"
-  # config.line.scope = "profile"
-  # config.line.bot_prompt = "normal"
-  # config.line.user_info_mapping = {name: 'displayName'}
+  config.line.key = ENV.fetch("LINE_CHANNEL_ID_LOGIN")
+  config.line.secret = ENV.fetch("LINE_CHANNEL_SECRET_LOGIN")
+  config.line.callback_url = "https://powerful-sands-04341-a27c5520cc0b.herokuapp.com/"
+  config.line.scope = "profile%20openid	"
+  config.line.bot_prompt = "aggressive"
+  config.line.user_info_mapping = {first_name: 'name', email: "email", line_user_id: "sub" }
 
-  
   # For information about Discord API
   # https://discordapp.com/developers/docs/topics/oauth2
   # config.discord.key = "xxxxxx"

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -542,7 +542,7 @@ Rails.application.config.sorcery.configure do |config|
     # Class which holds the various external provider data for this user.
     # Default: `nil`
     #
-    # user.authentications_class =
+    user.authentications_class = Authentication
 
     # User's identifier in the `authentications` class.
     # Default: `:user_id`

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -222,7 +222,7 @@ Rails.application.config.sorcery.configure do |config|
   config.line.key = ENV.fetch("LINE_CHANNEL_ID_LOGIN")
   config.line.secret = ENV.fetch("LINE_CHANNEL_SECRET_LOGIN")
   config.line.callback_url = "https://powerful-sands-04341-a27c5520cc0b.herokuapp.com/oauth/callback"
-  config.line.scope = "profile%20openid"
+  config.line.scope = "profile"
   config.line.bot_prompt = "aggressive"
   config.line.user_info_mapping = {first_name: 'name', email: "email", line_user_id: "sub" }
 

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -221,7 +221,7 @@ Rails.application.config.sorcery.configure do |config|
 
   config.line.key = ENV.fetch("LINE_CHANNEL_ID_LOGIN")
   config.line.secret = ENV.fetch("LINE_CHANNEL_SECRET_LOGIN")
-  config.line.callback_url = "https://powerful-sands-04341-a27c5520cc0b.herokuapp.com/oauth/callback"
+  # config.line.callback_url = "https://powerful-sands-04341-a27c5520cc0b.herokuapp.com/oauth/callback"
   config.line.scope = "profile"
   config.line.bot_prompt = "aggressive"
   config.line.user_info_mapping = {first_name: 'name', email: "email", line_user_id: "sub" }

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -222,7 +222,7 @@ Rails.application.config.sorcery.configure do |config|
   config.line.key = ENV.fetch("LINE_CHANNEL_ID_LOGIN")
   config.line.secret = ENV.fetch("LINE_CHANNEL_SECRET_LOGIN")
   config.line.callback_url = "https://powerful-sands-04341-a27c5520cc0b.herokuapp.com/oauth/callback"
-  config.line.scope = "profile%20openid"
+  config.line.scope = "profile openid"
   config.line.bot_prompt = "aggressive"
   config.line.user_info_mapping = {first_name: 'name', email: "email", line_user_id: "sub" }
 

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -222,7 +222,7 @@ Rails.application.config.sorcery.configure do |config|
   config.line.key = ENV.fetch("LINE_CHANNEL_ID_LOGIN")
   config.line.secret = ENV.fetch("LINE_CHANNEL_SECRET_LOGIN")
   config.line.callback_url = "https://powerful-sands-04341-a27c5520cc0b.herokuapp.com/oauth/callback"
-  config.line.scope = "profile%20openid	"
+  config.line.scope = "profile%20openid"
   config.line.bot_prompt = "aggressive"
   config.line.user_info_mapping = {first_name: 'name', email: "email", line_user_id: "sub" }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,6 @@ Rails.application.routes.draw do
 
   get 'line_qr_code', to: 'static_pages#line_qr_code'
 
-  post "oauth/callback" => "oauths#callback"
+  get "oauth/callback" => "oauths#callback"
   get "oauth/:provider" => "oauths#oauth", :as => :auth_at_provider
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,4 +18,7 @@ Rails.application.routes.draw do
   post '/' => 'line_bot#save_line_id'
 
   get 'line_qr_code', to: 'static_pages#line_qr_code'
+
+  post "oauth/callback" => "oauths#callback"
+  get "oauth/:provider" => "oauths#oauth", :as => :auth_at_provider
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
 
   get 'line_qr_code', to: 'static_pages#line_qr_code'
 
-  get "oauth/callback" => "oauths#callback"
-  get "oauth/:provider" => "oauths#oauth", :as => :auth_at_provider
+post "oauth/callback" => "oauths#callback"
+get "oauth/callback" => "oauths#callback" # for use with Github, Facebook
+get "oauth/:provider" => "oauths#oauth", :as => :auth_at_provider
 end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,2 @@
+sorcery:
+  line_callback_url: "https://eaf0-111-188-249-157.ngrok-free.app/oauth/callback?provider=line"

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,0 +1,2 @@
+sorcery:
+  line_callback_url: "https://powerful-sands-04341-a27c5520cc0b.herokuapp.com/oauth/callback?provider=line"

--- a/db/migrate/20240810231347_sorcery_external.rb
+++ b/db/migrate/20240810231347_sorcery_external.rb
@@ -1,0 +1,12 @@
+class SorceryExternal < ActiveRecord::Migration[7.1]
+  def change
+    create_table :authentications do |t|
+      t.integer :user_id, null: false
+      t.string :provider, :uid, null: false
+
+      t.timestamps              null: false
+    end
+
+    add_index :authentications, [:provider, :uid]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_17_031319) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_10_231347) do
   create_table "albums", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.date "date"
     t.string "title"
@@ -28,6 +28,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_17_031319) do
     t.bigint "question_id", null: false
     t.index ["question_id"], name: "index_answers_on_question_id"
     t.index ["value"], name: "index_answers_on_value", unique: true
+  end
+
+  create_table "authentications", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
   end
 
   create_table "events", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
### 概要
LINEログインの実装

---
### 背景・目的
LINE通知を簡単に行うため。

現状、LINEログインを使わず登録されたユーザーにLINE通知を送る場合、
①LINE公式アカウントに友達登録してもらう
②LINE公式アカウントにメールアドレスを送信してもらう（同時にLINE IDをAPIから取得）
③DBでメールアドレスに合致するユーザー情報に、LINE IDを登録
という手順になっている。

メールアドレスを送ってもらう手間が発生してしまうのが課題。

LINEログインを使ったユーザーに対しては、LINE公式アカウントに友達登録してもらうだけで、
メールアドレスを要求する必要がなくなる

---
### 内容
- [x] sorceryのサブモジュールを使って実装すること
- [x] 新規登録画面にLINEログインボタンを設置する
- [x] ログイン画面にLINEログインボタンを設置する

---
### 対応しないこと
- [ ] 

---
### 補足
This PR close #85 