### PR TITLE
LINE通知のオン・オフ設定

### DIFF
--- a/app/views/events/_notification_off.html.erb
+++ b/app/views/events/_notification_off.html.erb
@@ -1,0 +1,32 @@
+<div class="pt-40 max-w-md mx-auto text-white text-2xl">
+  <%= form_with model: @form, url: update_all_profile_events_path, method: :patch, data: { turbo: false } do |f| %>
+    <fieldset disabled="disabled">
+      <%= render 'shared/error_messages', model: f.object %>
+
+      <%= f.fields_for :events do |i| %>
+        <div class="grid grid-cols-3 items-center gap-2 mb-4">
+          <div class="col-span-1">
+            <%= "#{i.object.name}の" %>
+          </div>
+          <div class="col-span-1">
+            <%= i.select :notification_timing, [0,1,3,7,14,30,60], selected: i.object.notification_timing, class: "text-black w-full" %>日前に、
+          </div>
+          <div class="col-span-1 flex items-center">
+            通知
+          <%= i.select :notification_enabled, ["しない"] %>
+          </div>
+          <div>
+            <%= i.hidden_field :date, value: i.object.date %>
+            <%= i.hidden_field :name, value: i.object.name %>
+            <%= i.hidden_field :profile_id, value: i.object.profile_id %>
+          </div>
+        </div>
+      <% end %>
+      <div class="flex justify-center">
+        <%= f.submit '登録する', class: "btn bg-slate-300 text-black border-none shadow-2xl" %>
+      </div>
+    </fieldset>
+  <% end %>
+</div>
+※マイページの通知設定がOFFになっているため、変更できません
+マイページは<%= link_to "こちら", edit_user_path(@profile.user) %>

--- a/app/views/events/_notification_on.html.erb
+++ b/app/views/events/_notification_on.html.erb
@@ -1,0 +1,28 @@
+<div class="pt-40 max-w-md mx-auto text-white text-2xl">
+  <%= form_with model: @form, url: update_all_profile_events_path, method: :patch, data: { turbo: false } do |f| %>
+    <%= render 'shared/error_messages', model: f.object %>
+
+    <%= f.fields_for :events do |i| %>
+      <div class="grid grid-cols-3 items-center gap-2 mb-4">
+        <div class="col-span-1">
+          <%= "#{i.object.name}の" %>
+        </div>
+        <div class="col-span-1">
+          <%= i.select :notification_timing, [0,1,3,7,14,30,60], selected: i.object.notification_timing, class: "text-black w-full" %>日前に、
+        </div>
+        <div class="col-span-1 flex items-center">
+          通知
+        <%= i.select :notification_enabled, [["する", "on"], ["しない", "off"]] %>
+        </div>
+        <div>
+          <%= i.hidden_field :date, value: i.object.date %>
+          <%= i.hidden_field :name, value: i.object.name %>
+          <%= i.hidden_field :profile_id, value: i.object.profile_id %>
+        </div>
+      </div>
+    <% end %>
+    <div class="flex justify-center">
+      <%= f.submit '登録する', class: "btn bg-slate-300 text-black border-none shadow-2xl" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -12,7 +12,7 @@
         </div>
         <div class="col-span-1 flex items-center">
           通知
-          <%= i.check_box :notification_enabled, checked: i.object.notification_enabled == "on", class: "mr-2 ml-2" %>
+          <%= i.select :notification_enabled, [["する", "on"], ["しない", "off"]] %>
         </div>
         <div>
           <%= i.hidden_field :date, value: i.object.date %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,31 +1,9 @@
-<div class="pt-40 max-w-md mx-auto text-white text-2xl">
-  <%= form_with model: @form, url: update_all_profile_events_path, method: :patch, data: { turbo: false } do |f| %>
-    <%= render 'shared/error_messages', model: f.object %>
+<% if @profile.user.notification_enabled == "off" %>
+  <%= render "notification_off" %>
+<% else %>
+  <%= render "notification_on" %>
+<% end %>
 
-    <%= f.fields_for :events do |i| %>
-      <div class="grid grid-cols-3 items-center gap-2 mb-4">
-        <div class="col-span-1">
-          <%= "#{i.object.name}の" %>
-        </div>
-        <div class="col-span-1">
-          <%= i.select :notification_timing, [0,1,3,7,14,30,60], selected: i.object.notification_timing, class: "text-black w-full" %>日前に、
-        </div>
-        <div class="col-span-1 flex items-center">
-          通知
-          <%= i.select :notification_enabled, [["する", "on"], ["しない", "off"]] %>
-        </div>
-        <div>
-          <%= i.hidden_field :date, value: i.object.date %>
-          <%= i.hidden_field :name, value: i.object.name %>
-          <%= i.hidden_field :profile_id, value: i.object.profile_id %>
-        </div>
-      </div>
-    <% end %>
-    <div class="flex justify-center">
-      <%= f.submit '登録する', class: "btn bg-slate-300 text-black border-none shadow-2xl" %>
-    </div>
-  <% end %>
-</div>
 
 <div class="flex flex-col items-center mt-10 text-xl">
   <p>※通知機能を使うためには、LINEの友達登録が必要です。</p>


### PR DESCRIPTION
### 概要
マイページで通知をオフにした場合、個々の連絡先の通知設定を自動的にオフにし、マイページの通知がオフである限り変更ができないようにする

---
### 内容

- [x] マイページで通知オフとすると個々の連絡先の通知機能を、
- [x] グレーアウトさせ、変更できないようにする
- [x] 通知をすべて「しない」と表示する（たとえnotification_enabledがonになっていても、DBはoffにせず、HTML上でのみ「通知しない」と表示する）
- [x] 「※マイページの通知設定がOFFになっているため、変更できません」というメッセージを表示する
- [x] マイページの編集リンクを表示する

---
### 補足

This PR close #40 