### PR TITLE
Design/#228 profile form

### DIFF
--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -23,14 +23,14 @@
               <i class="fa-solid fa-cake-candles fa-sm"></i>
               <%= event_form.label :date, event.name, class: "block font-medium text-black mx-1" %>
             </div>
-            <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white border border-black" %>
+            <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white border border-black rounded" %>
             <%= event_form.hidden_field :name, value: event.name %>
           <% else %>
             <div class="flex mb-1 items-center">
               <i class="fa-solid fa-calendar-check fa-sm"></i>
               <%= event_form.text_field :name, placeholder: event.name, size: event.name.length, class: "block font-medium rounded pl-1 pr-7 mx-1 text-black bg-white border border-black " %>
             </div>
-            <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white border border-black" %>
+            <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white border border-black rounded" %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -36,23 +36,8 @@
     </div>
 
     <div class="mb-4">
-      <%= profile_form.label :line_name, 'LINEの名前', class: "block font-medium mb-1 text-orange-300" %>
-      <%= profile_form.text_field :line_name, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0" %>
-    </div>
-
-    <div class="mb-4">
-      <%= profile_form.label :birthplace, '出身地', class: "block font-medium mb-1 text-orange-300" %>
-      <%= profile_form.text_field :birthplace, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0" %>
-    </div>
-
-    <div class="mb-4">
       <%= profile_form.label :address, '住所', class: "block font-medium mb-1 text-orange-300" %>
       <%= profile_form.text_field :address, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0" %>
-    </div>
-
-    <div class="mb-4">
-      <%= profile_form.label :occupation, '職場', class: "block font-medium mb-1 text-orange-300" %>
-      <%= profile_form.text_field :occupation, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0" %>
     </div>
 
     <div class="mb-4">

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -19,33 +19,51 @@
       <% @profile.events.each do |event| %>
         <%= profile_form.fields_for :events, event do |event_form| %>
           <% if event.name == '誕生日' %>
-            <%= event_form.label :date, event.name, class: "block font-medium mb-1 text-black" %>
+            <div class="flex mb-1 items-center">
+              <i class="fa-solid fa-cake-candles fa-sm"></i>
+              <%= event_form.label :date, event.name, class: "block font-medium text-black mx-1" %>
+            </div>
             <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white border border-black" %>
             <%= event_form.hidden_field :name, value: event.name %>
           <% else %>
-            <%= event_form.text_field :name, placeholder: event.name, size: event.name.length, class: "block font-medium rounded pl-1 pr-7 mb-1 text-black bg-white border border-black" %>
+            <div class="flex mb-1 items-center">
+              <i class="fa-solid fa-calendar-check fa-sm"></i>
+              <%= event_form.text_field :name, placeholder: event.name, size: event.name.length, class: "block font-medium rounded pl-1 pr-7 mx-1 text-black bg-white border border-black " %>
+            </div>
             <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white border border-black" %>
           <% end %>
         <% end %>
       <% end %>
 
       <div class="mb-4">
-        <%= profile_form.label :phone, '電話番号', class: "block font-medium mb-1 text-black" %>
+        <div class="flex mb-1 items-center">
+          <i class="fa-solid fa-phone fa-sm"></i>
+          <%= profile_form.label :phone, '電話番号', class: "block font-medium text-black mx-1" %>
+        </div>
         <%= profile_form.text_field :phone, class: "w-full rounded p-2 bg-white border border-black" %>
       </div>
 
       <div class="mb-4">
-        <%= profile_form.label :email, 'メールアドレス', class: "block font-medium mb-1 text-black" %>
+        <div class="flex mb-1 items-center">
+          <i class="fa-regular fa-envelope fa-sm"></i>
+          <%= profile_form.label :email, 'メールアドレス', class: "block font-medium text-black mx-1" %>
+        </div>
         <%= profile_form.text_field :email, class: "w-full rounded p-2 bg-white border border-black" %>
       </div>
 
       <div class="mb-4">
