### PR TITLE
LINE公式アカウントに送られるメールアドレスからLINE IDを保存する処理について、LINE IDが保存済みかどうか確認する処理を追加する

### DIFF
--- a/app/services/line_id_registration_service.rb
+++ b/app/services/line_id_registration_service.rb
@@ -10,8 +10,10 @@ class LineIdRegistrationService
       line_id = event["source"]["userId"]
       user = find_user_by_email(event.message["text"])
 
-      if user&.update(line_user_id: line_id) || User.exists?(line_user_id: line_id)
+      if user&.update(line_user_id: line_id)
         send_success_message(event["replyToken"])
+      elsif User.exists?(line_user_id: line_id)
+        send_line_login_account_exist_message(event["replyToken"])
       else
         send_failure_message(event["replyToken"])
       end
@@ -42,6 +44,16 @@ class LineIdRegistrationService
       {
         type: "text",
         text: "アプリと連携ができました。大切な日に合わせてリマインド通知を受け取ることができます"
+      }
+    )
+  end
+
+  def send_line_login_account_exist_message(reply_token)
+    client.reply_message(
+      reply_token,
+      {
+        type: "text",
+        text: "アプリのLINEログインアカウントと連携済みです"
       }
     )
   end

--- a/app/services/line_id_registration_service.rb
+++ b/app/services/line_id_registration_service.rb
@@ -10,7 +10,7 @@ class LineIdRegistrationService
       line_id = event["source"]["userId"]
       user = find_user_by_email(event.message["text"])
 
-      if User.exists?(line_user_id: line_id) || user&.update(line_user_id: line_id)
+      if user&.update(line_user_id: line_id) || User.exists?(line_user_id: line_id)
         send_success_message(event["replyToken"])
       else
         send_failure_message(event["replyToken"])

--- a/app/services/line_id_registration_service.rb
+++ b/app/services/line_id_registration_service.rb
@@ -10,7 +10,7 @@ class LineIdRegistrationService
       line_id = event["source"]["userId"]
       user = find_user_by_email(event.message["text"])
 
-      if user&.update(line_user_id: line_id)
+      if User.exists?(line_user_id: line_id) || user&.update(line_user_id: line_id)
         send_success_message(event["replyToken"])
       else
         send_failure_message(event["replyToken"])


### PR DESCRIPTION
### 概要
LINE公式アカウントに送られるメールアドレスからLINE IDを保存する処理について、LINE IDが保存済みかどうか確認する処理を追加する

---
### 背景・目的
LINE公式アカウントにメールアドレスを送るユーザーは3パターン。
1. メアド・パスワード登録ユーザーで、まだline_user_idが登録されていないユーザー
2. メアド・パスワード登録ユーザーで、既にline_user_idが登録されたユーザー
3. LINEログインユーザー

現状のコードは、送られたメールアドレスでユーザーを検索し、そのユーザーのline_user_idにLINE IDを登録する仕様。
1のパターンは、問題なし。
2のパターンも、何回line_user_idをupdateしても問題ない。
3のパターンのユーザーは、email検索でユーザー情報を取得できないため、「連携に失敗しました」というメッセージが流れてしまう。しかし実際は、既にline_user_idにLINE IDが入っている。このユーザーに対しては、「連携済みです」というメッセージを送る
```
  def save
    @events.each do |event|
      next unless text_message?(event)

      line_id = event["source"]["userId"]
      user = find_user_by_email(event.message["text"])

      if user&.update(line_user_id: line_id)
        send_success_message(event["replyToken"])
      else
        send_failure_message(event["replyToken"])
      end
    end
  end
```
---

### 内容
- [x] 送られたメールアドレスでUserレコードを検索し、失敗した場合、LINE APIからのLINE IDとline_user_idが合致するかどうか判定する処理を行う
- [x] もし合致した場合、「アプリのLINEログインアカウントと連携済みです」というメッセージを送る

---
### 対応しないこと
- 

---

### 補足
- リスクとしては、他人（Bさん）のメールアドレスと一致するメールアドレスをAさんが送った場合、Bのline_user_idに、AのLINE IDが入ってしまうリスクを持っている。
- ユーザーCが、メアド・パスのアカウントと、LINEログインアカウントの2つを持っていた場合を想定する。ユーザーCがメアド・パスアカウントにLINEIDを登録したいと思い、メールアドレスを送るが、そのメールアドレスが間違っていた場合でも、LINEログインアカウントのLINE IDの検索に合致することになる。この場合でも「アプリと連携できました」とメッセージを送ると、ユーザーCは、メアド・パスのアカウントと連携できたと勘違いしてしまうリスクがある。したがって、「アプリのLINEログインアカウントと連携済みです」というメッセージにすることで、メアド・パスのアカウントとの紐づけができていないことを示す