### PR TITLE
ともだち帳　一覧リストで、今月・来月イベントがある連絡先の人を表示する

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -13,6 +13,10 @@ class ProfilesController < ApplicationController
     @q = current_user.profiles.ransack(params[:q])
     @q.combinator = "or"
     @profiles = @q.result(distinct: true).includes(:events).order(created_at: :desc)
+    @profiles_birthdays_this_month = Profile.with_birthday_this_month
+    @profiles_birthdays_next_month = Profile.with_birthday_next_month
+    @profiles_special_day_this_month = Profile.with_special_day_this_month
+    @profiles_special_day_next_month = Profile.with_special_day_next_month
   end
 
   def create

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -59,6 +59,6 @@ class ProfilesController < ApplicationController
   private
 
   def profile_params
-    params.require(:profile).permit(:avatar, :name, :furigana, :phone, :email, :line_name, :birthplace, :address, :occupation, events_attributes: %i[name date id])
+    params.require(:profile).permit(:avatar, :contacted, :name, :furigana, :phone, :email, :line_name, :birthplace, :address, :occupation, events_attributes: %i[name date id])
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -45,7 +45,15 @@ class ProfilesController < ApplicationController
   def destroy
     @profile = current_user.profiles.find(params[:id])
     @profile.destroy!
-    redirect_to profiles_path, status: :see_other
+
+    respond_to do |format|
+      format.html {
+        redirect_to profiles_path, status: :see_other
+      }
+      format.turbo_stream {
+        render turbo_stream: turbo_stream.remove("profile_#{@profile.id}")
+      }
+    end
   end
 
   private

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -51,12 +51,8 @@ class ProfilesController < ApplicationController
     @profile.destroy!
 
     respond_to do |format|