-        <%= profile_form.label :address, '住所', class: "block font-medium mb-1 text-black" %>
+        <div class="flex mb-1 items-center">
+          <i class="fa-solid fa-location-dot fa-sm"></i>
+          <%= profile_form.label :address, '住所', class: "block font-medium text-black mx-1" %>
+        </div>
         <%= profile_form.text_field :address, class: "w-full rounded p-2 bg-white border border-black" %>
       </div>
 
       <div class="mb-4">
-        <%= profile_form.label :avatar, 'プロフィール画像', class: "block font-medium mb-1 text-black" %>
+        <div class="flex mb-1 items-center">
+          <i class="fa-regular fa-image fa-sm"></i>
+          <%= profile_form.label :avatar, 'プロフィール画像', class: "block font-medium text-black mx-1" %>
+        </div>
         <%= profile_form.file_field :avatar, class: "rounded p-2" %>
       </div>
 

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,52 +1,57 @@
-<div class="pt-20 pb-10 max-w-md mx-auto">
-  <%= form_with model: profile, data: { turbo: false } do |profile_form| %>
-    <%= render 'shared/error_messages', model: profile_form.object %>
+<div class="flex flex-col items-center">
+  <div>
+    <h1 class="text-2xl py-5">連絡先フォーム</h1>
+  </div>
+  <div>
+    <%= form_with model: profile, data: { turbo: false } do |profile_form| %>
+      <%= render 'shared/error_messages', model: profile_form.object %>
 
-    <div class="mb-4">
-      <%= profile_form.label :name, '名前', class: "block font-medium mb-1 text-black" %>
-      <%= profile_form.text_field :name, class: "w-full rounded p-2 bg-white border border-black" %>
-    </div>
+      <div class="mb-4">
+        <%= profile_form.label :name, '名前', class: "block font-medium mb-1 text-black" %>
+        <%= profile_form.text_field :name, class: "w-full rounded p-2 bg-white border border-black" %>
+      </div>
 
-    <div class="mb-4">
-      <%= profile_form.label :furigana, 'フリガナ', class: "block font-medium mb-1 text-black" %>
-      <%= profile_form.text_field :furigana, class: "w-full rounded p-2 bg-white border border-black" %>
-    </div>
+      <div class="mb-4">
+        <%= profile_form.label :furigana, 'フリガナ', class: "block font-medium mb-1 text-black" %>
+        <%= profile_form.text_field :furigana, class: "w-full rounded p-2 bg-white border border-black" %>
+      </div>
 
-    <% @profile.events.each do |event| %>
-      <%= profile_form.fields_for :events, event do |event_form| %>
-        <% if event.name == '誕生日' %>
-          <%= event_form.label :date, event.name, class: "block font-medium mb-1 text-black" %>
-          <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white border border-black" %>
-          <%= event_form.hidden_field :name, value: event.name %>
-        <% else %>
-          <%= event_form.text_field :name, placeholder: event.name, size: event.name.length, class: "block font-medium rounded pl-1 pr-7 mb-1 text-black bg-white border border-black" %>
-          <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white border border-black" %>
+      <% @profile.events.each do |event| %>
+        <%= profile_form.fields_for :events, event do |event_form| %>
+          <% if event.name == '誕生日' %>
+            <%= event_form.label :date, event.name, class: "block font-medium mb-1 text-black" %>
+            <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white border border-black" %>
+            <%= event_form.hidden_field :name, value: event.name %>
+          <% else %>
+            <%= event_form.text_field :name, placeholder: event.name, size: event.name.length, class: "block font-medium rounded pl-1 pr-7 mb-1 text-black bg-white border border-black" %>
+            <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white border border-black" %>
+          <% end %>
         <% end %>
       <% end %>
+
+      <div class="mb-4">
+        <%= profile_form.label :phone, '電話番号', class: "block font-medium mb-1 text-black" %>
+        <%= profile_form.text_field :phone, class: "w-full rounded p-2 bg-white border border-black" %>
+      </div>
+
+      <div class="mb-4">
+        <%= profile_form.label :email, 'メールアドレス', class: "block font-medium mb-1 text-black" %>
+        <%= profile_form.text_field :email, class: "w-full rounded p-2 bg-white border border-black" %>
+      </div>
+
+      <div class="mb-4">
+        <%= profile_form.label :address, '住所', class: "block font-medium mb-1 text-black" %>
+        <%= profile_form.text_field :address, class: "w-full rounded p-2 bg-white border border-black" %>
+      </div>
+
+      <div class="mb-4">
+        <%= profile_form.label :avatar, 'プロフィール画像', class: "block font-medium mb-1 text-black" %>
+        <%= profile_form.file_field :avatar, class: "rounded p-2" %>
+      </div>
+
+      <div class="flex justify-center">
+        <%= profile_form.submit '登録する', class: "btn bg-slate-300 text-black border-none shadow-2xl" %>
+      </div>
     <% end %>
