### PR TITLE
Feature/#24 search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,9 @@ gem 'aws-sdk-s3'
 # file validation
 gem 'active_storage_validations'
 
+# search
+gem 'ransack'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,6 +302,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    ransack (4.2.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -434,6 +438,7 @@ DEPENDENCIES
   pry-rails
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
+  ransack
   rspec-rails
   rubocop
   rubocop-rails

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -10,7 +10,9 @@ class ProfilesController < ApplicationController
   end
 
   def index
-    @profiles = current_user.profiles.includes(:events).order(created_at: :desc)
+    @q = current_user.profiles.ransack(params[:q])
+    @q.combinator = "or"
+    @profiles = @q.result(distinct: true).includes(:events).order(created_at: :desc)
   end
 
   def create

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -14,4 +14,8 @@ class Profile < ApplicationRecord
                      content_type: %i[png jpeg],
                      size: { less_than: 1.megabytes, message: "is too large" },
                      limit: { max: 1 }
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["address", "birthplace", "created_at", "email", "furigana", "id", "id_value", "line_name", "name", "occupation", "phone", "updated_at", "user_id"]
+  end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -15,7 +15,7 @@ class Profile < ApplicationRecord
                      size: { less_than: 1.megabytes, message: "is too large" },
                      limit: { max: 1 }
 
-  def self.ransackable_attributes(auth_object = nil)
-    ["address", "birthplace", "created_at", "email", "furigana", "id", "id_value", "line_name", "name", "occupation", "phone", "updated_at", "user_id"]
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[name furigana line_name]
   end
 end

--- a/app/views/profiles/_search.html.erb
+++ b/app/views/profiles/_search.html.erb
@@ -1,0 +1,6 @@
+<%= search_form_for q, url: url do |f| %>
+  <%= f.search_field :name_cont, placeholder: "名前" %>
+  <%= f.search_field :furigana_cont, placeholder: "ふりがな" %>
+  <%= f.search_field :line_name_cont, placeholder: "LINE名" %>
+  <%= f.submit "検索" %>
+<% end %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -1,3 +1,5 @@
+<%= render "profiles/search", q: @q, url: profiles_path %>
+
 <div class="pt-16">
   <h1 class="text-2xl text-white pt-10 pl-48">れんらく帳</h1>
   <div class="flex justify-end pt-2 pr-48">


### PR DESCRIPTION
### 概要
登録した連絡先を、複数の条件できるようにする

---
### 背景
多数の連絡先が登録された場合、ユーザーが連絡先を探すのが大変になる為

---
### 内容
- [x] 検索対象は以下の通りとする
  - profiles
    - name
    - furigana
    - line_name

- [x] あいまい検索ができるようにする
- [x] 各カラムのOR検索とする（デフォルトはANDになっている）

---
### 補足
This PR close #24 