### PR TITLE
ともだち帳　友達リストページのレスポンシブデザインを実装

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,10 @@
       <%= breadcrumbs separator: "&rsaquo;" %>
     </main>
 
-    <%= render 'shared/footer' %>
+    <% if logged_in? %>
+      <%= render 'shared/footer' %>
+    <% else %>
+      <%= render 'shared/before_login_footer' %>
+    <% end %>
   </body>
 </html>

--- a/app/views/profiles/_event_notice.html.erb
+++ b/app/views/profiles/_event_notice.html.erb
@@ -1,5 +1,5 @@
 <!---スマホ画面用のテーブル--->
-<table class="w-full">
+<table class="w-full sm:hidden">
   <tr>
     <td class="w-1/2 text-center">今月のイベント！</td>
     <td class="w-1/2 text-center">来月のイベント！</td>

--- a/app/views/profiles/_event_notice.html.erb
+++ b/app/views/profiles/_event_notice.html.erb
@@ -1,4 +1,47 @@
-<table>
+<!---スマホ画面用のテーブル--->
+<table class="w-full">
+  <tr>
+    <td class="w-1/2 text-center">今月のイベント！</td>
+    <td class="w-1/2 text-center">来月のイベント！</td>
+  </tr>
+  <tr>
+    <td class="align-top">
+      <div class="m-3">
+        <% profiles_birthdays_this_month.each do |profile| %>
+          <div>
+            <%= profile.name %>さん
+            <i class="fa-solid fa-cake-candles"></i>
+          </div>
+        <% end %>
+        <% profiles_special_day_this_month.each do |profile| %>
+          <div>
+            <%= profile.name %>さん
+            <i class="fa-solid fa-calendar-check"></i>
+          </div>
+        <% end %>
+      </div>
+    </td>
+    <td class="align-top">
+      <div class="m-3">
+        <% profiles_birthdays_next_month.each do |profile| %>
+          <div>
+            <%= profile.name %>さん
+            <i class="fa-solid fa-cake-candles"></i>
+          </div>
+        <% end %>
+        <% profiles_special_day_next_month.each do |profile| %>
+          <div>
+            <%= profile.name %>さん
+            <i class="fa-solid fa-calendar-check"></i>
+          </div>
+        <% end %>
+      </div>
+    </td>
+  </tr>
+</table>
+
+<!---PC画面用のテーブル--->
+<table class="hidden sm:table">
   <tr>
     <td>今月のイベント！</td>
     <% profiles_birthdays_this_month.each do |profile| %>

--- a/app/views/profiles/_search.html.erb
+++ b/app/views/profiles/_search.html.erb
@@ -1,10 +1,16 @@
-<div>
-  <%= search_form_for q, url: url do |f| %>
-    <%= f.search_field :name_cont, placeholder: "名前" %>
-    <%= f.search_field :furigana_cont, placeholder: "ふりがな" %>
-    <%= f.search_field :line_name_cont, placeholder: "LINE名" %>
+<%= search_form_for q, url: url, class: "flex items-center" do |f| %>
+  <div>
+    <%= f.search_field :name_cont, placeholder: "名前", class: "w-full border px-2 py-1" %>
+  </div>
+  <div>
+    <%= f.search_field :furigana_cont, placeholder: "ふりがな", class: "w-full border px-2 py-1" %>
+  </div>
+  <div>
+    <%= f.search_field :line_name_cont, placeholder: "LINE名", class: "w-full border px-2 py-1" %>
+  </div>
+  <div>
     <button type="submit">
       <i class="fa-solid fa-magnifying-glass"></i>
     </button>
-  <% end %>
-</div>
+  </div>
+<% end %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -19,7 +19,7 @@
 </div>
 
 <!---スマホ画面用のブロック--->
-<div class="flex flex-col sm:hidden">
+<div class="flex flex-col sm:hidden pb-20">
   <% @profiles.each do |profile| %>
     <div class="flex h-24 my-5">
       <div class="w-1/12 flex items-center justify-center">

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -1,4 +1,4 @@
-<div class="flex justify-around items-center">
+<div class="sm:flex sm:justify-around sm:items-center">
   <div class="border-2 border-black rounded-md p-2 m-4">
     <%= render "event_notice",
         profiles_birthdays_this_month: @profiles_birthdays_this_month,

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -18,52 +18,53 @@
   </div>
 </div>
 
