### PR TITLE
バケット名にRails.env（環境名）を含めることで、データ喪失リスクを軽減する

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -12,7 +12,7 @@ amazon:
   access_key_id: <%= ENV.fetch("AWS_ACCESS_KEY_ID") %>
   secret_access_key: <%= ENV.fetch("AWS_SECRET_ACCESS_KEY") %>
   region: us-east-1
-  bucket: <%= ENV.fetch("AWS_BUCKET_NAME") %>
+  bucket: <%= ENV.fetch("AWS_BUCKET_NAME") + "-#{Rails.env}" %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
### 概要
バケット名にRails.env（環境名）を含める

---
### 背景・目的
データ喪失リスクを軽減する

---

### 内容
- [x] AWS S3のバケットを、開発用と本番用に分ける
  - 開発用　runteq-portfolio-development
  - 本番用　runteq-portfolio-production
- [x] config/storage.ymlのamazonS3の設定で、bucket nameを環境に合わせて動的に設定する

---
### 対応しないこと
- [ ] 

---
### 補足
This PR close #187 