### PR TITLE
ともだち帳　個別アルバム

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -28,6 +28,8 @@ class AlbumsController < ApplicationController
   end
 
   def edit
+    @profile = current_user.profiles.find(params[:profile_id])
+    @album = @profile.albums.find(params[:id])
   end
 
   def update

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -33,6 +33,21 @@ class AlbumsController < ApplicationController
   end
 
   def update
+    @profile = current_user.profiles.find(params[:profile_id])
+    @album = @profile.albums.find(params[:id])
+
+    if @album.update(album_params.reject { |k| k["images"] })
+      if album_params[:images].present?
+        album_params[:images].each do |image|
+          @album.images.attach(image)
+        end
+      end
+      flash[:success] = "アルバムを更新しました"
+      redirect_to profile_albums_path(@album.profile_id)
+    else
+      flash[:danger] = "更新に失敗しました"
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def destroy

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -1,0 +1,30 @@
+class AlbumsController < ApplicationController
+  def new
+    @profile = current_user.profiles.find(params[:profile_id])
+    @album = @profile.albums.new
+  end
+
+  def show
+  end
+
+  def index
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+
+private
+
+  # def profile_params
+  #   params.require(:).permit(:)
+  # end
+end

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -51,6 +51,11 @@ class AlbumsController < ApplicationController
   end
 
   def destroy
+    @profile = current_user.profiles.find(params[:profile_id])
+    @album = @profile.albums.find(params[:id])
+    @album.destroy!
+    flash[:success] = "削除しました"
+    redirect_to profile_albums_path(@album.profile_id), status: :see_other
   end
 
   private

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -11,6 +11,16 @@ class AlbumsController < ApplicationController
   end
 
   def create
+    @profile = current_user.profiles.find(params[:profile_id])
+    @album = @profile.albums.new(album_params)
+
+    if @album.save
+      flash[:success] = "アルバムを登録しました"
+      redirect_to profile_albums_path(@profile)
+    else
+      flash[:danger] = "登録に失敗しました"
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def edit
@@ -22,9 +32,9 @@ class AlbumsController < ApplicationController
   def destroy
   end
 
-private
+  private
 
-  # def profile_params
-  #   params.require(:).permit(:)
-  # end
+  def album_params
+    params.require(:album).permit(:date, :title, :diary, images:[])
+  end
 end

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -5,6 +5,8 @@ class AlbumsController < ApplicationController
   end
 
   def show
+    @profile = current_user.profiles.find(params[:profile_id])
+    @album = @profile.albums.find(params[:id])
   end
 
   def index

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -8,6 +8,8 @@ class AlbumsController < ApplicationController
   end
 
   def index
+    @profile = current_user.profiles.find(params[:profile_id])
+    @albums = @profile.albums.order(created_at: :desc)
   end
 
   def create
@@ -16,7 +18,7 @@ class AlbumsController < ApplicationController
 
     if @album.save
       flash[:success] = "アルバムを登録しました"
-      redirect_to profile_albums_path(@profile)
+      redirect_to profile_albums_path(@album.profile_id)
     else
       flash[:danger] = "登録に失敗しました"
       render :new, status: :unprocessable_entity

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: [profile, album], date: { turbo: false }) do |form| %>
+<%= form_with(model: [profile, album], data: { turbo: false }) do |form| %>
   <%= render 'shared/error_messages', model: form.object %>
 
   <%= form.label :date, "日付" %>

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_with(model: [profile, album], date: { turbo: false }) do |form| %>
+  <%= render 'shared/error_messages', model: form.object %>
+
+  <%= form.label :date, "日付" %>
+  <%= form.date_field :date %>
+
+  <%= form.label :title, "タイトル" %>
+  <%= form.text_field :title %>
+
+  <%= form.label :diary, "ノート" %>
+  <%= form.text_area :diary %>
+
+  <%= form.label :image, "写真" %>
+  <%= form.file_field :images, multiple: true %>
+
+  <%= form.submit "保存する" %>
+<% end %>

--- a/app/views/albums/edit.html.erb
+++ b/app/views/albums/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form', profile: @profile, album: @album %>

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -19,6 +19,9 @@
         <%= link_to profile_album_path(@profile, album) do %>
           <button class="btn bg-slate-300 text-black border-none shadow-2xl">詳細</button>
         <% end %>
+        <%= link_to edit_profile_album_path(@profile, album) do %>
+          <button class="btn bg-slate-300 text-black border-none shadow-2xl">編集</button>
+        <% end %>
         <%= link_to profile_album_path(@profile, album), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
           <button class="btn bg-slate-300 text-black border-none shadow-2xl">削除</button>
         <% end %>

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -1,0 +1,25 @@
+<table class="table bg-white text-black text-center mt-2">
+  <tr>
+    <th>日付</th>
+    <th>タイトル</th>
+    <th>写真</th>
+  </tr>
+  <% @albums.each do |album| %>
+    <tr>
+      <td><%= album.date %></td>
+      <td><%= album.title %></td>
+      <td>
+        <% if album.images.attached? %>
+          <% album.images.each do |image| %>
+            <%= image_tag image %>
+          <% end %>
+        <% end %>
+      </td>
+      <td>
+        <%= link_to profile_album_path(@profile, album) do %>
+          <button class="btn bg-slate-300 text-black border-none shadow-2xl">詳細</button>
+        <% end %>
+      </td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -19,6 +19,9 @@
         <%= link_to profile_album_path(@profile, album) do %>
           <button class="btn bg-slate-300 text-black border-none shadow-2xl">詳細</button>
         <% end %>
+        <%= link_to profile_album_path(@profile, album), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
+          <button class="btn bg-slate-300 text-black border-none shadow-2xl">削除</button>
+        <% end %>
       </td>
     </tr>
   <% end %>

--- a/app/views/albums/new.html.erb
+++ b/app/views/albums/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form', profile: @profile, album: @album %>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -1,0 +1,12 @@
+<%= @album.title %>
+<%= @album.date %>
+<%= @album.diary %>
+<% @album.images.each do |image| %>
+  <%= image_tag image %>
+<% end %>
+<%= link_to edit_profile_album_path(@profile, @album) do %>
+  <button class="btn bg-slate-300 text-black border-none shadow-2xl">編集</button>
+<% end %>
+<%= link_to profile_album_path(@profile, @album), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
+  <button class="btn bg-slate-300 text-black border-none shadow-2xl">削除</button>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
         patch :update_all
       end
     end
+    resources :albums
   end
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'


### PR DESCRIPTION
### 概要
連絡先ごとに、アルバムを作成でき、アルバムには、画像と文章を保存できるように実装する

---
### 背景・目的
アルバム作成機能の実装

---
### 内容
- [x] アルバムのCRUD機能を実装する
- [x] アルバム作成・編集フォーム
  - 日付
  - タイトル
  - ノート
  - 写真
  - 保存ボタン（表示文「保存する」）
- [x] アルバム一覧に表示する項目は以下の通り（作成日が新しいものが一番上になるように）
  - 日付
  - タイトル
  - 写真
  - 編集ボタン
  - 詳細ボタン
  - 削除ボタン
- [x] アルバム詳細に表示する項目は以下の通り
  - 日付
  - タイトル
  - 写真
  - 編集ボタン
  - 削除ボタン
- [x] 作成・更新・削除成功後は、アルバム一覧ページに遷移する
- [x] 削除ボタンを押下時には、「本当に削除しますか？」という確認メッセージを表示する
- [x] 「保存」ボタン押下後は、「保存しました」というメッセージを表示する
---
### 関連Issue
This PR close #26 
---
### 補足
