### PR TITLE
【デザイン】ともだち帳　友達リスト

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,26 +11,20 @@
     <script src="https://kit.fontawesome.com/ba69a80073.js" crossorigin="anonymous" defer></script>
   </head>
 
-  <body class="bg-white text-black">
-    <div>
-      <% if logged_in? %>
-        <%= render 'shared/header' %>
-      <% else %>
-        <%= render 'shared/before_login_header' %>
-      <% end %>
-    </div>
+  <body class="flex flex-col min-h-screen bg-white text-black">
+    <% if logged_in? %>
+      <%= render 'shared/header' %>
+    <% else %>
+      <%= render 'shared/before_login_header' %>
+    <% end %>
 
-    <div>
-      <%= render 'shared/flash_message' %>
-    </div>
+    <%= render 'shared/flash_message' %>
 
-    <main>
+    <main class="flex-grow">
       <%= yield %>
       <%= breadcrumbs separator: "&rsaquo;" %>
     </main>
 
-    <div>
-      <%= render 'shared/footer' %>
-    </div>
+    <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="min-h-screen flex flex-col">
+  <body class="min-h-screen flex flex-col bg-white">
     <% if logged_in? %>
       <%= render 'shared/header' %>
     <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="min-h-screen flex flex-col bg-white">
+  <body class="min-h-screen flex flex-col bg-white text-black">
     <% if logged_in? %>
       <%= render 'shared/header' %>
     <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <script src="https://kit.fontawesome.com/ba69a80073.js" crossorigin="anonymous" defer></script>
   </head>
 
   <body class="bg-white text-black">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="min-h-screen flex flex-col bg-white text-black">
+  <body class="bg-white text-black">
     <% if logged_in? %>
       <%= render 'shared/header' %>
     <% else %>
@@ -18,7 +18,7 @@
     <% end %>
 
     <%= render 'shared/flash_message' %>
-    <main class="flex-grow">
+    <main>
       <%= yield %>
       <%= breadcrumbs separator: "&rsaquo;" %>
     </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,17 +12,25 @@
   </head>
 
   <body class="bg-white text-black">
-    <% if logged_in? %>
-      <%= render 'shared/header' %>
-    <% else %>
-      <%= render 'shared/before_login_header' %>
-    <% end %>
+    <div>
+      <% if logged_in? %>
+        <%= render 'shared/header' %>
+      <% else %>
+        <%= render 'shared/before_login_header' %>
+      <% end %>
+    </div>
 
-    <%= render 'shared/flash_message' %>
+    <div>
+      <%= render 'shared/flash_message' %>
+    </div>
+
     <main>
       <%= yield %>
       <%= breadcrumbs separator: "&rsaquo;" %>
     </main>
-    <%= render 'shared/footer' %>
+
+    <div>
+      <%= render 'shared/footer' %>
+    </div>
   </body>
 </html>

--- a/app/views/profiles/_event_notice.html.erb
+++ b/app/views/profiles/_event_notice.html.erb
@@ -2,19 +2,31 @@
   <tr>
     <td>今月のイベント！</td>
     <% profiles_birthdays_this_month.each do |profile| %>
-      <td><%= profile.name %>さん</td>
+      <td>
+        <%= profile.name %>さん
+        <i class="fa-solid fa-cake-candles"></i>
+      </td>
     <% end %>
     <% profiles_special_day_this_month.each do |profile| %>
-      <td><%= profile.name %>さん</td>
+      <td>
+        <%= profile.name %>さん
+        <i class="fa-solid fa-calendar-check"></i>
+      </td>
     <% end %>
   </tr>
   <tr>
     <td>来月のイベント！</td>
     <% profiles_birthdays_next_month.each do |profile| %>
-      <td><%= profile.name %>さん</td>
+      <td>
+        <%= profile.name %>さん
+        <i class="fa-solid fa-cake-candles"></i>
+      </td>
     <% end %>
     <% profiles_special_day_next_month.each do |profile| %>
-      <td><%= profile.name %>さん</td>
+      <td>
+        <%= profile.name %>さん
+        <i class="fa-solid fa-calendar-check"></i>
+      </td>
     <% end %>
   </tr>
 </table>