-<div class="max-h-screen overflow-auto">
 <!---スマホ画面用のブロック--->
-  <div class="flex flex-col sm:hidden">
-    <% @profiles.each do |profile| %>
-      <div class="flex h-24 my-5">
-        <div class="w-1/12 flex items-center justify-center">
-          <%= profile.contacted %>
+<div class="flex flex-col sm:hidden">
+  <% @profiles.each do |profile| %>
+    <div class="flex h-24 my-5">
+      <div class="w-1/12 flex items-center justify-center">
+        <%= profile.contacted %>
+      </div>
+      <div class="w-2/12 flex items-center">
+        <%= image_tag profile.avatar.variant(resize_to_limit: [100, 100]) if profile.avatar.attached? %>
+      </div>
+      <div class="w-6/12">
+        <div class="text-5xl h-12">
+          <%= profile.name %>
         </div>
-        <div class="w-2/12 flex items-center">
-          <%= image_tag profile.avatar.variant(resize_to_limit: [100, 100]) if profile.avatar.attached? %>
+        <div>
+          <i class="fa-solid fa-cake-candles"></i>
+          <%= profile.events.first.date %>
         </div>
-        <div class="w-6/12">
-          <div class="text-5xl h-12">
-            <%= profile.name %>
-          </div>
-          <div>
-            <i class="fa-solid fa-cake-candles"></i>
-            <%= profile.events.first.date %>
-          </div>
-          <div>
-            <i class="fa-solid fa-calendar-check"></i>
-            <%= profile.events.last.date %>
-          </div>
-        </div>
-        <div class="w-3/12 flex justify-around items-center">
-          <div>
-            <%= link_to profile_path(profile) do %>
-              <i class="fa-solid fa-circle-info fa-lg"></i>
-            <% end %>
-          </div>
-          <div>
-            <%= link_to edit_profile_path(profile) do %>
-              <i class="fa-solid fa-pen-to-square fa-lg"></i>
-            <% end %>
-          </div>
-          <div>
-            <%= link_to profile_path(profile), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } do %>
-              <i class="fa-solid fa-trash fa-lg"></i>
-            <% end %>
-          </div>
+        <div>
+          <i class="fa-solid fa-calendar-check"></i>
+          <%= profile.events.last.date %>
         </div>
       </div>
-    <% end %>
-  </div>
+      <div class="w-3/12 flex justify-around items-center">
+        <div>
+          <%= link_to profile_path(profile) do %>
+            <i class="fa-solid fa-circle-info fa-lg"></i>
+          <% end %>
+        </div>
+        <div>
+          <%= link_to edit_profile_path(profile) do %>
+            <i class="fa-solid fa-pen-to-square fa-lg"></i>
+          <% end %>
+        </div>
+        <div>
+          <%= link_to profile_path(profile), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } do %>
+            <i class="fa-solid fa-trash fa-lg"></i>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>
+
 
 <!---PC画面用のテーブル--->
+<div class="max-h-screen overflow-auto">
   <table class="table table-fixed text-center hidden sm:table">
     <tr class="bg-white sticky top-0">
       <th class="w-1/12">連絡済み</th>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -19,14 +19,14 @@
 </div>
 
 <div class="max-h-screen overflow-auto">
-  <table class="table table-fixed text-center">
+  <table class="table table-fixed text-center hidden sm:table">
     <tr class="bg-white sticky top-0">
-      <th class="w-1/12 whitespace-nowrap">連絡済み</th>
+      <th class="w-1/12">連絡済み</th>
       <th class="w-1/12"></th>
       <th class="w-3/12">名前</th>
       <th class="w-2/12">誕生日</th>
-      <th class="w-2/12 whitespace-nowrap">大切な日</th>
-      <th class="w-1/12 hidden sm:table-cell"></th>
+      <th class="w-2/12">大切な日</th>
+      <th class="w-1/12"></th>
       <th class="w-1/12"></th>
     </tr>
 
@@ -37,7 +37,7 @@
         <td class="text-left"><%= profile.name %></td>
         <td><%= profile.events.first.date %></td>
         <td><%= profile.events.last.date %></td>
-        <td class="hidden sm:table-cell">
+        <td>
           <% album = profile&.albums.sample %>
           <%= image_tag album.images.sample.variant(resize_to_limit: [100, 100]) if album&.images&.attached? %>
         </td>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -23,7 +23,7 @@
   <div class="flex flex-col">
     <% @profiles.each do |profile| %>
       <div class="flex h-24 my-5">
