### PR TITLE
LINEログイン時、LINE IDをUserテーブルのline_user_idに保存する

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -25,6 +25,7 @@ class OauthsController < ApplicationController
 
   def new_user_login(provider)
     @user = create_from(provider)
+    @user.update!(line_user_id: @user.email)
     # NOTE: this is the place to add '@user.activate!' if you are using user_activation submodule
     reset_session # protect from session fixation attack
     auto_login(@user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,6 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validates :name, presence: true, length: { maximum: 255 }
   validates :email, presence: true, uniqueness: true
-  validates :line_user_id, uniqueness: true, allow_blank: true
   validates :notification_enabled, presence: true
   validates :reset_password_token, presence: true, uniqueness: true, allow_nil: true
 

--- a/db/migrate/20240830023132_remove_index_from_users_line_user_id.rb
+++ b/db/migrate/20240830023132_remove_index_from_users_line_user_id.rb
@@ -1,0 +1,5 @@
+class RemoveIndexFromUsersLineUserId < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :users, :line_user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_27_014708) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_30_023132) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -137,7 +137,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_27_014708) do
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["line_user_id"], name: "index_users_on_line_user_id", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 


### PR DESCRIPTION
### 概要
LINEログイン時、LINE IDをUserテーブルのline_user_idに保存する

---
### 背景・目的
LINEログイン時、LINE IDは一度Userテーブルのemailカラムにマッピングする仕様になっている（emailのnull制約を優先するため）。
しかし、LINE通知などは、Userテーブルのline_user_idカラムを取得して行うため、このカラムにLINE IDをいれる必要がある。

---
### 内容
- [x] oauthコントローラーで、LINEログインで新規ユーザー登録がされる際、emailカラムに入ったLINE ID情報を、line_user_idカラムにも保存するようにする
- [x] line_user_idのユニーク制約を外す（メアド・パスワードで登録し、line idも取得できているユーザーが、新しくLINEログインする際に、新たに作られるuserレコードのline_user_idが重複するため）

---
### 対応しないこと
- 

---
### 補足
This PR close #201 