### PR TITLE
Design/#131 albums list

### DIFF
--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -4,9 +4,10 @@
     <!-- Page content here -->
     <table class="table table-fixed text-center mt-2">
       <tr>
-        <th>日付</th>
-        <th>タイトル</th>
-        <th>サムネイル</th>
+        <th class="w-2/12">日付</th>
+        <th class="w-3/12">タイトル</th>
+        <th class="w-3/12">サムネイル</th>
+        <th class="w-2/12"></th>
       </tr>
       <% @albums.each do |album| %>
         <tr>

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -14,7 +14,7 @@
           <tr>
             <td class="h-32"><%= album.date %></td>
             <td class="h-32"><%= album.title %></td>
-            <td class="h-32" class="flex justify-center">
+            <td class="h-32">
               <% if album.images.attached? %>
                 <% album.images.each do |image| %>
                   <%= image_tag image.variant(resize_to_limit: [100, 100]) %>

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -12,7 +12,7 @@
         <tr>
           <td><%= album.date %></td>
           <td><%= album.title %></td>
-          <td>
+          <td class="flex justify-center">
             <% if album.images.attached? %>
               <% album.images.each do |image| %>
                 <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
@@ -20,15 +20,17 @@
             <% end %>
           </td>
           <td>
-            <%= link_to profile_album_path(@profile, album) do %>
-              <button class="btn bg-slate-300 text-black border-none shadow-2xl">詳細</button>
-            <% end %>
-            <%= link_to edit_profile_album_path(@profile, album) do %>
-              <button class="btn bg-slate-300 text-black border-none shadow-2xl">編集</button>
-            <% end %>
-            <%= link_to profile_album_path(@profile, album), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
-              <button class="btn bg-slate-300 text-black border-none shadow-2xl">削除</button>
-            <% end %>
+            <div class="flex justify-around">
+              <%= link_to profile_album_path(@profile, album) do %>
+                <i class="fa-solid fa-circle-info fa-lg"></i>
+              <% end %>
+              <%= link_to edit_profile_album_path(@profile, album) do %>
+                <i class="fa-solid fa-pen-to-square fa-lg"></i>
+              <% end %>
+              <%= link_to profile_album_path(@profile, album), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
+                <i class="fa-solid fa-trash fa-lg"></i>
+              <% end %>
+            </div>
           </td>
         </tr>
       <% end %>

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -37,6 +37,11 @@
           </tr>
         <% end %>
       </table>
+      <div class="flex justify-center my-4">
+        <%= link_to new_profile_album_path, class: "btn bg-peach text-black border-none shadow-lgl" do %>
+          <button>アルバムを作成</button>
+        <% end %>
+      </div>
     </div>
   </div>
   <div class="drawer-side">

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -1,31 +1,68 @@
-<table class="table bg-white text-black text-center mt-2">
-  <tr>
-    <th>日付</th>
-    <th>タイトル</th>
-    <th>写真</th>
-  </tr>
-  <% @albums.each do |album| %>
-    <tr>
-      <td><%= album.date %></td>
-      <td><%= album.title %></td>
-      <td>
-        <% if album.images.attached? %>
-          <% album.images.each do |image| %>
-            <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
-          <% end %>
+<div class="drawer lg:drawer-open">
+  <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
+  <div class="drawer-content sm:flex">
+    <!-- Page content here -->
+    <table class="table table-fixed text-center mt-2">
+      <tr>
+        <th>日付</th>
+        <th>タイトル</th>
+        <th>サムネイル</th>
+      </tr>
+      <% @albums.each do |album| %>
+        <tr>
+          <td><%= album.date %></td>
+          <td><%= album.title %></td>
+          <td>
+            <% if album.images.attached? %>
+              <% album.images.each do |image| %>
+                <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
+              <% end %>
+            <% end %>
+          </td>
+          <td>
+            <%= link_to profile_album_path(@profile, album) do %>
+              <button class="btn bg-slate-300 text-black border-none shadow-2xl">詳細</button>
+            <% end %>
+            <%= link_to edit_profile_album_path(@profile, album) do %>
+              <button class="btn bg-slate-300 text-black border-none shadow-2xl">編集</button>
+            <% end %>
+            <%= link_to profile_album_path(@profile, album), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
+              <button class="btn bg-slate-300 text-black border-none shadow-2xl">削除</button>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+  <div class="drawer-side">
+    <ul class="menu bg-base-200 text-base-content min-h-full w-80 p-4 text-lg justify-center items-center text-3xl">
+      <!-- Sidebar content here -->
+      <li class="m-3"><%= link_to "基本情報", profile_path(@profile) %></li>
+      <li class="m-3"><%= link_to "アルバム", profile_albums_path(@profile) %></li>
+      <li class="m-3"><%= link_to "通知設定", profile_events_path(@profile) %></li>
+      <li class="m-3"><%= link_to profiles_path do %>
+        <i class="fa-solid fa-backward"></i>連絡先一覧
         <% end %>