--- a/app/views/profiles/_search.html.erb
+++ b/app/views/profiles/_search.html.erb
@@ -3,6 +3,8 @@
     <%= f.search_field :name_cont, placeholder: "名前" %>
     <%= f.search_field :furigana_cont, placeholder: "ふりがな" %>
     <%= f.search_field :line_name_cont, placeholder: "LINE名" %>
-    <%= f.submit "検索" %>
+    <button type="submit">
+      <i class="fa-solid fa-magnifying-glass"></i>
+    </button>
   <% end %>
 </div>

--- a/app/views/profiles/_search.html.erb
+++ b/app/views/profiles/_search.html.erb
@@ -1,6 +1,8 @@
-<%= search_form_for q, url: url do |f| %>
-  <%= f.search_field :name_cont, placeholder: "名前" %>
-  <%= f.search_field :furigana_cont, placeholder: "ふりがな" %>
-  <%= f.search_field :line_name_cont, placeholder: "LINE名" %>
-  <%= f.submit "検索" %>
-<% end %>
+<div>
+  <%= search_form_for q, url: url do |f| %>
+    <%= f.search_field :name_cont, placeholder: "名前" %>
+    <%= f.search_field :furigana_cont, placeholder: "ふりがな" %>
+    <%= f.search_field :line_name_cont, placeholder: "LINE名" %>
+    <%= f.submit "検索" %>
+  <% end %>
+</div>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -1,5 +1,5 @@
-<div class="flex justify-between items-center">
-  <div>
+<div class="flex justify-around items-center">
+  <div class="border-2 border-black rounded-md p-2 m-4">
     <%= render "event_notice",
         profiles_birthdays_this_month: @profiles_birthdays_this_month,
         profiles_birthdays_next_month: @profiles_birthdays_next_month,

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -1,50 +1,55 @@
-<%= render "profiles/search", q: @q, url: profiles_path %>
+<div class="flex justify-between items-center">
+  <div>
+    <%= render "event_notice",
+        profiles_birthdays_this_month: @profiles_birthdays_this_month,
+        profiles_birthdays_next_month: @profiles_birthdays_next_month,
+        profiles_special_day_this_month: @profiles_special_day_this_month,
+        profiles_special_day_next_month: @profiles_special_day_next_month %>
+  </div>
 
-<div class="pt-16">
-  <h1 class="text-2xl text-white pt-10 pl-48">れんらく帳</h1>
-  <%= render "event_notice",
-      profiles_birthdays_this_month: @profiles_birthdays_this_month,
-      profiles_birthdays_next_month: @profiles_birthdays_next_month,
-      profiles_special_day_this_month: @profiles_special_day_this_month,
-      profiles_special_day_next_month: @profiles_special_day_next_month %>
+  <div>
+    <%= render "profiles/search", q: @q, url: profiles_path %>
+  </div>
 
-  <div class="flex justify-end pt-2 pr-48">
+  <div class="btn bg-peach text-black border-none shadow-2xl">
     <%= link_to new_profile_path do %>
-      <button class="btn bg-peach text-black border-none shadow-2xl">連絡先を作成</button>
+      <button>連絡先を作成</button>
     <% end %>
   </div>
-  <div class="px-48">
-    <table class="table bg-white text-black text-center mt-2">
-      <tr>
-        <th>連絡済み</th>
-        <th></th>
-        <th>名前</th>
-        <th>誕生日</th>
-        <th>大切な日</th>
+</div>
+
+<div>
+  <table class="table bg-white text-black text-center">
+    <tr>
+      <th>連絡済み</th>
+      <th></th>
+      <th>名前</th>
+      <th>誕生日</th>
+      <th>大切な日</th>
+    </tr>
+
+    <% @profiles.each do |profile| %>
+      <tr id="profile_<%= profile.id %>">
+        <td><%= profile.contacted %>
+        <td><%= image_tag profile.avatar.variant(resize_to_limit: [100, 100]) if profile.avatar.attached? %></td>
+        <td><%= profile.name %></td>
+        <td><%= profile.events.first.date %></td>
+        <td><%= profile.events.last.date %></td>
+        <td>
+          <% album = profile&.albums.sample %>
+          <%= image_tag album.images.sample.variant(resize_to_limit: [100, 100]) if album&.images&.attached? %>
+        </td>
+        <td>
+          <%= link_to profile_path(profile) do %>
+            <button class="btn bg-slate-300 text-black border-none shadow-2xl">詳細</button>
+          <% end %>
+        </td>
+        <td>
+          <%= link_to profile_path(profile), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } do %>
+            <button class="btn bg-slate-300 text-black border-none shadow-2xl">削除</button>
+          <% end %>
+        </td>
       </tr>
