### PR TITLE
Userテーブルのfirst_name、last_nameを削除し、nameを作成する

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,8 +10,7 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
-  validates :first_name, presence: true, length: { maximum: 255 }
-  validates :last_name, presence: true, length: { maximum: 255 }
+  validates :name, presence: true, length: { maximum: 255 }
   validates :email, presence: true, uniqueness: true
   validates :line_user_id, uniqueness: true, allow_blank: true
   validates :notification_enabled, presence: true

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -4,12 +4,8 @@
     <%= render 'shared/error_messages', model: f.object %>
 
     <div class="mb-3">
-      <%= f.label :last_name, "姓", class: "form-label" %>
-      <%= f.text_field :last_name, class: "form-control" %>
-    </div>
-    <div class="mb-3">
-      <%= f.label :first_name, "名", class: "form-label" %>
-      <%= f.text_field :first_name, class: "form-control" %>
+      <%= f.label :name, "名前", class: "form-label" %>
+      <%= f.text_field :name, class: "form-control" %>
     </div>
     <div class="mb-3">
       <%= f.label :email, "メールアドレス", class: "form-label" %>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -222,9 +222,9 @@ Rails.application.config.sorcery.configure do |config|
   config.line.key = ENV.fetch("LINE_CHANNEL_ID_LOGIN")
   config.line.secret = ENV.fetch("LINE_CHANNEL_SECRET_LOGIN")
   config.line.callback_url = Settings.sorcery[:line_callback_url]
-  config.line.scope = "profile openid"
+  config.line.scope = "profile openid email"
   config.line.bot_prompt = "aggressive"
-  config.line.user_info_mapping = { first_name: 'displayName', line_user_id: "userId" }
+  config.line.user_info_mapping = { name: 'displayName', line_user_id: "userId", email: "email" }
 
   # For information about Discord API
   # https://discordapp.com/developers/docs/topics/oauth2

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,2 @@
 sorcery:
-  line_callback_url: "https://eaf0-111-188-249-157.ngrok-free.app/oauth/callback?provider=line"
+  line_callback_url: "https://41ec-111-188-249-157.ngrok-free.app/oauth/callback?provider=line"

--- a/db/migrate/20240814064633_remove_first_name_and_last_name_from_users.rb
+++ b/db/migrate/20240814064633_remove_first_name_and_last_name_from_users.rb
@@ -1,0 +1,6 @@
+class RemoveFirstNameAndLastNameFromUsers < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :users, :first_name, :string
+    remove_column :users, :last_name, :string
+  end
+end

--- a/db/migrate/20240814065659_add_name_to_users.rb
+++ b/db/migrate/20240814065659_add_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddNameToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :name, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_10_231347) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_14_065659) do
   create_table "albums", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.date "date"
     t.string "title"
@@ -99,12 +99,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_10_231347) do
     t.string "email", null: false
     t.string "crypted_password"
     t.string "salt"
-    t.string "first_name", null: false
-    t.string "last_name", null: false
     t.string "line_user_id"
     t.boolean "notification_enabled", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["line_user_id"], name: "index_users_on_line_user_id", unique: true
   end


### PR DESCRIPTION
### 概要
Userテーブルのfirst_name、last_nameを削除し、nameを作成する

---
### 背景・目的
LINEログインで取得したユーザー名を、Userテーブルのカラムに紐づけるため。
現状、first_nameとlast_nameの2つのカラムがあり、どちらに紐づけるか混乱するため1つのカラム（name）に統一する

---
### 内容
- [x] first_name、last_nameを削除（Userテーブル）
- [x] nameカラムを作成（Userテーブル）
- [x] Userモデルのバリデーションを修正
  - [x] first_nameとlast_nameに関するバリデーションを削除
  - [x] nameに関してバリデーションを設定（presence: true, length: 最大255文字）
- [x] LINE APIから取得するユーザー情報をUserテーブルにマッピングする
  - [x] プロフィール情報（name）
  - [x] LINE ID（line_user_id）
  - [ ] メールアドレス（email）
- [x] 新規登録ビューを修正
- [x] ストロングパラメーターを修正
- [x] ER図を修正

---
### 対応しないこと
- メールアドレス（email）情報のマッピング。メールアドレス取得申請中のため、別issueで対応。したがって、現在emailのnull制約によってLINEログインはできない状況

---
### 補足
This PR close #151 