### PR TITLE
【デザイン】ともだち帳　アルバム　レイアウト

### DIFF
--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -1,8 +1,6 @@
-<div class="drawer lg:drawer-open">
-  <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
-  <div class="drawer-content sm:flex">
-    <!-- Page content here -->
-    <div class="max-h-screen overflow-auto">
+<div class="drawer lg:drawer-open h-full">
+  <div class="drawer-content bg-white flex flex-col sm:flex h-full">
+    <div>
       <table class="table table-fixed text-center mt-2">
         <tr>
           <th class="w-2/12">日付</th>
@@ -37,16 +35,15 @@
           </tr>
         <% end %>
       </table>
-      <div class="flex justify-center my-4">
-        <%= link_to new_profile_album_path, class: "btn bg-peach text-black border-none shadow-lgl" do %>
-          <button>アルバムを作成</button>
-        <% end %>
-      </div>
+    </div>
+    <div class="flex justify-center my-4">
+      <%= link_to new_profile_album_path, class: "btn bg-peach text-black border-none shadow-lgl" do %>
+        <button>アルバムを作成</button>
+      <% end %>
     </div>
   </div>
-  <div class="drawer-side">
+  <div class="drawer-side h-full">
     <ul class="menu bg-base-200 text-base-content min-h-full w-80 p-4 text-lg justify-center items-center text-3xl">
-      <!-- Sidebar content here -->
       <li class="m-3"><%= link_to "基本情報", profile_path(@profile) %></li>
       <li class="m-3"><%= link_to "アルバム", profile_albums_path(@profile) %></li>
       <li class="m-3"><%= link_to "通知設定", profile_events_path(@profile) %></li>
@@ -56,6 +53,7 @@
       </li>
     </ul>
   </div>
+  <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
 </div>
 
 

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -13,12 +13,8 @@
           <tr>
             <td class="h-32"><%= album.date %></td>
             <td class="h-32"><%= album.title %></td>
-            <td class="h-32">
-              <% if album.images.attached? %>
-                <% album.images.each do |image| %>
-                  <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
-                <% end %>
-              <% end %>
+            <td class="h-32 flex justify-center">
+              <%= image_tag album.images.first.variant(resize_to_limit: [100, 100]) if album.images.attached? %>
             </td>
             <td class="h-32">
               <div class="flex justify-around">

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -1,4 +1,5 @@
 <div class="drawer lg:drawer-open h-full">
+  <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
   <div class="drawer-content bg-white flex flex-col sm:flex h-full">
     <div>
       <table class="table table-fixed text-center mt-2">
@@ -53,7 +54,6 @@
       </li>
     </ul>
   </div>
-  <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
 </div>
 
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <script src="https://kit.fontawesome.com/ba69a80073.js" crossorigin="anonymous" defer></script>
   </head>
 
-  <body class="flex flex-col min-h-screen bg-white text-black">
+  <body class="flex flex-col h-screen bg-white text-black">
     <% if logged_in? %>
       <%= render 'shared/header' %>
     <% else %>

--- a/app/views/shared/_before_login_footer.html.erb
+++ b/app/views/shared/_before_login_footer.html.erb
@@ -1,5 +1,5 @@
 <!---スマホ画面用のフッター--->
-<footer class="fixed bottom-0 bg-black w-full sm:hidden">
+<footer class="fixed bottom-0 h-20 bg-black w-full sm:hidden">
   <div class="flex justify-center space-x-8 text-white my-4">
     <div class="flex flex-col justify-center text-center">
       <div>
@@ -34,7 +34,7 @@
 
 
 <!---PC画面用のフッター--->
-<footer class="bottom-0 bg-opacity-20 bg-black w-full left-0 hidden sm:block">
+<footer class="bottom-0 bg-opacity-20 bg-black w-full left-0 hidden sm:block h-6">
   <div class="flex justify-center space-x-8 text-white">
     <%= link_to "利用規約", '#' %>
     <%= link_to "プライバシーポリシー", '#' %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,4 +1,4 @@
-<header class="sticky top-0 bg-opacity-20 bg-black w-full">
+<header class="sticky top-0 bg-opacity-20 bg-black w-full h-11">
   <nav class="flex justify-between container mx-auto items-center text-white">
     <div class="text-3xl">
       <%= link_to "Reconnect　～ともだちと再びつながるアプリ～", root_path %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,5 @@
 <!---スマホ画面用のフッター--->
-<footer class="fixed bottom-0 bg-black w-full sm:hidden">
+<footer class="fixed bottom-0 h-20 bg-black w-full sm:hidden">
   <div class="flex justify-center space-x-8 text-white my-4">
     <div class="flex flex-col justify-center text-center">
       <div>
@@ -38,7 +38,7 @@
 
 
 <!---PC画面用のフッター--->
-<footer class="bottom-0 bg-opacity-20 bg-black w-full left-0 hidden sm:block">
+<footer class="bottom-0 bg-opacity-20 bg-black w-full left-0 hidden sm:block h-6">
   <div class="flex justify-center space-x-8 text-white">
     <%= link_to "利用規約", '#' %>
     <%= link_to "プライバシーポリシー", '#' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="sticky sm:top-0 bg-opacity-20 bg-black w-full">
+<header class="sticky sm:top-0 bg-opacity-20 bg-black w-full h-11">
   <nav class="flex justify-center sm:justify-between container mx-auto items-center text-white">
     <div class="text-center whitespace-nowrap">
       <%= link_to root_path do %>


### PR DESCRIPTION
### 概要
ともだち帳　アルバムのレイアウトを追加で調整する

---
### 背景・目的
UIの改善

---

### 内容
- [x] サムネイルをアルバムに保存されている1枚目とする
- [x] サムネイルを列の中央に配置
- [x] ヘッダーの高さを固定
- [x] フッターの高さを固定
- [x] Bodyタグの高さを固定

---
### 対応しないこと
- 

---
### 補足
This PR close #230 