### PR TITLE
CIのRSpecを削除し、一旦Rubocopのみにする

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -7,57 +7,57 @@
 name: "auto test and deploy"
 on: push
 jobs:
-  rspec:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    services:
-      mysql:
-        image: mysql:8.0
-        ports:
-          - 3306:3306
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-        options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 10
+  # rspec:
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 10
+  #   services:
+  #     mysql:
+  #       image: mysql:8.0
+  #       ports:
+  #         - 3306:3306
+  #       env:
+  #         MYSQL_ALLOW_EMPTY_PASSWORD: yes
+  #       options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 10
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
+  #     - name: Set up Ruby
+  #       uses: ruby/setup-ruby@v1
+  #       with:
+  #         bundler-cache: true
 
-      - name: Cache node modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+  #     - name: Cache node modules
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: node_modules
+  #         key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-node-
 
-      - name: Bundler and gem install
-        run: |
-          gem install bundler
-          bundle install --jobs 4 --retry 3 --path vendor/bundle
+  #     - name: Bundler and gem install
+  #       run: |
+  #         gem install bundler
+  #         bundle install --jobs 4 --retry 3 --path vendor/bundle
 
-      - name: Set environment variables
-        run: |
-          echo "OPENAI_ACCESS_TOKEN=${{ secrets.OPENAI_ACCESS_TOKEN }}" >> $GITHUB_ENV
-          echo "LINE_CHANNEL_ID_LOGIN=${{ secrets.LINE_CHANNEL_ID_LOGIN }}" >> $GITHUB_ENV
-          echo "LINE_CHANNEL_SECRET_LOGIN=${{ secrets.LINE_CHANNEL_SECRET_LOGIN }}" >> $GITHUB_ENV
+  #     - name: Set environment variables
+  #       run: |
+  #         echo "OPENAI_ACCESS_TOKEN=${{ secrets.OPENAI_ACCESS_TOKEN }}" >> $GITHUB_ENV
+  #         echo "LINE_CHANNEL_ID_LOGIN=${{ secrets.LINE_CHANNEL_ID_LOGIN }}" >> $GITHUB_ENV
+  #         echo "LINE_CHANNEL_SECRET_LOGIN=${{ secrets.LINE_CHANNEL_SECRET_LOGIN }}" >> $GITHUB_ENV
 
-      - name: Yarn install
-        run: yarn install --check-files
+  #     - name: Yarn install
+  #       run: yarn install --check-files
 
-      - name: Database create and migrate
-        run: |
-          cp config/database.yml.ci config/database.yml
-          bundle exec rails db:create RAILS_ENV=test
-          bundle exec rails db:migrate RAILS_ENV=test
+  #     - name: Database create and migrate
+  #       run: |
+  #         cp config/database.yml.ci config/database.yml
+  #         bundle exec rails db:create RAILS_ENV=test
+  #         bundle exec rails db:migrate RAILS_ENV=test
 
-      - name: Run rspec
-        run: bundle exec rspec
+  #     - name: Run rspec
+  #       run: bundle exec rspec
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### 概要
CIのRSpecを削除し、一旦Rubocopのみにする

---
### 背景・目的
RSpecのシステムテストでエラーが起きるため、一旦削除し、別イシューでエラーの対応を実施する

---

### 内容
- [x] .github/workflows/rubyonrails.ymlからRSpecのジョブを削除

---
### 対応しないこと
- [ ] 

---
### 補足
This PR close #174 