-        <div class="w-1/12">
+        <div class="w-1/12 flex items-center justify-center">
           <%= profile.contacted %>
         </div>
         <div class="w-2/12 flex items-center">

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -40,7 +40,7 @@
             <%= profile.events.last.date %>
           </div>
         </div>
-        <div class="w-3/12">
+        <div class="w-3/12 flex justify-around items-center">
           <div>
             <%= link_to profile_path(profile) do %>
               <i class="fa-solid fa-circle-info fa-lg"></i>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -11,7 +11,7 @@
     <%= render "profiles/search", q: @q, url: profiles_path %>
   </div>
 
-  <div>
+  <div class="flex justify-center my-4">
     <%= link_to new_profile_path, class: "btn bg-peach text-black border-none shadow-lgl" do %>
       <button>連絡先を作成</button>
     <% end %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -22,7 +22,7 @@
 <!---スマホ画面用のブロック--->
   <div class="flex flex-col">
     <% @profiles.each do |profile| %>
-      <div class="flex">
+      <div class="flex h-24">
         <div class="w-1/12">
           <%= profile.contacted %>
         </div>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -19,6 +19,53 @@
 </div>
 
 <div class="max-h-screen overflow-auto">
+<!---スマホ画面用のブロック--->
+  <div class="flex flex-col">
+    <% @profiles.each do |profile| %>
+      <div class="flex">
+        <div class="w-1/12">
+          <%= profile.contacted %>
+        </div>
+        <div class="w-2/12">
+          <%= image_tag profile.avatar.variant(resize_to_limit: [100, 100]) if profile.avatar.attached? %>
+        </div>
+        <div class="w-4/12">
+          <div>
+            <%= profile.name %>
+          </div>
+          <div>
+            <%= profile.events.first.date %>
+          </div>
+          <div>
+            <%= profile.events.last.date %>
+          </div>
+        </div>
+        <div class="w-3/12">
+          <% album = profile&.albums.sample %>
+          <%= image_tag album.images.sample.variant(resize_to_limit: [100, 100]) if album&.images&.attached? %>
+        </div>
+        <div class="w-2/12">
+          <div>
+            <%= link_to profile_path(profile) do %>
+              <i class="fa-solid fa-circle-info fa-lg"></i>
+            <% end %>
+          </div>
+          <div>
+            <%= link_to edit_profile_path(profile) do %>
+              <i class="fa-solid fa-pen-to-square fa-lg"></i>
+            <% end %>
+          </div>
+          <div>
+            <%= link_to profile_path(profile), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } do %>
+              <i class="fa-solid fa-trash fa-lg"></i>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+<!---PC画面用のテーブル--->
   <table class="table table-fixed text-center hidden sm:table">
     <tr class="bg-white sticky top-0">
       <th class="w-1/12">連絡済み</th>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -26,7 +26,7 @@
       <th class="w-3/12">名前</th>
       <th class="w-2/12">誕生日</th>
       <th class="w-2/12">大切な日</th>
-      <th class="w-1/12"></th>
+      <th class="w-1/12 hidden sm:table-cell"></th>
       <th class="w-1/12"></th>
     </tr>
 
@@ -37,7 +37,7 @@
         <td class="text-left"><%= profile.name %></td>
         <td><%= profile.events.first.date %></td>
         <td><%= profile.events.last.date %></td>
-        <td>
+        <td class="hidden sm:table-cell">
           <% album = profile&.albums.sample %>
           <%= image_tag album.images.sample.variant(resize_to_limit: [100, 100]) if album&.images&.attached? %>
         </td>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -26,7 +26,7 @@
         <div class="w-1/12">
           <%= profile.contacted %>
         </div>
-        <div class="w-2/12">
+        <div class="w-2/12 flex items-center">
           <%= image_tag profile.avatar.variant(resize_to_limit: [100, 100]) if profile.avatar.attached? %>
         </div>
         <div class="w-6/12">

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -11,8 +11,8 @@
     <%= render "profiles/search", q: @q, url: profiles_path %>
   </div>
 