-
-    <div class="mb-4">
-      <%= profile_form.label :phone, '電話番号', class: "block font-medium mb-1 text-black" %>
-      <%= profile_form.text_field :phone, class: "w-full rounded p-2 bg-white border border-black" %>
-    </div>
-
-    <div class="mb-4">
-      <%= profile_form.label :email, 'メールアドレス', class: "block font-medium mb-1 text-black" %>
-      <%= profile_form.text_field :email, class: "w-full rounded p-2 bg-white border border-black" %>
-    </div>
-
-    <div class="mb-4">
-      <%= profile_form.label :address, '住所', class: "block font-medium mb-1 text-black" %>
-      <%= profile_form.text_field :address, class: "w-full rounded p-2 bg-white border border-black" %>
-    </div>
-
-    <div class="mb-4">
-      <%= profile_form.label :avatar, 'プロフィール画像', class: "block font-medium mb-1 text-black" %>
-      <%= profile_form.file_field :avatar, class: "rounded p-2" %>
-    </div>
-
-    <div class="flex justify-center">
-      <%= profile_form.submit '登録する', class: "btn bg-slate-300 text-black border-none shadow-2xl" %>
-    </div>
-  <% end %>
+  </div>
 </div>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -4,45 +4,45 @@
 
     <div class="mb-4">
       <%= profile_form.label :name, '名前', class: "block font-medium mb-1 text-orange-300" %>
-      <%= profile_form.text_field :name, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0" %>
+      <%= profile_form.text_field :name, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0 bg-white" %>
     </div>
 
     <div class="mb-4">
       <%= profile_form.label :furigana, 'フリガナ', class: "block font-medium mb-1 text-orange-300" %>
-      <%= profile_form.text_field :furigana, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0" %>
+      <%= profile_form.text_field :furigana, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0 bg-white" %>
     </div>
 
     <% @profile.events.each do |event| %>
       <%= profile_form.fields_for :events, event do |event_form| %>
         <% if event.name == '誕生日' %>
           <%= event_form.label :date, event.name, class: "block font-medium mb-1 text-orange-300" %>
-          <%= event_form.date_field :date, class: "block font-medium mb-5" %>
+          <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white" %>
           <%= event_form.hidden_field :name, value: event.name %>
         <% else %>
-          <%= event_form.text_field :name, placeholder: event.name, class: "block font-medium mb-1 border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0 mb-1 text-orange-300" %>
-          <%= event_form.date_field :date, class: "block font-medium mb-5" %>
+          <%= event_form.text_field :name, placeholder: event.name, class: "block font-medium mb-1 border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0 mb-1 text-orange-300 bg-white" %>
+          <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white" %>
         <% end %>
       <% end %>
     <% end %>
 
     <div class="mb-4">
       <%= profile_form.label :phone, '電話番号', class: "block font-medium mb-1 text-orange-300" %>
-      <%= profile_form.text_field :phone, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0" %>
+      <%= profile_form.text_field :phone, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0 bg-white" %>
     </div>
 
     <div class="mb-4">
       <%= profile_form.label :email, 'メールアドレス', class: "block font-medium mb-1 text-orange-300" %>
-      <%= profile_form.text_field :email, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0" %>
+      <%= profile_form.text_field :email, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0 bg-white" %>
     </div>
 
     <div class="mb-4">
       <%= profile_form.label :address, '住所', class: "block font-medium mb-1 text-orange-300" %>
-      <%= profile_form.text_field :address, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0" %>
+      <%= profile_form.text_field :address, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0 bg-white" %>
     </div>
 
     <div class="mb-4">
       <%= profile_form.label :avatar, 'プロフィール画像', class: "block font-medium mb-1 text-orange-300" %>
