### PR TITLE
アップロード選択した画像を表示する

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,6 @@ application.register("clipboard", ClipboardController)
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import PreviewsController from "./previews_controller"
+application.register("previews", PreviewsController)

--- a/app/javascript/controllers/previews_controller.js
+++ b/app/javascript/controllers/previews_controller.js
@@ -2,23 +2,31 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="previews"
 export default class extends Controller {
-  static targets = ["input", "preview"]
-  connect() {
-  }
+  static targets = ["input", "previewContainer"]
+
   preview() {
     let input = this.inputTarget;
-    let preview = this.previewTarget;
-    let file = input.files[0];
-    let reader = new FileReader();
+    let previewContainer = this.previewContainerTarget;
 
-    reader.onloadend = function(){
-      preview.src = reader.result;
-    };
+    // プレビューコンテナをクリア
+    previewContainer.innerHTML = "";
 
-    if(file) {
-      reader.readAsDataURL(file);
-    } else {
-      preview.src = "";
-    }
+    // すべてのファイルをループで処理
+    Array.from(input.files).forEach(file => {
+      let reader = new FileReader();
+
+      reader.onloadend = function() {
+        // 新しい画像要素を作成してプレビューコンテナに追加
+        let img = document.createElement("img");
+        img.src = reader.result;
+        img.style.width = "100px";
+        // img.style.marginRight = "10px";
+        previewContainer.appendChild(img);
+      };
+
+      if(file) {
+        reader.readAsDataURL(file);
+      }
+    });
   }
 }

--- a/app/javascript/controllers/previews_controller.js
+++ b/app/javascript/controllers/previews_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="previews"
+export default class extends Controller {
+  static targets = ["input", "preview"]
+  connect() {
+  }
+  preview() {
+    let input = this.inputTarget;
+    let preview = this.previewTarget;
+    let file = input.files[0];
+    let reader = new FileReader();
+
+    reader.onloadend = function(){
+      preview.src = reader.result;
+    };
+
+    if(file) {
+      reader.readAsDataURL(file);
+    } else {
+      preview.src = "";
+    }
+  }
+}

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -24,8 +24,6 @@
         <%= link_to "削除", image_path(image), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
       </div>
     <% end %>
-    <%= image_tag "", data: { previews_target: "preview" } %>
-  <% else %>
-    <%= image_tag "", data: { previews_target: "preview" } %>
   <% end %>
+  <div data-previews-target="previewContainer"></div>
 </div>

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -1,26 +1,31 @@
-<%= form_with(model: [profile, album], data: { turbo: false }) do |form| %>
-  <%= render 'shared/error_messages', model: form.object %>
+<div data-controller="previews">
+  <%= form_with(model: [profile, album], data: { turbo: false }) do |form| %>
+    <%= render 'shared/error_messages', model: form.object %>
 
-  <%= form.label :date, "日付" %>
-  <%= form.date_field :date %>
+    <%= form.label :date, "日付" %>
+    <%= form.date_field :date %>
 
-  <%= form.label :title, "タイトル" %>
-  <%= form.text_field :title %>
+    <%= form.label :title, "タイトル" %>
+    <%= form.text_field :title %>
 
-  <%= form.label :diary, "ノート" %>
-  <%= form.text_area :diary %>
+    <%= form.label :diary, "ノート" %>
+    <%= form.text_area :diary %>
 
-  <%= form.label :image, "写真" %>
-  <%= form.file_field :images, multiple: true %>
+    <%= form.label :image, "写真" %>
+    <%= form.file_field :images, multiple: true, data: { previews_target: "input", action: "change->previews#preview" } %>
 
-  <%= form.submit "保存する" %>
-<% end %>
-
-<% if album.images.attached? %>
-  <% album.images.each do |image| %>
-    <div id="<%= "#{dom_id(album)}-#{image.id}" %>">
-      <%= image_tag image %>
-      <%= link_to "削除", image_path(image), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
-    </div>
+    <%= form.submit "保存する" %>
   <% end %>
-<% end %>
+
+  <% if album.images.attached? %>
+    <% album.images.each do |image| %>
+      <div id="<%= "#{dom_id(album)}-#{image.id}" %>">
+        <%= image_tag image %>
+        <%= link_to "削除", image_path(image), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
+      </div>
+    <% end %>
+    <%= image_tag "", data: { previews_target: "preview" } %>
+  <% else %>
+    <%= image_tag "", data: { previews_target: "preview" } %>
+  <% end %>
+</div>


### PR DESCRIPTION
### 概要
保存したいアルバム画像のファイルを選択すると、画像のプレビューを表示させる

---
### 背景・目的
どのような画像を選んだか、分かりやすくするため

---
### 内容
- [x] 複数選択された画像を、プレビューで表示させる
[![Image from Gyazo](https://i.gyazo.com/19b8453c038efa98237361f1b45fca49.png)](https://gyazo.com/19b8453c038efa98237361f1b45fca49)
---
### 対応しないこと
- [ ] 

---
### 補足
This PR close #190 