### PR TITLE
既存のalbum画像がある場合、画像を追加保存し、合計３枚（上限）以上になっても、エラーメッセージが表示されない問題の解消

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -27,8 +27,7 @@ class AlbumsController < ApplicationController
   def edit; end
 
   def update
-    if @album.update(album_params.except(:images))
-      attach_images if album_params[:images].present?
+    if @album.update(album_params)
       flash[:success] = "アルバムを更新しました"
       redirect_to profile_albums_path(@album.profile_id)
     else
@@ -55,9 +54,5 @@ class AlbumsController < ApplicationController
 
   def set_album
     @album = @profile.albums.find(params[:id])
-  end
-
-  def attach_images
-    album_params[:images].each { |image| @album.images.attach(image) }
   end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -2,5 +2,10 @@ class ImagesController < ApplicationController
   def destroy
     @image = ActiveStorage::Attachment.find(params[:id])
     @image.purge
+
+    render turbo_stream: [
+      turbo_stream.remove("album_#{@image.record_id}-#{@image.id}"),
+      turbo_stream.replace("album_hidden_fields", partial: "albums/hidden_fields", locals: { album: @image.record } )
+    ]
   end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -5,7 +5,7 @@ class ImagesController < ApplicationController
 
     render turbo_stream: [
       turbo_stream.remove("album_#{@image.record_id}-#{@image.id}"),
-      turbo_stream.replace("album_hidden_fields", partial: "albums/hidden_fields", locals: { album: @image.record } )
+      turbo_stream.replace("album_hidden_fields", partial: "albums/hidden_fields", locals: { album: @image.record })
     ]
   end
 end

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -15,7 +15,7 @@
     <%# <turbo-frame id="album_hidden_fields"> %>
       <% @album.images.each do |image| %>
         <% if image.persisted? %>
-          <%= form.hidden_field :images, multiple: true, value: image.signed_id %>
+          <%= form.hidden_field :images, value: image.signed_id %>
         <% end %>
       <% end %>
     <%# </turbo-frame> %>

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -12,6 +12,13 @@
     <%= form.text_area :diary %>
 
     <%= form.label :image, "写真" %>
+    <%# <turbo-frame id="album_hidden_fields"> %>
+      <% @album.images.each do |image| %>
+        <% if image.persisted? %>
+          <%= form.hidden_field :images, multiple: true, value: image.signed_id %>
+        <% end %>
+      <% end %>
+    <%# </turbo-frame> %>
     <%= form.file_field :images, multiple: true, data: { previews_target: "input", action: "change->previews#preview" } %>
 
     <%= form.submit "保存する" %>

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -15,7 +15,7 @@
     <turbo-frame id="album_hidden_fields">
       <% @album.images.each do |image| %>
         <% if image.persisted? %>
-          <%= form.hidden_field :images, value: image.signed_id %>
+          <%= form.hidden_field :images, multiple: true, value: image.signed_id %>
         <% end %>
       <% end %>
     </turbo-frame>

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -27,8 +27,10 @@
   <% if album.images.attached? && album.persisted? %>
     <% album.images.each do |image| %>
       <div id="<%= "#{dom_id(album)}-#{image.id}" %>">
+      <% if image.persisted? %>
         <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
         <%= link_to "削除", image_path(image), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
+      <% end %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -12,13 +12,13 @@
     <%= form.text_area :diary %>
 
     <%= form.label :image, "写真" %>
-    <%# <turbo-frame id="album_hidden_fields"> %>
+    <turbo-frame id="album_hidden_fields">
       <% @album.images.each do |image| %>
         <% if image.persisted? %>
           <%= form.hidden_field :images, value: image.signed_id %>
         <% end %>
       <% end %>
-    <%# </turbo-frame> %>
+    </turbo-frame>
     <%= form.file_field :images, multiple: true, data: { previews_target: "input", action: "change->previews#preview" } %>
 
     <%= form.submit "保存する" %>

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -13,7 +13,7 @@
 
     <%= form.label :image, "写真" %>
     <turbo-frame id="album_hidden_fields">
-      <% @album.images.each do |image| %>
+      <% album.images.each do |image| %>
         <% if image.persisted? %>
           <%= form.hidden_field :images, multiple: true, value: image.signed_id %>
         <% end %>

--- a/app/views/albums/_hidden_fields.html.erb
+++ b/app/views/albums/_hidden_fields.html.erb
@@ -1,0 +1,5 @@
+<% album.images.each do |image| %>
+  <% if image.persisted? %>
+    <%= hidden_field_tag "album[images][]", image.signed_id %>
+  <% end %>
+<% end %>

--- a/app/views/images/destroy.turbo_stream.erb
+++ b/app/views/images/destroy.turbo_stream.erb
@@ -1,1 +1,0 @@
-<%= turbo_stream.remove "album_#{@image.record_id}-#{@image.id}" %>


### PR DESCRIPTION
### 概要
既存のalbum画像がある場合、画像を追加保存し、合計３枚（上限）以上になっても、エラーメッセージが表示されない問題の解消
---
### 背景・目的
エラーメッセージを表示させることで、投稿エラーの原因をユーザーに知らせる

---

### 内容
- [x] フォームに隠しフィールドを設置し、保存済みの画像を入れる
- [x] 非同期で削除された画像は、隠しフィールドには入らないようにするため、隠しフィールドを置換する


---
### 対応しないこと
- 

---
### 補足
This PR close #210 