### PR TITLE
保存されいているalbum imagesを、編集画面に表示し、各画像ごとに削除ボタンを設置する

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,0 +1,6 @@
+class ImagesController < ApplicationController
+  def destroy
+    image = ActiveStorage::Attachment.find(params[:id])
+    image.purge
+  end
+end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,6 +1,6 @@
 class ImagesController < ApplicationController
   def destroy
-    image = ActiveStorage::Attachment.find(params[:id])
-    image.purge
+    @image = ActiveStorage::Attachment.find(params[:id])
+    @image.purge
   end
 end

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -10,14 +10,15 @@
   <%= form.label :diary, "ノート" %>
   <%= form.text_area :diary %>
 
-  <% if album.images.attached? %>
-    <% album.images.each do |image| %>
-      <%= image_tag image, id: "#{dom_id(album)}-#{image.id}" %>
-    <% end %>
-  <% end %>
-
   <%= form.label :image, "写真" %>
   <%= form.file_field :images, multiple: true %>
 
   <%= form.submit "保存する" %>
+<% end %>
+
+<% if album.images.attached? %>
+  <% album.images.each do |image| %>
+    <%= image_tag image, id: "#{dom_id(album)}-#{image.id}" %>
+    <%= link_to "削除", image_path(image), data: { turbo_method: :delete } %>
+  <% end %>
 <% end %>

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -12,7 +12,7 @@
 
   <% if album.images.attached? %>
     <% album.images.each do |image| %>
-      <%= image_tag image %>
+      <%= image_tag image, id: "#{dom_id(album)}-#{image.id}" %>
     <% end %>
   <% end %>
 

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -10,6 +10,12 @@
   <%= form.label :diary, "ノート" %>
   <%= form.text_area :diary %>
 
+  <% if album.images.attached? %>
+    <% album.images.each do |image| %>
+      <%= image_tag image %>
+    <% end %>
+  <% end %>
+
   <%= form.label :image, "写真" %>
   <%= form.file_field :images, multiple: true %>
 

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -18,7 +18,9 @@
 
 <% if album.images.attached? %>
   <% album.images.each do |image| %>
-    <%= image_tag image, id: "#{dom_id(album)}-#{image.id}" %>
-    <%= link_to "削除", image_path(image), data: { turbo_method: :delete } %>
+    <div id="<%= "#{dom_id(album)}-#{image.id}" %>">
+      <%= image_tag image %>
+      <%= link_to "削除", image_path(image), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/images/destroy.turbo_stream.erb
+++ b/app/views/images/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove "album_#{@image.record_id}-#{@image.id}" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,4 +24,6 @@ Rails.application.routes.draw do
 post "oauth/callback" => "oauths#callback"
 get "oauth/callback" => "oauths#callback" # for use with Github, Facebook
 get "oauth/:provider" => "oauths#oauth", :as => :auth_at_provider
+
+  resources :images, only: [:destroy]
 end


### PR DESCRIPTION
### 概要
保存されいているalbum imagesを、編集画面に表示し、各画像ごとに削除ボタンを設置する

---
### 背景・目的
現在の実装だと、一度アップロードした画像を削除する方法がないため、
album編集画面で削除できるようにしたい

---
### 内容
- [x] album編集画面で、保存済みの画像を表示
- [x] 各保存済み画像に対し、削除ボタンを設置
- [x] 画像を非同期で削除するルーティングを設定
- [x] 非同期でDBから画像を削除する
- [x] DBから画像を削除したら、編集画面から、削除した画像を除く

---
### 対応しないこと
- [ ] 

---
### 補足
This PR close #182 