### PR TITLE
AIによるメッセージ提案（パンくずリスト）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,9 @@ gem 'active_storage_validations'
 # search
 gem 'ransack'
 
+#breadcrumbs
+gem 'gretel'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,9 @@ GEM
     ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gretel (5.0.1)
+      actionview (>= 6.1)
+      railties (>= 6.1)
     hashie (5.0.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
@@ -428,6 +431,7 @@ DEPENDENCIES
   debug
   dotenv
   factory_bot_rails
+  gretel
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails

--- a/app/controllers/openai_api_controller.rb
+++ b/app/controllers/openai_api_controller.rb
@@ -6,7 +6,7 @@ class OpenaiApiController < ApplicationController
     ai_suggest_service = AiSuggestionService.new(@client, session)
 
     @message = ai_suggest_service.suggest
-    @last_question = Question.find_by(number: "3")
+    @last_question = Question.order(number: :desc).first
   end
 
   private

--- a/app/controllers/openai_api_controller.rb
+++ b/app/controllers/openai_api_controller.rb
@@ -6,6 +6,7 @@ class OpenaiApiController < ApplicationController
     ai_suggest_service = AiSuggestionService.new(@client, session)
 
     @message = ai_suggest_service.suggest
+    @last_question = Question.find_by(number: "3")
   end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
     <%= render 'shared/flash_message' %>
     <main class="flex-grow">
       <%= yield %>
+      <%= breadcrumbs separator: "&rsaquo;" %>
     </main>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/openai_api/show.html.erb
+++ b/app/views/openai_api/show.html.erb
@@ -26,3 +26,4 @@
     <button>連絡帳へ</button>
   <% end %>
 </div>
+<% breadcrumb :ai_message, @last_question %>

--- a/app/views/questions/_question_multiple_choice.html.erb
+++ b/app/views/questions/_question_multiple_choice.html.erb
@@ -1,0 +1,17 @@
+<%= form_with url: answers_path, method: :post, data: { turbo: false }, id: 'ai_questions' do |form| %>
+  <div class="flex flex-col text-center mb-5 text-2xl text-white">
+    <h1><%= question.text %></h1>
+    <h2 class="text-base mt-2">※複数選択可</h2>
+  </div>
+  <% @answers.each do |answer| %>
+    <div class="flex items-center mb-2 text-white text-xl gap-2">
+      <%= form.check_box "answer[question#{question.number}]", { multiple: true }, answer.value, nil %>
+      <%= form.label "answer[question#{question.number}]_#{answer.value}", answer.text %>
+    </div>
+  <% end %>
+  <div class="w-full flex justify-center">
+    <%= form.submit '次へ', class:"btn bg-white rounded-md text-black border-none shadow-2xl hover:bg-white" %>
+  </div>
+<% end %>
+
+<% breadcrumb :question_2, question %>

--- a/app/views/questions/_question_single_choice.html.erb
+++ b/app/views/questions/_question_single_choice.html.erb
@@ -1,0 +1,20 @@
+<%= form_with url: answers_path, method: :post, data: { turbo: false }, id: 'ai_questions' do |form| %>
+  <div class="text-center mb-5 text-2xl text-white">
+    <%= question.text %>
+  </div>
+  <% @answers.each do |answer| %>
+    <div class="flex items-center mb-2 text-white text-xl gap-2">
+      <%= form.radio_button "answer[question#{question.number}]", answer.value, required: :true %>
+      <%= form.label "answer[question#{question.number}]_#{answer.value}", answer.text %>
+    </div>
+  <% end %>
+  <div class="w-full flex justify-center">
+    <%= form.submit '次へ', class:"btn bg-white rounded-md text-black border-none shadow-2xl hover:bg-white" %>
+  </div>
+<% end %>
+
+<% if question.number == 1 %>
+  <% breadcrumb :question_1, question %>
+<% else %>
+  <% breadcrumb :question_3, question %>
+<% end %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,36 +1,10 @@
 <div class="flex items-center justify-center min-h-screen">
   <div class="border-white border-2 rounded-md p-10">
-
     <div class="flex items-center justify-center">
-      <%= form_with url: answers_path, method: :post, data: { turbo: false }, id: 'ai_questions' do |form| %>
-        <% if @question.number.to_i == Settings.question_type.multiple_choice %>
-          <div class="flex flex-col text-center mb-5 text-2xl text-white">
-            <h1><%= @question.text %></h1>
-            <h2 class="text-base mt-2">※複数選択可</h2>
-          </div>
-          <% @answers.each do |answer| %>
-            <div class="flex items-center mb-2 text-white text-xl gap-2">
-              <%= form.check_box "answer[question#{@question.number}]", { multiple: true }, answer.value, nil %>
-              <%= form.label "answer[question#{@question.number}]_#{answer.value}", answer.text %>
-            </div>
-          <% end %>
-          <div class="w-full flex justify-center">
-            <%= form.submit '次へ', class:"btn bg-white rounded-md text-black border-none shadow-2xl hover:bg-white" %>
-          </div>
-        <% else %>
-          <div class="text-center mb-5 text-2xl text-white">
-            <%= @question.text %>
-          </div>
-          <% @answers.each do |answer| %>
-            <div class="flex items-center mb-2 text-white text-xl gap-2">
-              <%= form.radio_button "answer[question#{@question.number}]", answer.value, required: :true %>
-              <%= form.label "answer[question#{@question.number}]_#{answer.value}", answer.text %>
-            </div>
-          <% end %>
-          <div class="w-full flex justify-center">
-            <%= form.submit '次へ', class:"btn bg-white rounded-md text-black border-none shadow-2xl hover:bg-white" %>
-          </div>
-        <% end %>
+      <% if @question.number.to_i == Settings.question_type.multiple_choice %>
+        <%= render "question_multiple_choice", question: @question %>
+      <% else %>
+        <%= render "question_single_choice", question: @question %>
       <% end %>
     </div>
   </div>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,25 @@
+crumb :root do
+  link "Top", root_path
+end
+
+crumb :question_1 do |question|
+  link "質問#{question.number}", question_path(question.number)
+  parent :root
+end
+
+crumb :question_2 do |question|
+  parent_question = Question.find_by(number: question.number - 1)
+  link "質問#{question.number}", question_path(question.number)
+  parent :question_1, parent_question
+end
+
+crumb :question_3 do |question|
+  parent_question = Question.find_by(number: question.number - 1)
+  link "質問#{question.number}", question_path(question.number)
+  parent :question_2, parent_question
+end
+
+crumb :ai_message do |question|
+  link "AI提案文", ai_message_path
+  parent :question_3, question
+end


### PR DESCRIPTION
### 概要
AI質問画面に、パンくずリストを表示する

---
### 背景
質問に回答するユーザーの現在地を表示することで、離脱を防ぎたいため

---
### 内容
- [x] AI質問と、AI提案文ページに、パンくずリストを表示する（introduction_1, introduction_2のビューファイルには表示しない）

This PR close #7 