### PR TITLE
imagesがバリデーションエラーでアップロード失敗した場合、再度new.html.erbをレンダリングした際、DBに登録されていないal…

### DIFF
--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -17,7 +17,7 @@
     <%= form.submit "保存する" %>
   <% end %>
 
-  <% if album.images.attached? %>
+  <% if album.images.attached? && album.persisted? %>
     <% album.images.each do |image| %>
       <div id="<%= "#{dom_id(album)}-#{image.id}" %>">
         <%= image_tag image.variant(resize_to_limit: [100, 100]) %>


### PR DESCRIPTION
### 概要
album画像を複数投稿した際のエラー対処

---
### 背景・目的

- gemを使って、３枚までアップロードするようにバリデーションを設定
```
class Album < ApplicationRecord
  belongs_to :profile

  has_many_attached :images

  validates :images, processable_image: true,
                     content_type: %i[png jpeg],
                     size: { less_than: 5.megabytes, message: "is too large" },
                     limit: { max: 3 }
end

```

‐ ４枚以上アップロードしようとすると、バリデーションで弾かれた後、再度new.htmlをレンダリングし、エラーが起きる
```
Started POST "/profiles/32/albums" for 192.168.208.1 at 2024-08-28 12:51:34 +0900
Cannot render console from 192.168.208.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
Processing by AlbumsController#create as HTML
  Parameters: {"authenticity_token"=>"[FILTERED]", "album"=>{"date"=>"", "title"=>"", "diary"=>"", "images"=>["", #<ActionDispatch::Http::UploadedFile:0x00007f62e14479b0 @tempfile=#<Tempfile:/tmp/RackMultipart20240828-15-9exxnz.png>, @content_type="image/png", @original_filename="50f2261e4e3a97bf5a5f58af5ec2f845.png", @headers="Content-Disposition: form-data; name=\"album[images][]\"; filename=\"50f2261e4e3a97bf5a5f58af5ec2f845.png\"\r\nContent-Type: image/png\r\n">, #<ActionDispatch::Http::UploadedFile:0x00007f62e1447960 @tempfile=#<Tempfile:/tmp/RackMultipart20240828-15-f31cgf.jpg>, @content_type="image/jpeg", @original_filename="965aecc908fb8b7c6b84421e6dd1cfa7.jpg", @headers="Content-Disposition: form-data; name=\"album[images][]\"; filename=\"965aecc908fb8b7c6b84421e6dd1cfa7.jpg\"\r\nContent-Type: image/jpeg\r\n">, #<ActionDispatch::Http::UploadedFile:0x00007f62e1447910 @tempfile=#<Tempfile:/tmp/RackMultipart20240828-15-r6me51.jpg>, @content_type="image/jpeg", @original_filename="00000003200003_A01.jpg", @headers="Content-Disposition: form-data; name=\"album[images][]\"; filename=\"00000003200003_A01.jpg\"\r\nContent-Type: image/jpeg\r\n">, #<ActionDispatch::Http::UploadedFile:0x00007f62e14478c0 @tempfile=#<Tempfile:/tmp/RackMultipart20240828-15-82mo0p.png>, @content_type="image/png", @original_filename="b0afc11b539c6867e89d6765bbfb65c4.png", @headers="Content-Disposition: form-data; name=\"album[images][]\"; filename=\"b0afc11b539c6867e89d6765bbfb65c4.png\"\r\nContent-Type: image/png\r\n">]}, "commit"=>"保存する", "profile_id"=>"32"}
  User Load (0.8ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` = 16 LIMIT 1
  Profile Load (1.2ms)  SELECT `profiles`.* FROM `profiles` WHERE `profiles`.`user_id` = 16 AND `profiles`.`id` = 32 LIMIT 1
  ↳ app/controllers/albums_controller.rb:53:in `set_profile'
  Rendering layout layouts/application.html.erb
  Rendering albums/new.html.erb within layouts/application
  Rendered shared/_error_messages.html.erb (Duration: 0.7ms | Allocations: 317)
  Rendered albums/_form.html.erb (Duration: 7.2ms | Allocations: 2306)
  Rendered albums/new.html.erb within layouts/application (Duration: 7.6ms | Allocations: 2369)
  Rendered layout layouts/application.html.erb (Duration: 7.9ms | Allocations: 2460)
Completed 500 Internal Server Error in 155ms (ActiveRecord: 2.1ms | Allocations: 9173)

ActionView::Template::Error (Cannot get a signed_id for a new record):
    20:   <% if album.images.attached? %>
    21:     <% album.images.each do |image| %>
    22:       <div id="<%= "#{dom_id(album)}-#{image.id}" %>">
    23:         <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
    24:         <%= link_to "削除", image_path(image), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
    25:       </div>
    26:     <% end %>

app/views/albums/_form.html.erb:23
app/views/albums/_form.html.erb:21
app/views/albums/new.html.erb:1
app/controllers/albums_controller.rb:23:in `create'

```
---

### 解決方法
原因

1. saveメソッドが呼ばれると、ActiveStorageのattachmentにレコードがつくられる（例え、saveに失敗しても）
    
    ```ruby
      def create
        @album = @profile.albums.new(album_params)
    
        if @album.save
          flash[:success] = "アルバムを登録しました"
          redirect_to profile_albums_path(@album.profile_id)
        else
          flash[:danger] = "登録に失敗しました"
          render :new, status: :unprocessable_entity
        end
      end
    ```
    
2. しかし、saveは失敗するため、albumのレコードはDBに登録されない
3. render :newで再度フォームが表示される
    
    ```ruby
    フォーム省略
    ...
      <% if album.images.attached? %>
        <% album.images.each do |image| %>
          <div id="<%= "#{dom_id(album)}-#{image.id}" %>">
            <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
            <%= link_to "削除", image_path(image), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
          </div>
        <% end %>
      <% end %>
    ```
    
4. `album.images.attached?`はtrueになるが、`image_tag`や`image.variant`は、albumから呼び出されるが、このalbumはまだDBに保存されていないので、signed_idが付与されておらずエラーが起きた

対策

- albumレコードが存在するかどうかチェックする処理を追加
    
    ```ruby
    <% if album.images.attached? && album.persisted? %>
    ```

---
### 対応しないこと
- 

---
### 補足