### PR TITLE
マイページ

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,9 +25,20 @@ class UsersController < ApplicationController
     @user = current_user
   end
 
+  def update
+    @user = current_user
+    if @user.update(user_params)
+      flash[:success] = "更新しました"
+      redirect_to user_path(@user)
+    else
+      flash[:danger] = "更新に失敗しました"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :notification_enabled)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
+  before_action :set_user, only: %i[show edit update]
 
   def new
     @user = User.new
@@ -17,16 +18,11 @@ class UsersController < ApplicationController
     end
   end
 
-  def show
-    @user = current_user
-  end
+  def show; end
 
-  def edit
-    @user = current_user
-  end
+  def edit; end
 
   def update
-    @user = current_user
     if @user.update(user_params)
       flash[:success] = "更新しました"
       redirect_to user_path(@user)
@@ -40,5 +36,9 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation, :notification_enabled)
+  end
+
+  def set_user
+    @user = current_user
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,6 +21,10 @@ class UsersController < ApplicationController
     @user = current_user
   end
 
+  def edit
+    @user = current_user
+  end
+
   private
 
   def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,10 @@ class UsersController < ApplicationController
     end
   end
 
+  def show
+    @user = current_user
+  end
+
   private
 
   def user_params

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,7 +6,7 @@
     <div class="font-bold space-x-8">
       <%= link_to "AIメッセージ作成", introduction_path(1) %>
       <%= link_to "連絡帳", profiles_path %>
-      <%# <%= link_to "カレンダー", '#' %>
+      <%= link_to "マイページ", user_path(current_user)  %>
       <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete } %>
     </div>
   </nav>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -2,9 +2,8 @@
   <%= f.label :name, "名前" %>
   <%= f.text_field :name %>
 
-  <%= f.label :notification_enabled, "LINE通知 ON" %>
-  <input type="hidden" name="user[notification_enabled]" value="off">
-  <input type="checkbox" name="user[notification_enabled]" id="user_notification_enabled" value="on" <%= "checked" if @user.notification_enabled == "on" %>>
+  <%= f.label :notification_enabled, "LINE通知" %>
+  <%= f.select :notification_enabled, [["ON", "on"], ["OFF", "off"]] %>
 
   <%= f.submit "更新" %>
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -3,10 +3,12 @@
   <%= f.text_field :name %>
 
   <%= f.label :notification_enabled, "LINE通知 ON" %>
-  <%= f.check_box :notification_enabled %>
+  <input type="hidden" name="user[notification_enabled]" value="off">
+  <input type="checkbox" name="user[notification_enabled]" id="user_notification_enabled" value="on" <%= "checked" if @user.notification_enabled == "on" %>>
+
+  <%= f.submit "更新" %>
 <% end %>
 
 <% unless @user.authentications.exists? %>
   <%= link_to "パスワードの変更はこちらから", new_password_reset_path %>
 <% end %>
-

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,12 @@
+<%= form_with model: @user, data: { turbo: false } do |f| %>
+  <%= f.label :name, "名前" %>
+  <%= f.text_field :name %>
+
+  <%= f.label :notification_enabled, "LINE通知 ON" %>
+  <%= f.check_box :notification_enabled %>
+<% end %>
+
+<% unless @user.authentications.exists? %>
+  <%= link_to "パスワードの変更はこちらから", new_password_reset_path %>
+<% end %>
+

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,5 @@
 ユーザー名：<%= @user.name %><br>
-LINE通知設定：<%= @user.notification_enabled %><br>
+LINE通知設定：
+<%= @user.notification_enabled == "on" ? "ON" : "OFF" %>
 
 <%= link_to "編集", edit_user_path(@user) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,4 @@
 ユーザー名：<%= @user.name %><br>
 LINE通知設定：<%= @user.notification_enabled %><br>
 
-<% unless @user.authentications.exists? %>
-  <%= link_to "パスワードの変更はこちらから", new_password_reset_path %>
-<% end %>
+<%= link_to "編集", edit_user_path(@user) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,6 @@
+ユーザー名：<%= @user.name %><br>
+LINE通知設定：<%= @user.notification_enabled %><br>
+
+<% unless @user.authentications.exists? %>
+  <%= link_to "パスワードの変更はこちらから", new_password_reset_path %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   resources :introductions, only: [:show]
   resources :questions, only: [:show]
   resources :answers, only: [:create]
-  resources :users, only: [:new, :create]
+  resources :users, only: [:new, :create, :show, :edit, :update]
   resources :password_resets, only: [:new, :create, :edit, :update]
   resources :profiles do
     resources :events do


### PR DESCRIPTION
### 概要
マイページに、会員情報を表示・編集できるようにする

---
### 内容
- [x] 表示する項目は以下の通り
  - ユーザーネーム
  - 通知機能（ON、OFFをプルダウンメニューで表示）

- [x] ユーザーネーム、通知機能が変更後、保存された場合は、「保存しました」というフラッシュメッセージを表示する
- [x] マイページのリンクを、ログイン後ヘッダーに表示する

---
### 補足
- 最低限の機能だけ実装する
  - 名前の変更
  - 通知の変更
- 下記機能は、優先順位が低いので、開発スケジュールを鑑みて、別途実装を検討する
  - メールアドレスの変更（メールアドレスの変更ニーズがどの程度あるか不明のため）
  - パスワードの変更（パスワードリセットからパスワードができるため）

This PR close #19 