### PR TITLE
【デザイン】ともだち帳　プロフィール（詳細画面）レスポンシブ

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -19,7 +19,7 @@
               <div class="text-2xl tracking-widest">
                 <%= @profile.furigana %>
               </div>
-              <div class="text-8xl">
+              <div class="text-6xl sm:text-8xl">
                 <%= @profile.name %>
               </div>
             </div>
@@ -39,23 +39,23 @@
             <div>
               <div class="my-5 text-left">
                 <i class="fa-solid fa-phone fa-lg"></i>
-                <span class="text-2xl"><%= @profile.phone %></span>
+                <span class="text-xl sm:text-2xl"><%= @profile.phone %></span>
               </div>
               <div class="my-5 text-left">
                 <i class="fa-regular fa-envelope fa-lg"></i>
-                <span class="text-2xl"><%= @profile.email %></span>
+                <span class="text-xl sm:text-2xl"><%= @profile.email %></span>
               </div>
               <div class="my-5 text-left">
                 <i class="fa-solid fa-location-dot fa-lg"></i>
-                <span class="text-2xl"><%= @profile.address %></span>
+                <span class="text-xl sm:text-2xl"><%= @profile.address %></span>
               </div>
               <div class="my-5 text-left">
                 <i class="fa-solid fa-cake-candles fa-lg"></i>
-                <span class="text-2xl"><%= @profile.events.first.date %></span>
+                <span class="text-xl sm:text-2xl"><%= @profile.events.first.date %></span>
               </div>
               <div class="my-5 text-left">
                 <i class="fa-solid fa-calendar-check fa-lg"></i>
-                <span class="text-2xl"><%= @profile.events.last.date %></span>
+                <span class="text-xl sm:text-2xl"><%= @profile.events.last.date %></span>
               </div>
             </div>
           </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -14,7 +14,7 @@
           <% end %>
         </div>
         <div id ="profile_info" class="flex flex-col flex-grow items-left justify-center">
-          <div class="flex">
+          <div class="sm:flex">
             <div>
               <div class="text-2xl tracking-widest">
                 <%= @profile.furigana %>
@@ -23,7 +23,7 @@
                 <%= @profile.name %>
               </div>
             </div>
-            <div class="flex flex-col justify-end">
+            <div class="flex flex-col items-center sm:justify-end">
               <div>
                 <%= link_to edit_profile_path(@profile) do %>
                   <i class="fa-solid fa-pen-to-square fa-lg"></i>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -15,7 +15,7 @@
         </div>
         <div id ="profile_info" class="flex flex-col flex-grow items-left justify-center">
           <div class="sm:flex">
-            <div>
+            <div class="text-center">
               <div class="text-2xl tracking-widest">
                 <%= @profile.furigana %>
               </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,10 +2,10 @@
     <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
     <div class="drawer-content sm:flex justify-center">
       <!-- Page content here -->
-      <div role="tablist" class="tabs tabs-bordered sm:hidden">
-        <a role="tab" class="tab">Tab 1</a>
-        <a role="tab" class="tab tab-active">Tab 2</a>
-        <a role="tab" class="tab">Tab 3</a>
+      <div role="tablist" class="tabs tabs-bordered mt-3 sm:hidden">
+        <%= link_to "基本情報", profile_path(@profile), role: "tab", class: "tab #{"tab-active" if current_page?(profile_path(@profile))}" %>
+        <%= link_to "アルバム", profile_albums_path(@profile), role: "tab #{"tab-active" if current_page?(profile_path(@profile))}", class: "tab" %>
+        <%= link_to "通知設定", profile_events_path(@profile), role: "tab #{"tab-active" if current_page?(profile_path(@profile))}", class: "tab" %>
       </div>
       <div class="mt-8 sm:flex">
         <div id="avatar" class="flex justify-center sm:items-center sm:pr-10">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -7,13 +7,13 @@
         <a role="tab" class="tab tab-active">Tab 2</a>
         <a role="tab" class="tab">Tab 3</a>
       </div>
-      <div class="sm:flex">
+      <div class="mt-8 sm:flex">
         <div id="avatar" class="flex justify-center sm:items-center sm:pr-10">
           <% if @profile.avatar.attached? %>
             <%= image_tag @profile.avatar.variant(resize_to_limit: [200, 200]) %>
           <% end %>
         </div>
-        <div id ="profile_info" class="flex flex-col flex-grow items-left justify-center">
+        <div id ="profile_info" class="flex flex-col flex-grow items-left justify-center mt-5">
           <div class="sm:flex">
             <div class="text-center">
               <div class="text-2xl tracking-widest">
@@ -23,7 +23,7 @@
                 <%= @profile.name %>
               </div>
             </div>
