### PR TITLE
Feature/#177 resize images

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,7 +9,7 @@ RUN apt-get update -qq \
 && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
 && wget --quiet -O - /tmp/pubkey.gpg https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update -qq && apt-get install -y build-essential libssl-dev nodejs yarn vim
+RUN apt-get update -qq && apt-get install -y build-essential libssl-dev nodejs yarn vim libvips imagemagick
 RUN mkdir /myapp
 WORKDIR /myapp
 RUN gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.2"
 
 # To use OpenAI API
 gem "ruby-openai"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,11 +141,20 @@ GEM
       multipart-post (~> 2)
     faraday-net_http (3.1.0)
       net-http
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    image_processing (1.13.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.7.2)
     irb (1.14.0)
       rdoc (>= 4.0.0)
@@ -173,6 +182,7 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.24.1)
     msgpack (1.7.2)
@@ -322,6 +332,9 @@ GEM
       faraday (>= 1)
       faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.2)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.3.2)
     selenium-webdriver (4.22.0)
       base64 (~> 0.2)
@@ -393,6 +406,7 @@ DEPENDENCIES
   debug
   dotenv
   factory_bot_rails
+  image_processing (~> 1.2)
   jbuilder
   jsbundling-rails
   line-bot-api

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -20,7 +20,7 @@
   <% if album.images.attached? %>
     <% album.images.each do |image| %>
       <div id="<%= "#{dom_id(album)}-#{image.id}" %>">
-        <%= image_tag image %>
+        <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
         <%= link_to "削除", image_path(image), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
       </div>
     <% end %>

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -11,7 +11,7 @@
       <td>
         <% if album.images.attached? %>
           <% album.images.each do |image| %>
-            <%= image_tag image %>
+            <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
           <% end %>
         <% end %>
       </td>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -2,7 +2,7 @@
 <%= @album.date %>
 <%= @album.diary %>
 <% @album.images.each do |image| %>
-  <%= image_tag image %>
+  <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
 <% end %>
 <%= link_to edit_profile_album_path(@profile, @album) do %>
   <button class="btn bg-slate-300 text-black border-none shadow-2xl">編集</button>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -58,7 +58,7 @@
         <tr class="border-b border-white">
           <% if @profile.avatar.attached? %>
             <td class="px-4 py-2 border-r border-white font-bold">プロフィール画像</td>
-            <td class="px-4 py-2 border-white"><%= image_tag @profile.avatar %></td>
+            <td class="px-4 py-2 border-white"><%= image_tag @profile.avatar.variant(resize_to_limit: [100, 100]) %></td>
           <% end %>
         </tr>
       </tbody>


### PR DESCRIPTION
### 概要
表示する画像をリサイズする

---
### 背景・目的
画像の大きさを調整し、ページのデザインを整えるため

---
### 内容
- [x] image_processingをインストール
- [x] コンテナ内に、libvipsとimagemagickをインストール（Dockerfile.devのスクリプトを変更)
- [x] avatar画像をリサイズ（100 x 100）
- [x] images画像をリサイズ（100 x 100）

---
### 対応しないこと
- デザインissueにて、画像の大きさは再度修正する

---
### 補足
This PR close #177 