-      </td>
-      <td>
-        <%= link_to profile_album_path(@profile, album) do %>
-          <button class="btn bg-slate-300 text-black border-none shadow-2xl">詳細</button>
-        <% end %>
-        <%= link_to edit_profile_album_path(@profile, album) do %>
-          <button class="btn bg-slate-300 text-black border-none shadow-2xl">編集</button>
-        <% end %>
-        <%= link_to profile_album_path(@profile, album), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
-          <button class="btn bg-slate-300 text-black border-none shadow-2xl">削除</button>
-        <% end %>
-      </td>
-    </tr>
-  <% end %>
-</table>
+      </li>
+    </ul>
+  </div>
+</div>
+
+
+<!---
+    <div class="grid grid-cols-4 gap-4 place-items-center w-full">
+      <% @albums.each do |album| %>
+        <div class="card bg-base-100 w-full shadow-xl">
+          <figure>
+            <% if album.images.attached? %>
+              <%= image_tag album.images.first.variant(resize_to_limit: [100, 100]) %>
+            <% end %>
+          </figure>
+          <div class="card-body">
+            <h2 class="card-title"><%= album.title%></h2>
+            <p><%= album.date %></p>
+          </div>
+        </div>
+      <% end %>
+    </div>
+--->

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -2,40 +2,42 @@
   <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
   <div class="drawer-content sm:flex">
     <!-- Page content here -->
-    <table class="table table-fixed text-center mt-2">
-      <tr>
-        <th class="w-2/12">日付</th>
-        <th class="w-3/12">タイトル</th>
-        <th class="w-3/12">サムネイル</th>
-        <th class="w-2/12"></th>
-      </tr>
-      <% @albums.each do |album| %>
+    <div class="max-h-screen overflow-auto">
+      <table class="table table-fixed text-center mt-2">
         <tr>
-          <td><%= album.date %></td>
-          <td><%= album.title %></td>
-          <td class="flex justify-center">
-            <% if album.images.attached? %>
-              <% album.images.each do |image| %>
-                <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
-              <% end %>
-            <% end %>
-          </td>
-          <td>
-            <div class="flex justify-around">
-              <%= link_to profile_album_path(@profile, album) do %>
-                <i class="fa-solid fa-circle-info fa-lg"></i>
-              <% end %>
-              <%= link_to edit_profile_album_path(@profile, album) do %>
-                <i class="fa-solid fa-pen-to-square fa-lg"></i>
-              <% end %>
-              <%= link_to profile_album_path(@profile, album), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
-                <i class="fa-solid fa-trash fa-lg"></i>
-              <% end %>
-            </div>
-          </td>
+          <th class="w-2/12">日付</th>
+          <th class="w-3/12">タイトル</th>
+          <th class="w-3/12">サムネイル</th>
+          <th class="w-2/12"></th>
         </tr>
-      <% end %>
-    </table>
+        <% @albums.each do |album| %>
+          <tr>
+            <td class="h-32"><%= album.date %></td>
+            <td class="h-32"><%= album.title %></td>
+            <td class="h-32" class="flex justify-center">
+              <% if album.images.attached? %>
+                <% album.images.each do |image| %>
+                  <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
+                <% end %>
+              <% end %>
+            </td>
+            <td class="h-32">
+              <div class="flex justify-around">
+                <%= link_to profile_album_path(@profile, album) do %>
+                  <i class="fa-solid fa-circle-info fa-lg"></i>
+                <% end %>
+                <%= link_to edit_profile_album_path(@profile, album) do %>
+                  <i class="fa-solid fa-pen-to-square fa-lg"></i>
+                <% end %>
+                <%= link_to profile_album_path(@profile, album), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
+                  <i class="fa-solid fa-trash fa-lg"></i>
+                <% end %>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+    </div>
   </div>
   <div class="drawer-side">
     <ul class="menu bg-base-200 text-base-content min-h-full w-80 p-4 text-lg justify-center items-center text-3xl">


### PR DESCRIPTION
### 概要
ともだち帳　友達詳細　アルバムページのデザインブラッシュアップ

---
### 背景・目的
PCユーザーのUI・UXの向上

---
### 内容
- [x] 「アルバムを作成」ボタンを設置（new_profile_album_pathのリンクをつける）
- [x] 詳細、編集、削除ボタンをアイコンに変更
- [x] 行の高さをアイコン（100px, 100px）に合わせて固定
- [x] テーブルの最大高さはスクリーンの高さとし、それ以上行がある場合はスクロールバーを表示させる
- [x] テーブルをdrawerの中に設置


---
### 対応しないこと
- [ ] 

---
### 補足
This PR close #131 