### PR TITLE
ログイン後、元のページに遷移する

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -11,7 +11,7 @@ class OauthsController < ApplicationController
   def callback
     provider = auth_params[:provider]
     if (@user = login_from(provider))
-      redirect_to root_path, notice: "Logged in from #{provider.titleize}!"
+      redirect_back_or_to root_path, notice: "Logged in from #{provider.titleize}!"
     else
       new_user_login(provider)
     end
@@ -28,7 +28,7 @@ class OauthsController < ApplicationController
     # NOTE: this is the place to add '@user.activate!' if you are using user_activation submodule
     reset_session # protect from session fixation attack
     auto_login(@user)
-    redirect_to root_path, notice: "Logged in from #{provider.titleize}!"
+    redirect_back_or_to root_path, notice: "Logged in from #{provider.titleize}!"
   rescue StandardError
     redirect_to root_path, alert: "Failed to login from #{provider.titleize}!"
   end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -8,7 +8,7 @@ class UserSessionsController < ApplicationController
 
     if @user
       flash[:success] = "ログインしました"
-      redirect_to root_path
+      redirect_back_or_to root_path
     else
       flash.now[:danger] = "メールアドレスまたはパスワードが正しくありません"
       render :new, status: :unprocessable_entity


### PR DESCRIPTION
### 概要
ログイン後、元のページに遷移する

---
### 背景・目的
連絡帳機能はログインが必要となっており、ログイン後、スムーズに連絡帳の利用をしてもらうため

---
### 内容
- [x] ログイン後、元のページに遷移する（例：連絡帳リンク→ログイン成功→連絡帳ページ）

---
### 対応しないこと
- [ ] 

---
### 補足
This PR close #71 