### PR TITLE
画像アップロードのバリデーションを設定する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,9 @@ gem 'config'
 # Amazon S3
 gem 'aws-sdk-s3'
 
+# file validation
+gem 'active_storage_validations'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,11 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_storage_validations (1.1.4)
+      activejob (>= 5.2.0)
+      activemodel (>= 5.2.0)
+      activestorage (>= 5.2.0)
+      activesupport (>= 5.2.0)
     activejob (7.1.3.4)
       activesupport (= 7.1.3.4)
       globalid (>= 0.3.6)
@@ -410,6 +415,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_storage_validations
   aws-sdk-s3
   bootsnap
   capybara

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -2,4 +2,9 @@ class Album < ApplicationRecord
   belongs_to :profile
 
   has_many_attached :images
+
+  validates :images, processable_image: true,
+                     content_type: %i[png jpeg],
+                     size: { less_than: 5.megabytes , message: 'is too large' },
+                     limit: { max: 3 }
 end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -5,6 +5,6 @@ class Album < ApplicationRecord
 
   validates :images, processable_image: true,
                      content_type: %i[png jpeg],
-                     size: { less_than: 5.megabytes , message: 'is too large' },
+                     size: { less_than: 5.megabytes, message: "is too large" },
                      limit: { max: 3 }
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -12,6 +12,6 @@ class Profile < ApplicationRecord
 
   validates :avatar, processable_image: true,
                      content_type: %i[png jpeg],
-                     size: { less_than: 1.megabytes , message: 'is too large' },
+                     size: { less_than: 1.megabytes, message: "is too large" },
                      limit: { max: 1 }
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -9,4 +9,9 @@ class Profile < ApplicationRecord
   accepts_nested_attributes_for :events
 
   has_one_attached :avatar
+
+  validates :avatar, processable_image: true,
+                     content_type: %i[png jpeg],
+                     size: { less_than: 1.megabytes , message: 'is too large' },
+                     limit: { max: 1 }
 end


### PR DESCRIPTION
### 概要
画像アップロードのバリデーションを設定する

---
### 背景・目的
- 大量の画像がアップロードされることで、ストレージ容量を消費することを防ぐ
- 画像のみアップロードできるようにする

---
### 内容
- [x] ファイル形式の制限（png, jpeg）
- [x] １枚当たりのファイルサイズの制限
  - [x] avatar 最大1MB
  - [x] image 最大 5MB
- [x] 登録できる画像枚数の制限（３枚まで）
  - [x] avatar 最大１枚
  - [x] images　最大３枚
---
### 対応しないこと
- 

---
### 補足
サイズオーバーの場合は、圧縮する処理を別イシューで実装する

This PR close #193 