-      format.html {
-        redirect_to profiles_path, status: :see_other
-      }
-      format.turbo_stream {
-        render turbo_stream: turbo_stream.remove("profile_#{@profile.id}")
-      }
+      format.html { redirect_to profiles_path, status: :see_other }
+      format.turbo_stream { render turbo_stream: turbo_stream.remove("profile_#{@profile.id}") }
     end
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -16,19 +16,19 @@ class Profile < ApplicationRecord
                      limit: { max: 1 }
 
   scope :with_birthday_this_month, lambda {
-    joins(:events).where('events.name LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.month)
+    joins(:events).where("events.name LIKE ? AND MONTH(events.date) = ?", "誕生日", Date.today.month)
   }
 
   scope :with_birthday_next_month, lambda {
-    joins(:events).where('events.name LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.next_month.month)
+    joins(:events).where("events.name LIKE ? AND MONTH(events.date) = ?", "誕生日", Date.today.next_month.month)
   }
 
   scope :with_special_day_this_month, lambda {
-    joins(:events).where('events.name NOT LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.month)
+    joins(:events).where("events.name NOT LIKE ? AND MONTH(events.date) = ?", "誕生日", Date.today.month)
   }
 
   scope :with_special_day_next_month, lambda {
-    joins(:events).where('events.name NOT LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.next_month.month)
+    joins(:events).where("events.name NOT LIKE ? AND MONTH(events.date) = ?", "誕生日", Date.today.next_month.month)
   }
 
   def self.ransackable_attributes(_auth_object = nil)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -14,6 +14,7 @@ class Profile < ApplicationRecord
                      content_type: %i[png jpeg],
                      size: { less_than: 1.megabytes, message: "is too large" },
                      limit: { max: 1 }
+  validates :contacted, presence: true
 
   scope :with_birthday_this_month, lambda {
     joins(:events).where("events.name LIKE ? AND MONTH(events.date) = ?", "誕生日", Date.today.month)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -15,21 +15,21 @@ class Profile < ApplicationRecord
                      size: { less_than: 1.megabytes, message: "is too large" },
                      limit: { max: 1 }
 
-scope :with_birthday_this_month, lambda {
-  joins(:events).where('events.name LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.month)
-}
+  scope :with_birthday_this_month, lambda {
+    joins(:events).where('events.name LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.month)
+  }
 
-scope :with_birthday_next_month, lambda {
-  joins(:events).where('events.name LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.next_month.month)
-}
+  scope :with_birthday_next_month, lambda {
+    joins(:events).where('events.name LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.next_month.month)
+  }
 
-scope :with_special_day_this_month, lambda {
-  joins(:events).where('events.name NOT LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.month)
-}
+  scope :with_special_day_this_month, lambda {
+    joins(:events).where('events.name NOT LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.month)
+  }
 
-scope :with_special_day_next_month, lambda {
-  joins(:events).where('events.name NOT LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.next_month.month)
-}
+  scope :with_special_day_next_month, lambda {
+    joins(:events).where('events.name NOT LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.next_month.month)
+  }
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[name furigana line_name]

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -15,19 +15,19 @@ class Profile < ApplicationRecord
                      size: { less_than: 1.megabytes, message: "is too large" },
                      limit: { max: 1 }
 
-scope :with_birthday_this_month, -> {
+scope :with_birthday_this_month, lambda {
   joins(:events).where('events.name LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.month)
 }
 
-scope :with_birthday_next_month, -> {
+scope :with_birthday_next_month, lambda {
   joins(:events).where('events.name LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.next_month.month)
 }
 
-scope :with_special_day_this_month, -> {
+scope :with_special_day_this_month, lambda {
   joins(:events).where('events.name NOT LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.month)
 }
 
-scope :with_special_day_next_month, -> {
+scope :with_special_day_next_month, lambda {
   joins(:events).where('events.name NOT LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.next_month.month)
 }
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -14,7 +14,6 @@ class Profile < ApplicationRecord
                      content_type: %i[png jpeg],
                      size: { less_than: 1.megabytes, message: "is too large" },
                      limit: { max: 1 }
-  validates :contacted, presence: true
 
   scope :with_birthday_this_month, lambda {
     joins(:events).where("events.name LIKE ? AND MONTH(events.date) = ?", "誕生日", Date.today.month)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -15,6 +15,22 @@ class Profile < ApplicationRecord
                      size: { less_than: 1.megabytes, message: "is too large" },
                      limit: { max: 1 }
 
+scope :with_birthday_this_month, -> {
+  joins(:events).where('events.name LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.month)
+}
+
+scope :with_birthday_next_month, -> {
+  joins(:events).where('events.name LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.next_month.month)
+}
+
+scope :with_special_day_this_month, -> {
+  joins(:events).where('events.name NOT LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.month)
+}
+
+scope :with_special_day_next_month, -> {
+  joins(:events).where('events.name NOT LIKE ? AND MONTH(events.date) = ?', '誕生日', Date.today.next_month.month)
+}
+
   def self.ransackable_attributes(_auth_object = nil)
     %w[name furigana line_name]
   end

--- a/app/views/profiles/_event_notice.html.erb
+++ b/app/views/profiles/_event_notice.html.erb
@@ -1,0 +1,20 @@
+<table>
+  <tr>
+    <td>今月のイベント！</td>
+    <% profiles_birthdays_this_month.each do |profile| %>
+      <td><%= profile.name %>さん</td>
+    <% end %>
+    <% profiles_special_day_this_month.each do |profile| %>
+      <td><%= profile.name %>さん</td>
+    <% end %>
+  </tr>
+  <tr>
+    <td>来月のイベント！</td>
+    <% profiles_birthdays_next_month.each do |profile| %>
+      <td><%= profile.name %>さん</td>
+    <% end %>
+    <% profiles_special_day_next_month.each do |profile| %>
+      <td><%= profile.name %>さん</td>
+    <% end %>
+  </tr>
+</table>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -23,6 +23,10 @@
             <td><%= event.date %></td>
           <% end %>
           <td>
+            <% album = profile.albums.sample if profile.albums.any? %>
+            <%= image_tag album.images.sample.variant(resize_to_limit: [100, 100]) if album.images.attached? %>
+          </td>
+          <td>
             <%= link_to profile_path(profile) do %>
               <button class="btn bg-slate-300 text-black border-none shadow-2xl">詳細</button>
             <% end %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -27,6 +27,11 @@
               <button class="btn bg-slate-300 text-black border-none shadow-2xl">詳細</button>
             <% end %>
           </td>
+          <td>
+            <%= link_to profile_path(profile), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } do %>
+              <button class="btn bg-slate-300 text-black border-none shadow-2xl">削除</button>
+            <% end %>
+          </td>
         </tr>
       <% end %>
     </table>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -16,6 +16,7 @@
   <div class="px-48">
     <table class="table bg-white text-black text-center mt-2">
       <tr>
+        <th>連絡済み</th>
         <th></th>
         <th>名前</th>
         <th>誕生日</th>
@@ -23,6 +24,7 @@
       </tr>
       <% @profiles.each do |profile| %>
         <tr id="profile_<%= profile.id %>">
+          <td><%= profile.contacted %>
           <td><%= image_tag profile.avatar.variant(resize_to_limit: [100, 100]) if profile.avatar.attached? %></td>
           <td><%= profile.name %></td>
           <% profile.events.each do |event| %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -2,6 +2,12 @@
 
 <div class="pt-16">
   <h1 class="text-2xl text-white pt-10 pl-48">れんらく帳</h1>
+  <%= render "event_notice",
+      profiles_birthdays_this_month: @profiles_birthdays_this_month,
+      profiles_birthdays_next_month: @profiles_birthdays_next_month,
+      profiles_special_day_this_month: @profiles_special_day_this_month,
+      profiles_special_day_next_month: @profiles_special_day_next_month %>
+
   <div class="flex justify-end pt-2 pr-48">
     <%= link_to new_profile_path do %>
       <button class="btn bg-peach text-black border-none shadow-2xl">連絡先を作成</button>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -10,12 +10,14 @@
   <div class="px-48">
     <table class="table bg-white text-black text-center mt-2">
       <tr>
+        <th></th>
         <th>名前</th>
         <th>誕生日</th>
         <th>大切な日</th>
       </tr>
       <% @profiles.each do |profile| %>
         <tr>
+          <td><%= image_tag profile.avatar.variant(resize_to_limit: [100, 100]) %></td>
           <td><%= profile.name %></td>
           <% profile.events.each do |event| %>
             <td><%= event.date %></td>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -17,7 +17,7 @@
       </tr>
       <% @profiles.each do |profile| %>
         <tr id="profile_<%= profile.id %>">
-          <td><%= image_tag profile.avatar.variant(resize_to_limit: [100, 100]) %></td>
+          <td><%= image_tag profile.avatar.variant(resize_to_limit: [100, 100]) if profile.avatar.attached? %></td>
           <td><%= profile.name %></td>
           <% profile.events.each do |event| %>
             <td><%= event.date %></td>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -29,8 +29,8 @@
             <td><%= event.date %></td>
           <% end %>
           <td>
-            <% album = profile.albums.sample if profile.albums.any? %>
-            <%= image_tag album.images.sample.variant(resize_to_limit: [100, 100]) if album.images.attached? %>
+            <% album = profile&.albums.sample %>
+            <%= image_tag album.images.sample.variant(resize_to_limit: [100, 100]) if album&.images&.attached? %>
           </td>
           <td>
             <%= link_to profile_path(profile) do %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -16,7 +16,7 @@
         <th>大切な日</th>
       </tr>
       <% @profiles.each do |profile| %>
-        <tr>
+        <tr id="profile_<%= profile.id %>">
           <td><%= image_tag profile.avatar.variant(resize_to_limit: [100, 100]) %></td>
           <td><%= profile.name %></td>
           <% profile.events.each do |event| %>

--- a/db/migrate/20240902075438_add_contacted_to_profiles.rb
+++ b/db/migrate/20240902075438_add_contacted_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddContactedToProfiles < ActiveRecord::Migration[7.1]
+  def change
+    add_column :profiles, :contacted, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20240902091100_remove_null_constraint_from_profiles_contacted.rb
+++ b/db/migrate/20240902091100_remove_null_constraint_from_profiles_contacted.rb
@@ -1,0 +1,5 @@
+class RemoveNullConstraintFromProfilesContacted < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :profiles, :contacted, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_30_023132) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_02_075438) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -115,6 +115,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_30_023132) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "contacted", default: false, null: false
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_02_075438) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_02_091100) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -115,7 +115,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_02_075438) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "contacted", default: false, null: false
+    t.boolean "contacted", default: false
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 


### PR DESCRIPTION
### 概要
ともだち帳　一覧リストをブラッシュアップする

---
### 背景・目的
誕生日などのイベントが近づいている人をお知らせすることで、メッセージを送るように促す

---
### 内容
- [x] 今月のイベント（誕生日、大切な日）と、来月のイベントを表示する
- [x] Userテーブルに、カラムを追加する
  - カラム名：contacted
  - データ型：boolean
- [x] 下記を追加表示する
  - [x] contacted
  - [x] avatar
  - [x] images (1枚)
  - [x] 削除ボタン

---
### 対応しないこと
- contactedカラムの情報が、そのままtrue, falseという文字列で表示されているが、別イシューで対応する

---
### 補足
This PR close #122 