-      <% @profiles.each do |profile| %>
-        <tr id="profile_<%= profile.id %>">
-          <td><%= profile.contacted %>
-          <td><%= image_tag profile.avatar.variant(resize_to_limit: [100, 100]) if profile.avatar.attached? %></td>
-          <td><%= profile.name %></td>
-          <td><%= profile.events.first.date %></td>
-          <td><%= profile.events.last.date %></td>
-          <td>
-            <% album = profile&.albums.sample %>
-            <%= image_tag album.images.sample.variant(resize_to_limit: [100, 100]) if album&.images&.attached? %>
-          </td>
-          <td>
-            <%= link_to profile_path(profile) do %>
-              <button class="btn bg-slate-300 text-black border-none shadow-2xl">詳細</button>
-            <% end %>
-          </td>
-          <td>
-            <%= link_to profile_path(profile), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } do %>
-              <button class="btn bg-slate-300 text-black border-none shadow-2xl">削除</button>
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
-    </table>
-  </div>
+    <% end %>
+  </table>
 </div>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -19,7 +19,7 @@
 </div>
 
 <div>
-  <table class="table bg-white text-black text-center">
+  <table class="table text-center">
     <tr>
       <th>連絡済み</th>
       <th></th>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -18,14 +18,17 @@
   </div>
 </div>
 
-<div>
+<div class="max-h-screen overflow-auto">
   <table class="table text-center">
-    <tr>
+    <tr class="bg-white sticky top-0">
       <th>連絡済み</th>
       <th></th>
       <th>名前</th>
       <th>誕生日</th>
       <th>大切な日</th>
+      <th></th>
+      <th></th>
+      <th></th>
     </tr>
 
     <% @profiles.each do |profile| %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -28,7 +28,6 @@
       <th class="w-2/12">大切な日</th>
       <th class="w-1/12"></th>
       <th class="w-1/12"></th>
-      <th class="w-1/12"></th>
     </tr>
 
     <% @profiles.each do |profile| %>
@@ -43,15 +42,18 @@
           <%= image_tag album.images.sample.variant(resize_to_limit: [100, 100]) if album&.images&.attached? %>
         </td>
         <td>
-          <%= link_to profile_path(profile) do %>
-          <i class="fa-solid fa-circle-info fa-2x"></i>
-
-          <% end %>
-        </td>
-        <td>
-          <%= link_to profile_path(profile), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } do %>
-            <i class="fa-solid fa-trash fa-2x"></i>
-          <% end %>
+          <div class="flex justify-around">
+            <div>
+              <%= link_to profile_path(profile) do %>
+                <i class="fa-solid fa-circle-info fa-2x"></i>
+              <% end %>
+            </div>
+            <div>
+              <%= link_to profile_path(profile), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } do %>
+                <i class="fa-solid fa-trash fa-2x"></i>
+              <% end %>
+            </div>
+          </div>
         </td>
       </tr>
     <% end %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -19,16 +19,16 @@
 </div>
 
 <div class="max-h-screen overflow-auto">
-  <table class="table text-center">
+  <table class="table table-fixed text-center">
     <tr class="bg-white sticky top-0">
-      <th>連絡済み</th>
-      <th></th>
-      <th>名前</th>
-      <th>誕生日</th>
-      <th>大切な日</th>
-      <th></th>
-      <th></th>
-      <th></th>
+      <th class="w-1/12">連絡済み</th>
+      <th class="w-1/12"></th>
+      <th class="w-3/12">名前</th>
+      <th class="w-2/12">誕生日</th>
+      <th class="w-2/12">大切な日</th>
+      <th class="w-1/12"></th>
+      <th class="w-1/12"></th>
+      <th class="w-1/12"></th>
     </tr>
 
     <% @profiles.each do |profile| %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -44,6 +44,11 @@
         <td>
           <div class="flex justify-around">
             <div>
+              <%= link_to profile_path(profile) do %>
+                <i class="fa-solid fa-circle-info fa-2x"></i>
+              <% end %>
+            </div>
+            <div>
               <%= link_to edit_profile_path(profile) do %>
                 <i class="fa-solid fa-pen-to-square fa-2x"></i>
               <% end %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -11,7 +11,7 @@
     <%= render "profiles/search", q: @q, url: profiles_path %>
   </div>
 