-  <div class="btn bg-peach text-black border-none shadow-lgl">
-    <%= link_to new_profile_path do %>
+  <div>
+    <%= link_to new_profile_path, class: "btn bg-peach text-black border-none shadow-lgl" do %>
       <button>連絡先を作成</button>
     <% end %>
   </div>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -22,7 +22,7 @@
 <!---スマホ画面用のブロック--->
   <div class="flex flex-col">
     <% @profiles.each do |profile| %>
-      <div class="flex h-24">
+      <div class="flex h-24 my-5">
         <div class="w-1/12">
           <%= profile.contacted %>
         </div>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -41,10 +41,6 @@
           </div>
         </div>
         <div class="w-3/12">
-          <% album = profile&.albums.sample %>
-          <%= image_tag album.images.sample.variant(resize_to_limit: [100, 100]) if album&.images&.attached? %>
-        </div>
-        <div class="w-2/12">
           <div>
             <%= link_to profile_path(profile) do %>
               <i class="fa-solid fa-circle-info fa-lg"></i>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -34,9 +34,11 @@
             <%= profile.name %>
           </div>
           <div>
+            <i class="fa-solid fa-cake-candles"></i>
             <%= profile.events.first.date %>
           </div>
           <div>
+            <i class="fa-solid fa-calendar-check"></i>
             <%= profile.events.last.date %>
           </div>
         </div>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -29,8 +29,8 @@
         <div class="w-2/12">
           <%= image_tag profile.avatar.variant(resize_to_limit: [100, 100]) if profile.avatar.attached? %>
         </div>
-        <div class="w-4/12">
-          <div>
+        <div class="w-6/12">
+          <div class="text-5xl">
             <%= profile.name %>
           </div>
           <div>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -20,7 +20,7 @@
 
 <div class="max-h-screen overflow-auto">
 <!---スマホ画面用のブロック--->
-  <div class="flex flex-col">
+  <div class="flex flex-col sm:hidden">
     <% @profiles.each do |profile| %>
       <div class="flex h-24 my-5">
         <div class="w-1/12 flex items-center justify-center">

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -30,7 +30,7 @@
           <%= image_tag profile.avatar.variant(resize_to_limit: [100, 100]) if profile.avatar.attached? %>
         </div>
         <div class="w-6/12">
-          <div class="text-5xl">
+          <div class="text-5xl h-12">
             <%= profile.name %>
           </div>
           <div>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -21,11 +21,11 @@
 <div class="max-h-screen overflow-auto">
   <table class="table table-fixed text-center">
     <tr class="bg-white sticky top-0">
-      <th class="w-1/12">連絡済み</th>
+      <th class="w-1/12 whitespace-nowrap">連絡済み</th>
       <th class="w-1/12"></th>
       <th class="w-3/12">名前</th>
       <th class="w-2/12">誕生日</th>
-      <th class="w-2/12">大切な日</th>
+      <th class="w-2/12 whitespace-nowrap">大切な日</th>
       <th class="w-1/12 hidden sm:table-cell"></th>
       <th class="w-1/12"></th>
     </tr>

