### PR TITLE
【デザイン】ともだち帳　通知設定

### DIFF
--- a/app/views/events/_notification_off.html.erb
+++ b/app/views/events/_notification_off.html.erb
@@ -1,4 +1,4 @@
-<div class="pt-40 max-w-md mx-auto text-white text-2xl">
+<div class="pt-40 max-w-md mx-auto text-black text-2xl">
   <%= form_with model: @form, url: update_all_profile_events_path, method: :patch, data: { turbo: false } do |f| %>
     <fieldset disabled="disabled">
       <%= render 'shared/error_messages', model: f.object %>

--- a/app/views/events/_notification_off.html.erb
+++ b/app/views/events/_notification_off.html.erb
@@ -28,9 +28,9 @@
     </fieldset>
   <% end %>
 </div>
-<div class="flex justify-center mt-4">
+<div class="flex justify-center mt-10 text-xl">
   <div class="text-center">
     <p>※マイページの通知設定がOFFになっているため、変更できません</p>
-    <p>マイページは<%= link_to "こちら", edit_user_path(@profile.user) %></p>
+    マイページは<%= link_to "こちら", edit_user_path(@profile.user), class: "underline underline-offset-1" %>
   </div>
 </div>

--- a/app/views/events/_notification_off.html.erb
+++ b/app/views/events/_notification_off.html.erb
@@ -28,7 +28,7 @@
     </fieldset>
   <% end %>
 </div>
-<div class="flex justify-center mt-10 text-xl">
+<div class="flex justify-center mt-10 text-sm sm:text-xl">
   <div class="text-center">
     <p>※マイページの通知設定がOFFになっているため、変更できません</p>
     マイページは<%= link_to "こちら", edit_user_path(@profile.user), class: "underline underline-offset-1" %>

--- a/app/views/events/_notification_off.html.erb
+++ b/app/views/events/_notification_off.html.erb
@@ -28,5 +28,9 @@
     </fieldset>
   <% end %>
 </div>
-※マイページの通知設定がOFFになっているため、変更できません
-マイページは<%= link_to "こちら", edit_user_path(@profile.user) %>
+<div class="flex justify-center mt-4">
+  <div class="text-center">
+    <p>※マイページの通知設定がOFFになっているため、変更できません</p>
+    <p>マイページは<%= link_to "こちら", edit_user_path(@profile.user) %></p>
+  </div>
+</div>

--- a/app/views/events/_notification_on.html.erb
+++ b/app/views/events/_notification_on.html.erb
@@ -1,4 +1,4 @@
-<div class="pt-40 max-w-md mx-auto text-white text-2xl">
+<div class="pt-40 max-w-md mx-auto text-2xl">
   <%= form_with model: @form, url: update_all_profile_events_path, method: :patch, data: { turbo: false } do |f| %>
     <%= render 'shared/error_messages', model: f.object %>
 
@@ -7,11 +7,11 @@
         <div class="col-span-1">
           <%= "#{i.object.name}の" %>
         </div>
-        <div class="col-span-1">
-          <%= i.select :notification_timing, [0,1,3,7,14,30,60], selected: i.object.notification_timing, class: "text-black w-full" %>日前に、
+        <div class="col-span-1 text-white">
+          <%= i.select :notification_timing, [0,1,3,7,14,30,60], selected: i.object.notification_timing %><span class="text-black">日前に、</span>
         </div>
-        <div class="col-span-1 flex items-center">
-          通知
+        <div class="col-span-1 flex items-center text-white">
+          <span class="text-black">通知</span>
         <%= i.select :notification_enabled, [["する", "on"], ["しない", "off"]] %>
         </div>
         <div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,16 +1,30 @@
-<% if @profile.user.notification_enabled == "off" %>
-  <%= render "notification_off" %>
-<% else %>
-  <%= render "notification_on" %>
-<% end %>
-
-
-<div class="flex flex-col items-center mt-10 text-xl">
-  <p>※通知機能を使うためには、LINEの友達登録が必要です。</p>
-  <div>
-    友達登録は
-    <%= link_to line_qr_code_path, class:"underline underline-offset-1"	do %>
-      こちらから
+<div class="drawer lg:drawer-open h-full">
+  <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
+  <div class="drawer-content bg-white flex flex-col sm:flex h-full">
+    <% if @profile.user.notification_enabled == "off" %>
+      <%= render "notification_off" %>
+    <% else %>
+      <%= render "notification_on" %>
     <% end %>