-  <div class="btn bg-peach text-black border-none shadow-2xl">
+  <div class="btn bg-peach text-black border-none shadow-lgl">
     <%= link_to new_profile_path do %>
       <button>連絡先を作成</button>
     <% end %>
@@ -45,17 +45,17 @@
           <div class="flex justify-around">
             <div>
               <%= link_to profile_path(profile) do %>
-                <i class="fa-solid fa-circle-info fa-2x"></i>
+                <i class="fa-solid fa-circle-info fa-lg"></i>
               <% end %>
             </div>
             <div>
               <%= link_to edit_profile_path(profile) do %>
-                <i class="fa-solid fa-pen-to-square fa-2x"></i>
+                <i class="fa-solid fa-pen-to-square fa-lg"></i>
               <% end %>
             </div>
             <div>
               <%= link_to profile_path(profile), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } do %>
-                <i class="fa-solid fa-trash fa-2x"></i>
+                <i class="fa-solid fa-trash fa-lg"></i>
               <% end %>
             </div>
           </div>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -44,12 +44,13 @@
         </td>
         <td>
           <%= link_to profile_path(profile) do %>
-            <button class="btn bg-slate-300 text-black border-none shadow-2xl">詳細</button>
+          <i class="fa-solid fa-circle-info fa-2x"></i>
+
           <% end %>
         </td>
         <td>
           <%= link_to profile_path(profile), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } do %>
-            <button class="btn bg-slate-300 text-black border-none shadow-2xl">削除</button>
+            <i class="fa-solid fa-trash fa-2x"></i>
           <% end %>
         </td>
       </tr>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -27,9 +27,8 @@
           <td><%= profile.contacted %>
           <td><%= image_tag profile.avatar.variant(resize_to_limit: [100, 100]) if profile.avatar.attached? %></td>
           <td><%= profile.name %></td>
-          <% profile.events.each do |event| %>
-            <td><%= event.date %></td>
-          <% end %>
+          <td><%= profile.events.first.date %></td>
+          <td><%= profile.events.last.date %></td>
           <td>
             <% album = profile&.albums.sample %>
             <%= image_tag album.images.sample.variant(resize_to_limit: [100, 100]) if album&.images&.attached? %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -44,8 +44,8 @@
         <td>
           <div class="flex justify-around">
             <div>
-              <%= link_to profile_path(profile) do %>
-                <i class="fa-solid fa-circle-info fa-2x"></i>
+              <%= link_to edit_profile_path(profile) do %>
+                <i class="fa-solid fa-pen-to-square fa-2x"></i>
               <% end %>
             </div>
             <div>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -34,7 +34,7 @@
       <tr id="profile_<%= profile.id %>">
         <td><%= profile.contacted %>
         <td><%= image_tag profile.avatar.variant(resize_to_limit: [100, 100]) if profile.avatar.attached? %></td>
-        <td><%= profile.name %></td>
+        <td class="text-left"><%= profile.name %></td>
         <td><%= profile.events.first.date %></td>
         <td><%= profile.events.last.date %></td>
         <td>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="sticky bottom-0 bg-opacity-20 bg-black w-full left-0">
+<footer class="bottom-0 bg-opacity-20 bg-black w-full left-0">
   <div class="flex justify-center space-x-8 text-white">
     <%= link_to "利用規約", '#' %>
     <%= link_to "プライバシーポリシー", '#' %>


### PR DESCRIPTION
### 概要
ともだち帳　友達リストページのデザインブラッシュアップ

---
### 背景・目的
UI・UXの向上

---
### 内容
- [x] テーブルのデータを、eachを使わず、first, lastで表示させるように変更
- [x] 背景色を白に設定
- [x] すべての文字を黒に設定
- [x] 各パーツにdivタグを設置し、イベント通知欄・検索フィールド・連絡先作成ボタンをflexコンテナに入れる
- [x] テーブルの一行目を固定し、スクロールバーを表示させる
- [x] fontawesomeをCDNで読み込む
- [x] 詳細、編集、削除ボタンをアイコンに変更
- [x] footerのsticky表示を解除
- [x] イベントの表示名に誕生日アイコン・カレンダーアイコンを表示

---
### 対応しないこと
- [ ] 

---
### 補足