--- a/app/views/shared/_before_login_footer.html.erb
+++ b/app/views/shared/_before_login_footer.html.erb
@@ -1,0 +1,43 @@
+<!---スマホ画面用のフッター--->
+<footer class="fixed bottom-0 bg-black w-full sm:hidden">
+  <div class="flex justify-center space-x-8 text-white my-4">
+    <div class="flex flex-col justify-center text-center">
+      <div>
+        <%= link_to introduction_path(1) do %>
+          <i class="fa-regular fa-message fa-lg"></i>
+        <% end %>
+      </div>
+      <div>AIメッセージ</div>
+    </div>
+    <div class="flex flex-col justify-center text-center">
+      <div>
+        <%= link_to profiles_path do %>
+          <i class="fa-regular fa-address-book fa-lg"></i>
+        <% end %>
+      </div>
+      <div>連絡帳</div>
+    </div>
+    <div class="flex flex-col justify-center text-center">
+      <%= link_to login_path do %>
+        <i class="fa-solid fa-arrow-right-to-bracket fa-lg"></i>
+      <% end %>
+      <div>ログイン</div>
+    </div>
+    <div class="flex flex-col justify-center text-center">
+      <%= link_to new_user_path do %>
+        <i class="fa-solid fa-user-plus fa-lg"></i>
+      <% end %>
+      <div>新規登録</div>
+    </div>
+  </div>
+</footer>
+
+
+<!---PC画面用のフッター--->
+<footer class="bottom-0 bg-opacity-20 bg-black w-full left-0 hidden sm:block">
+  <div class="flex justify-center space-x-8 text-white">
+    <%= link_to "利用規約", '#' %>
+    <%= link_to "プライバシーポリシー", '#' %>
+    <%= link_to "お問い合わせ", '#' %>
+  </div>
+</footer>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,44 @@
-<footer class="bottom-0 bg-opacity-20 bg-black w-full left-0">
+<!---スマホ画面用のフッター--->
+<footer class="bottom-0 bg-black w-full sm:hidden">
+  <div class="flex justify-center space-x-8 text-white my-4">
+    <div class="flex flex-col justify-center text-center">
+      <div>
+        <%= link_to introduction_path(1) do %>
+          <i class="fa-regular fa-message fa-lg"></i>
+        <% end %>
+      </div>
+      <div>AIメッセージ</div>
+    </div>
+    <div class="flex flex-col justify-center text-center">
+      <div>
+        <%= link_to profiles_path do %>
+          <i class="fa-regular fa-address-book fa-lg"></i>
+        <% end %>
+      </div>
+      <div>連絡帳</div>
+    </div>
+    <div class="flex flex-col justify-center text-center">
+      <div>
+        <%= link_to user_path(current_user) do %>
+          <i class="fa-regular fa-user fa-lg"></i>
+        <% end %>
+      </div>
+      <div>マイページ</div>
+    </div>
+    <div class="flex flex-col justify-center text-center">
+      <div>
+        <%= link_to logout_path, data: { turbo_method: :delete } do %>
+          <i class="fa-solid fa-arrow-right-from-bracket fa-lg"></i>
+        <% end %>
+      </div>
+      <div>ログアウト</div>
+    </div>
+  </div>
+</footer>
+
+
+<!---PC画面用のフッター--->
+<footer class="bottom-0 bg-opacity-20 bg-black w-full left-0 hidden sm:block">
   <div class="flex justify-center space-x-8 text-white">
     <%= link_to "利用規約", '#' %>
     <%= link_to "プライバシーポリシー", '#' %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,5 @@
 <!---スマホ画面用のフッター--->
-<footer class="bottom-0 bg-black w-full sm:hidden">
+<footer class="fixed bottom-0 bg-black w-full sm:hidden">
   <div class="flex justify-center space-x-8 text-white my-4">
     <div class="flex flex-col justify-center text-center">
       <div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,9 +1,11 @@
 <header class="sticky top-0 bg-opacity-20 bg-black w-full">
-  <nav class="flex justify-between container mx-auto items-center text-white">
-    <div class="text-3xl">
-      <%= link_to "Reconnect　～ともだちと再びつながるアプリ～", root_path %>
+  <nav class="flex justify-center sm:justify-between container mx-auto items-center text-white">
+    <div class="text-center whitespace-nowrap">
+      <%= link_to root_path do %>
+        <span class="text-3xl sm:text-4xl">Reconnect</span><span class="text-lg sm:text-3xl">～ともだちと再びつながるアプリ～</span>
+      <% end %>
     </div>
-    <div class="font-bold space-x-8">
+    <div class="font-bold space-x-8 hidden sm:block">
       <%= link_to "AIメッセージ作成", introduction_path(1) %>
       <%= link_to "連絡帳", profiles_path %>
       <%= link_to "マイページ", user_path(current_user)  %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="sticky top-0 bg-opacity-20 bg-black w-full">
+<header class="sticky sm:top-0 bg-opacity-20 bg-black w-full">
   <nav class="flex justify-center sm:justify-between container mx-auto items-center text-white">
     <div class="text-center whitespace-nowrap">
       <%= link_to root_path do %>


### PR DESCRIPTION
### 概要
ともだち帳　友達リストページのレスポンシブデザインを実装

---
### 背景・目的
スマホでのUI・UXの向上

---
### 内容
- [x] 検索フォームを横並びで表示
- [x] 連絡先をテーブル→ブロック要素で表示する
- [x] アルバム列を非表示
- [x] イベント表示を整列
- [x] スマホ用のフッターを作成（ログイン前・ログイン後共に）
- [x] スマホではヘッダーを上部に固定しない
---
### 対応しないこと
- [ ] 

---
### 補足
This PR close #222 