-      <%= profile_form.file_field :avatar, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0" %>
+      <%= profile_form.file_field :avatar, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0 bg-white" %>
     </div>
 
     <div class="flex justify-center">

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -3,45 +3,45 @@
     <%= render 'shared/error_messages', model: profile_form.object %>
 
     <div class="mb-4">
-      <%= profile_form.label :name, '名前', class: "block font-medium mb-1 text-orange-300" %>
+      <%= profile_form.label :name, '名前', class: "block font-medium mb-1 text-black" %>
       <%= profile_form.text_field :name, class: "w-full rounded p-2 bg-white border border-black" %>
     </div>
 
     <div class="mb-4">
-      <%= profile_form.label :furigana, 'フリガナ', class: "block font-medium mb-1 text-orange-300" %>
+      <%= profile_form.label :furigana, 'フリガナ', class: "block font-medium mb-1 text-black" %>
       <%= profile_form.text_field :furigana, class: "w-full rounded p-2 bg-white border border-black" %>
     </div>
 
     <% @profile.events.each do |event| %>
       <%= profile_form.fields_for :events, event do |event_form| %>
         <% if event.name == '誕生日' %>
-          <%= event_form.label :date, event.name, class: "block font-medium mb-1 text-orange-300" %>
+          <%= event_form.label :date, event.name, class: "block font-medium mb-1 text-black" %>
           <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white border border-black" %>
           <%= event_form.hidden_field :name, value: event.name %>
         <% else %>
-          <%= event_form.text_field :name, placeholder: event.name, class: "block font-medium mb-1 rounded p-2 mb-1 text-orange-300 bg-white border border-black" %>
+          <%= event_form.text_field :name, placeholder: event.name, class: "block font-medium mb-1 rounded p-2 mb-1 text-black bg-white border border-black" %>
           <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white border border-black" %>
         <% end %>
       <% end %>
     <% end %>
 
     <div class="mb-4">
-      <%= profile_form.label :phone, '電話番号', class: "block font-medium mb-1 text-orange-300" %>
+      <%= profile_form.label :phone, '電話番号', class: "block font-medium mb-1 text-black" %>
       <%= profile_form.text_field :phone, class: "w-full rounded p-2 bg-white border border-black" %>
     </div>
 
     <div class="mb-4">
-      <%= profile_form.label :email, 'メールアドレス', class: "block font-medium mb-1 text-orange-300" %>
+      <%= profile_form.label :email, 'メールアドレス', class: "block font-medium mb-1 text-black" %>
       <%= profile_form.text_field :email, class: "w-full rounded p-2 bg-white border border-black" %>
     </div>
 
     <div class="mb-4">
-      <%= profile_form.label :address, '住所', class: "block font-medium mb-1 text-orange-300" %>
+      <%= profile_form.label :address, '住所', class: "block font-medium mb-1 text-black" %>
       <%= profile_form.text_field :address, class: "w-full rounded p-2 bg-white border border-black" %>
     </div>
 
     <div class="mb-4">
-      <%= profile_form.label :avatar, 'プロフィール画像', class: "block font-medium mb-1 text-orange-300" %>
+      <%= profile_form.label :avatar, 'プロフィール画像', class: "block font-medium mb-1 text-black" %>
       <%= profile_form.file_field :avatar, class: "w-full rounded p-2 bg-white border border-black" %>
     </div>
 

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -19,7 +19,7 @@
           <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white border border-black" %>
           <%= event_form.hidden_field :name, value: event.name %>
         <% else %>
-          <%= event_form.text_field :name, placeholder: event.name, class: "block font-medium mb-1 rounded p-2 mb-1 text-black bg-white border border-black" %>
+          <%= event_form.text_field :name, placeholder: event.name, size: event.name.length, class: "block font-medium rounded pl-1 pr-7 mb-1 text-black bg-white border border-black" %>
           <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white border border-black" %>
         <% end %>
       <% end %>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -42,7 +42,7 @@
 
     <div class="mb-4">
       <%= profile_form.label :avatar, 'プロフィール画像', class: "block font-medium mb-1 text-black" %>