+    <div class="flex flex-col items-center mt-10 text-xl">
+      <p>※通知機能を使うためには、LINEの友達登録が必要です。</p>
+      <div>
+        友達登録は
+        <%= link_to line_qr_code_path, class:"underline underline-offset-1"	do %>
+          こちらから
+        <% end %>
+      </div>
+    </div>
+  </div>
+  <div class="drawer-side h-full">
+    <ul class="menu bg-base-200 text-base-content min-h-full w-80 p-4 text-lg justify-center items-center text-3xl">
+      <li class="m-3"><%= link_to "基本情報", profile_path(@profile) %></li>
+      <li class="m-3"><%= link_to "アルバム", profile_albums_path(@profile) %></li>
+      <li class="m-3"><%= link_to "通知設定", profile_events_path(@profile) %></li>
+      <li class="m-3"><%= link_to profiles_path do %>
+        <i class="fa-solid fa-backward"></i>連絡先一覧
+        <% end %>
+      </li>
+    </ul>
   </div>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -10,7 +10,7 @@
     <% else %>
       <%= render "notification_on" %>
     <% end %>
-    <div class="flex flex-col items-center mt-10 text-xl">
+    <div class="flex flex-col items-center mt-10 sm:text-xl text-sm">
       <p>※通知機能を使うためには、LINEの友達登録が必要です。</p>
       <div>
         友達登録は

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,6 +1,10 @@
 <div class="drawer lg:drawer-open h-full">
   <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
   <div class="drawer-content bg-white flex flex-col sm:flex h-full">
+    <div class="flex items-center mt-2 ml-2 p-3">
+      <%= image_tag @profile.avatar.variant(resize_to_limit: [50, 50]) if @profile.avatar.attached? %>
+      <p class="text-lg"><%= @profile.name%></p>
+    </div>
     <% if @profile.user.notification_enabled == "off" %>
       <%= render "notification_off" %>
     <% else %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -22,10 +22,10 @@
   </div>
   <div class="drawer-side h-full">
     <ul class="menu bg-base-200 text-base-content min-h-full w-80 p-4 text-lg justify-center items-center text-3xl">
-      <li class="m-3"><%= link_to "基本情報", profile_path(@profile) %></li>
-      <li class="m-3"><%= link_to "アルバム", profile_albums_path(@profile) %></li>
-      <li class="m-3"><%= link_to "通知設定", profile_events_path(@profile) %></li>
-      <li class="m-3"><%= link_to profiles_path do %>
+      <li class="m-3"><%= link_to "基本情報", profile_path(@profile), class: (current_page?(profile_path(@profile)) ? "text-red-400 underline underline-offset-8" : "") %></li>
+      <li class="m-3"><%= link_to "アルバム", profile_albums_path(@profile), class: (current_page?(profile_albums_path(@profile)) ? "text-red-400 underline underline-offset-8" : "") %></li>
+      <li class="m-3"><%= link_to "通知設定", profile_events_path(@profile), class: (current_page?(profile_events_path(@profile)) ? "text-red-400 underline underline-offset-8" : "") %></li>
+      <li class="m-3"><%= link_to profiles_path, class: (current_page?(profiles_path) ? "text-red-400 underline underline-offset-8" : "") do %>
         <i class="fa-solid fa-backward"></i>連絡先一覧
         <% end %>
       </li>


### PR DESCRIPTION
### 概要
ともだち帳　友達詳細　通知設定ページのデザインブラッシュアップ

---
### 背景・目的
UI・UXの向上

---
### 内容
- [x] スマホ画面では、フォントサイズを小さくする
- [x] drawerの設置
- [x] サイドバーのリンクが、現在のページと一致すれば、リンクを赤く表示させる
- [x] どの連絡先を開いているか分かるように、連絡先のアバターと名前を表示する
- [x] 各要素を中央揃えで配置

---
### 対応しないこと
- [ ] 

---
### 補足
This PR close #132 