-            <div class="flex flex-col items-center mt-2 sm:justify-end">
+            <div class="flex flex-col items-center mt-4 sm:justify-end">
               <div>
                 <%= link_to edit_profile_path(@profile) do %>
                   <i class="fa-solid fa-pen-to-square fa-lg"></i>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -23,7 +23,7 @@
                 <%= @profile.name %>
               </div>
             </div>
-            <div class="flex flex-col items-center sm:justify-end">
+            <div class="flex flex-col items-center mt-2 sm:justify-end">
               <div>
                 <%= link_to edit_profile_path(@profile) do %>
                   <i class="fa-solid fa-pen-to-square fa-lg"></i>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -35,26 +35,28 @@
             </div>
           </div>
 
-          <div>
-            <div class="my-5 pl-5">
-              <i class="fa-solid fa-phone fa-lg"></i>
-              <span class="text-2xl"><%= @profile.phone %></span>
-            </div>
-            <div class="my-5 pl-5">
-              <i class="fa-regular fa-envelope fa-lg"></i>
-              <span class="text-2xl"><%= @profile.email %></span>
-            </div>
-            <div class="my-5 pl-5">
-              <i class="fa-solid fa-location-dot fa-lg"></i>
-              <span class="text-2xl"><%= @profile.address %></span>
-            </div>
-            <div class="my-5 pl-5">
-              <i class="fa-solid fa-cake-candles fa-lg"></i>
-              <span class="text-2xl"><%= @profile.events.first.date %></span>
-            </div>
-            <div class="my-5 pl-5">
-              <i class="fa-solid fa-calendar-check fa-lg"></i>
-              <span class="text-2xl"><%= @profile.events.last.date %></span>
+          <div class="flex justify-center">
+            <div>
+              <div class="my-5 text-left">
+                <i class="fa-solid fa-phone fa-lg"></i>
+                <span class="text-2xl"><%= @profile.phone %></span>
+              </div>
+              <div class="my-5 text-left">
+                <i class="fa-regular fa-envelope fa-lg"></i>
+                <span class="text-2xl"><%= @profile.email %></span>
+              </div>
+              <div class="my-5 text-left">
+                <i class="fa-solid fa-location-dot fa-lg"></i>
+                <span class="text-2xl"><%= @profile.address %></span>
+              </div>
+              <div class="my-5 text-left">
+                <i class="fa-solid fa-cake-candles fa-lg"></i>
+                <span class="text-2xl"><%= @profile.events.first.date %></span>
+              </div>
+              <div class="my-5 text-left">
+                <i class="fa-solid fa-calendar-check fa-lg"></i>
+                <span class="text-2xl"><%= @profile.events.last.date %></span>
+              </div>
             </div>
           </div>
         </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,7 +1,12 @@
   <div class="drawer lg:drawer-open">
     <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
-    <div class="drawer-content flex justify-center">
+    <div class="drawer-content sm:flex justify-center">
       <!-- Page content here -->
+      <div role="tablist" class="tabs tabs-bordered sm:hidden">
+        <a role="tab" class="tab">Tab 1</a>
+        <a role="tab" class="tab tab-active">Tab 2</a>
+        <a role="tab" class="tab">Tab 3</a>
+      </div>
       <div class="flex">
         <div id="avatar" class="flex items-center pr-10">
           <% if @profile.avatar.attached? %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -8,7 +8,7 @@
         <a role="tab" class="tab">Tab 3</a>
       </div>
       <div class="sm:flex">
-        <div id="avatar" class="flex items-center pr-10">
+        <div id="avatar" class="flex justify-center sm:items-center sm:pr-10">
           <% if @profile.avatar.attached? %>
             <%= image_tag @profile.avatar.variant(resize_to_limit: [200, 200]) %>
           <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -7,7 +7,7 @@
         <a role="tab" class="tab tab-active">Tab 2</a>
         <a role="tab" class="tab">Tab 3</a>
       </div>
-      <div class="flex">
+      <div class="sm:flex">
         <div id="avatar" class="flex items-center pr-10">
           <% if @profile.avatar.attached? %>
             <%= image_tag @profile.avatar.variant(resize_to_limit: [200, 200]) %>


### PR DESCRIPTION
### 概要
ともだち帳　プロフィール（詳細画面）のレスポンシブデザインを実装する。

---
### 背景・目的
スマホユーザーのUI・UXを向上させる

---

### 内容
- [x]  サイドバーをsm以上で表示するように設定
- [x]  トップタブを表示
    - [x]  基本情報
    - [x]  アルバム
    - [x]  通知設定
- [x]  アバターをtopにもってくる
- [x] プロフィール情報を中央に配列

---
### 対応しないこと
- 

---
### 補足
This PR close #227 