-      <%= profile_form.file_field :avatar, class: "w-full rounded p-2 bg-white border border-black" %>
+      <%= profile_form.file_field :avatar, class: "rounded p-2" %>
     </div>
 
     <div class="flex justify-center">

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="flex flex-col items-center">
   <div>
-    <h1 class="text-2xl py-5">連絡先フォーム</h1>
+    <h1 class="text-2xl font-bold py-5">連絡先フォーム</h1>
   </div>
   <div>
     <%= form_with model: profile, data: { turbo: false } do |profile_form| %>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -4,45 +4,45 @@
 
     <div class="mb-4">
       <%= profile_form.label :name, '名前', class: "block font-medium mb-1 text-orange-300" %>
-      <%= profile_form.text_field :name, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0 bg-white" %>
+      <%= profile_form.text_field :name, class: "w-full rounded p-2 bg-white border border-black" %>
     </div>
 
     <div class="mb-4">
       <%= profile_form.label :furigana, 'フリガナ', class: "block font-medium mb-1 text-orange-300" %>
-      <%= profile_form.text_field :furigana, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0 bg-white" %>
+      <%= profile_form.text_field :furigana, class: "w-full rounded p-2 bg-white border border-black" %>
     </div>
 
     <% @profile.events.each do |event| %>
       <%= profile_form.fields_for :events, event do |event_form| %>
         <% if event.name == '誕生日' %>
           <%= event_form.label :date, event.name, class: "block font-medium mb-1 text-orange-300" %>
-          <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white" %>
+          <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white border border-black" %>
           <%= event_form.hidden_field :name, value: event.name %>
         <% else %>
-          <%= event_form.text_field :name, placeholder: event.name, class: "block font-medium mb-1 border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0 mb-1 text-orange-300 bg-white" %>
-          <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white" %>
+          <%= event_form.text_field :name, placeholder: event.name, class: "block font-medium mb-1 rounded p-2 mb-1 text-orange-300 bg-white border border-black" %>
+          <%= event_form.date_field :date, class: "block font-medium mb-5 bg-white border border-black" %>
         <% end %>
       <% end %>
     <% end %>
 
     <div class="mb-4">
       <%= profile_form.label :phone, '電話番号', class: "block font-medium mb-1 text-orange-300" %>
-      <%= profile_form.text_field :phone, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0 bg-white" %>
+      <%= profile_form.text_field :phone, class: "w-full rounded p-2 bg-white border border-black" %>
     </div>
 
     <div class="mb-4">
       <%= profile_form.label :email, 'メールアドレス', class: "block font-medium mb-1 text-orange-300" %>
-      <%= profile_form.text_field :email, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0 bg-white" %>
+      <%= profile_form.text_field :email, class: "w-full rounded p-2 bg-white border border-black" %>
     </div>
 
     <div class="mb-4">
       <%= profile_form.label :address, '住所', class: "block font-medium mb-1 text-orange-300" %>
-      <%= profile_form.text_field :address, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0 bg-white" %>
+      <%= profile_form.text_field :address, class: "w-full rounded p-2 bg-white border border-black" %>
     </div>
 
     <div class="mb-4">
       <%= profile_form.label :avatar, 'プロフィール画像', class: "block font-medium mb-1 text-orange-300" %>
-      <%= profile_form.file_field :avatar, class: "w-full border-gray-300 rounded p-2 focus:border-blue-300 focus:ring-0 bg-white" %>
+      <%= profile_form.file_field :avatar, class: "w-full rounded p-2 bg-white border border-black" %>
     </div>
 
     <div class="flex justify-center">


### PR DESCRIPTION
### 概要
プロフィール　新規作成・編集画面のデザインを実装する（PC画面）

---
### 背景・目的
PCユーザーに対しての、UI・UXを向上させる

---
### 内容
- [x] フォームのタイトルを付ける（「連絡先フォーム」）
- [x] タイトルは中央揃えにする
- [x] フォームのラベルにアイコンをつける
- [x] フォームの背景書を白にする
- [x] フォームの文字色を黒にする
- [x] 日付フィールドのボーダーを丸くする

---
### 対応しないこと
- 

---
### 補足
This PR close #228 