### PR TITLE
【デザイン】AI提案ページ

### DIFF
--- a/app/views/introductions/show.html.erb
+++ b/app/views/introductions/show.html.erb
@@ -1,10 +1,10 @@
-<div class="flex flex-col justify-center min-h-screen">
-  <div class="mx-auto border-white border-2 rounded-md p-10 text-2xl">
+<div class="flex flex-col items-center">
+  <div class="text-2xl text-black border rounded-2xl border-black p-10 mt-20">
     <p>久しぶりに連絡を取り合いたい人を<br>
         １人思い浮かべてください・・・</p>
     <div class="text-center mt-5 flex justify-center">
       <%= link_to question_path(1) do %>
-        <button class="btn btn-lg bg-white text-black border-none shadow-2xl hover:bg-white">次へ</button>
+        <button class="btn bg-slate-300 text-black border-none shadow-2xl">次へ</button>
       <% end %>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
 
     <main class="flex-grow">
       <%= yield %>
-      <%= breadcrumbs separator: "&rsaquo;" %>
+      <%= breadcrumbs separator: "&rsaquo;", class: "breadcrumbs text-center mt-4" %>
     </main>
 
     <% if logged_in? %>

--- a/app/views/openai_api/show.html.erb
+++ b/app/views/openai_api/show.html.erb
@@ -6,7 +6,7 @@
     <%= form_with url: "#", local: true do |form| %>
       <div>
         <%= form.label :message, "メッセージを編集する", class: "block font-medium mb-1 text-black" %>
-        <%= form.text_area :message, value: @message, rows: 2, cols: 100, data: { clipboard_target: "source" }, class: "bg-white" %>
+        <%= form.text_area :message, value: @message, rows: 2, cols: 100, data: { clipboard_target: "source" }, class: "textarea bg-white bg-slate-100" %>
       </div>
     <% end %>
     <button type="button", data-action= "clipboard#copy", data-clipboard-target= "copy_button", class="btn bg-slate-300 text-black border-none shadow-2xl" >

--- a/app/views/openai_api/show.html.erb
+++ b/app/views/openai_api/show.html.erb
@@ -5,7 +5,7 @@
   <div id="edit_form" data-controller="clipboard", class="flex flex-col items-center" >
     <%= form_with url: "#", local: true do |form| %>
       <div>
-        <%= form.label :message, "メッセージを編集する" %><br>
+        <%= form.label :message, "メッセージを編集する", class: "block font-medium mb-1 text-black" %>
         <%= form.text_area :message, value: @message, rows: 2, cols: 100, data: { clipboard_target: "source" }, class: "bg-white" %>
       </div>
     <% end %>

--- a/app/views/openai_api/show.html.erb
+++ b/app/views/openai_api/show.html.erb
@@ -1,29 +1,28 @@
-<div class="flex items-center justify-center min-h-screen flex-col">
-  <div class="border-white border-2 rounded-md p-10">
-    <div class="mb-10 text-2xl text-peach">
-      <%= @message %>
-    </div>
-    <div data-controller="clipboard", class="text-white" >
-      <%= form_with url: "#", local: true do |form| %>
-        <div>
-          <%= form.label :message, "編集する" %><br>
-          <%= form.text_area :message, value: @message, rows: 2, cols: 100, data: { clipboard_target: "source" } %>
-        </div>
-      <% end %>
-      <button type="button", data-action= "clipboard#copy", data-clipboard-target= "copy_button", class="btn bg-white rounded-md text-black border-none shadow-2xl hover:bg-white" >
-      コピーする
-      </button>
-    </div>
+<div class="flex flex-col items-center">
+  <div class="text-2xl font-bold border rounded-2xl border-black p-10">
+    <%= @message %>
+  </div>
+  <div id="edit_form" data-controller="clipboard", class="flex flex-col items-center" >
+    <%= form_with url: "#", local: true do |form| %>
+      <div>
+        <%= form.label :message, "メッセージを編集する" %><br>
+        <%= form.text_area :message, value: @message, rows: 2, cols: 100, data: { clipboard_target: "source" }, class: "bg-white" %>
+      </div>
+    <% end %>
+    <button type="button", data-action= "clipboard#copy", data-clipboard-target= "copy_button", class="btn bg-slate-300 text-black border-none shadow-2xl" >
+    コピーする
+    </button>
+  </div>
+  <div>
+    <%= link_to root_path do %>
+      <button>トップページに戻る</button>
+    <% end %>
+    ｜
+    <%= link_to profiles_path do %>
+      <button>連絡帳</button>
+    <% end %>
   </div>
 </div>
-<div>
-  <%= link_to root_path do %>
-    <button>トップページに戻る</button>
-  <% end %>
-</div>
-<div>
-  <%= link_to profiles_path do %>
-    <button>連絡帳へ</button>
-  <% end %>
-</div>
+
+
 <% breadcrumb :ai_message, @last_question %>

--- a/app/views/openai_api/show.html.erb
+++ b/app/views/openai_api/show.html.erb
@@ -1,5 +1,5 @@
 <div class="flex flex-col items-center">
-  <div class="text-2xl font-bold border rounded-2xl border-black p-10">
+  <div class="text-2xl font-bold border rounded-2xl border-black p-10 w-2/3">
     <%= @message %>
   </div>
   <div id="edit_form" data-controller="clipboard", class="flex flex-col items-center" >

--- a/app/views/openai_api/show.html.erb
+++ b/app/views/openai_api/show.html.erb
@@ -3,17 +3,14 @@
     <%= @message %>
   </div>
   <div id="edit_form" data-controller="clipboard", class="flex flex-col items-center" >
-    <%= form_with url: "#", local: true do |form| %>
-      <div>
-        <%= form.label :message, "メッセージを編集する", class: "block font-medium mb-1 text-black" %>
-        <%= form.text_area :message, value: @message, rows: 2, cols: 100, data: { clipboard_target: "source" }, class: "textarea bg-white bg-slate-100 mb-3" %>
-      </div>
+    <%= form_with url: "#", class: "flex flex-col items-center w-full", local: true do |form| %>
+      <%= form.label :message, "メッセージを編集する", class: "block font-medium mb-1 text-black w-11/12" %>
+      <%= form.text_area :message, value: @message, rows: 2, cols: 100, data: { clipboard_target: "source" }, class: "textarea bg-white bg-slate-100 mb-3 w-11/12" %>
     <% end %>
     <button type="button", data-action= "clipboard#copy", data-clipboard-target= "copy_button", class="btn bg-slate-300 text-black border-none shadow-2xl" >
     コピーする
     </button>
   </div>
-
 
   <div class="mt-6 mb-10">
     <%= link_to root_path do %>
@@ -25,4 +22,5 @@
     <% end %>
   </div>
 </div>
+
 <% breadcrumb :ai_message, @last_question %>

--- a/app/views/openai_api/show.html.erb
+++ b/app/views/openai_api/show.html.erb
@@ -1,5 +1,5 @@
 <div class="flex flex-col items-center mt-20">
-  <div class="text-2xl font-bold border rounded-2xl border-black p-10 mb-10 w-2/3">
+  <div class="text-lg sm:text-2xl font-bold border rounded-2xl border-black p-10 mb-10 w-2/3">
     <%= @message %>
   </div>
   <div id="edit_form" data-controller="clipboard", class="flex flex-col items-center" >

--- a/app/views/openai_api/show.html.erb
+++ b/app/views/openai_api/show.html.erb
@@ -1,19 +1,21 @@
-<div class="flex flex-col items-center">
-  <div class="text-2xl font-bold border rounded-2xl border-black p-10 w-2/3">
+<div class="flex flex-col items-center mt-20">
+  <div class="text-2xl font-bold border rounded-2xl border-black p-10 mb-10 w-2/3">
     <%= @message %>
   </div>
   <div id="edit_form" data-controller="clipboard", class="flex flex-col items-center" >
     <%= form_with url: "#", local: true do |form| %>
       <div>
         <%= form.label :message, "メッセージを編集する", class: "block font-medium mb-1 text-black" %>
-        <%= form.text_area :message, value: @message, rows: 2, cols: 100, data: { clipboard_target: "source" }, class: "textarea bg-white bg-slate-100" %>
+        <%= form.text_area :message, value: @message, rows: 2, cols: 100, data: { clipboard_target: "source" }, class: "textarea bg-white bg-slate-100 mb-3" %>
       </div>
     <% end %>
     <button type="button", data-action= "clipboard#copy", data-clipboard-target= "copy_button", class="btn bg-slate-300 text-black border-none shadow-2xl" >
     コピーする
     </button>
   </div>
-  <div>
+
+
+  <div class="mt-6 mb-10">
     <%= link_to root_path do %>
       <button>トップページに戻る</button>
     <% end %>
@@ -23,6 +25,4 @@
     <% end %>
   </div>
 </div>
-
-
 <% breadcrumb :ai_message, @last_question %>

--- a/app/views/questions/_question_multiple_choice.html.erb
+++ b/app/views/questions/_question_multiple_choice.html.erb
@@ -1,16 +1,18 @@
 <%= form_with url: answers_path, method: :post, data: { turbo: false }, id: 'ai_questions' do |form| %>
-  <div class="flex flex-col text-center mb-5 text-2xl text-white">
+  <div class="text-2xl font-bold mb-10 text-center">
     <h1><%= question.text %></h1>
     <h2 class="text-base mt-2">※複数選択可</h2>
   </div>
+
   <% @answers.each do |answer| %>
-    <div class="flex items-center mb-2 text-white text-xl gap-2">
-      <%= form.check_box "answer[question#{question.number}]", { multiple: true }, answer.value, nil %>
+    <div class="flex items-center mb-3 text-xl gap-2">
+      <%= form.check_box "answer[question#{question.number}]", { multiple: true, class: "checkbox checkbox-xs bg-white border border-black" }, answer.value, nil %>
       <%= form.label "answer[question#{question.number}]_#{answer.value}", answer.text %>
     </div>
   <% end %>
-  <div class="w-full flex justify-center">
-    <%= form.submit '次へ', class:"btn bg-white rounded-md text-black border-none shadow-2xl hover:bg-white" %>
+
+  <div class="flex justify-center mt-10">
+    <%= form.submit '次へ', class:"btn bg-slate-300 text-black border-none shadow-2xl" %>
   </div>
 <% end %>
 

--- a/app/views/questions/_question_single_choice.html.erb
+++ b/app/views/questions/_question_single_choice.html.erb
@@ -1,15 +1,17 @@
 <%= form_with url: answers_path, method: :post, data: { turbo: false }, id: 'ai_questions' do |form| %>
-  <div class="text-center mb-5 text-2xl text-white">
+  <div class="text-2xl font-bold mb-10">
     <%= question.text %>
   </div>
+
   <% @answers.each do |answer| %>
-    <div class="flex items-center mb-2 text-white text-xl gap-2">
+    <div class="flex items-center mb-3 text-xl gap-2">
       <%= form.radio_button "answer[question#{question.number}]", answer.value, required: :true %>
       <%= form.label "answer[question#{question.number}]_#{answer.value}", answer.text %>
     </div>
   <% end %>
-  <div class="w-full flex justify-center">
-    <%= form.submit '次へ', class:"btn bg-white rounded-md text-black border-none shadow-2xl hover:bg-white" %>
+
+  <div class="flex justify-center mt-10">
+    <%= form.submit '次へ', class:"btn bg-slate-300 text-black border-none shadow-2xl" %>
   </div>
 <% end %>
 

--- a/app/views/questions/_question_single_choice.html.erb
+++ b/app/views/questions/_question_single_choice.html.erb
@@ -5,7 +5,7 @@
 
   <% @answers.each do |answer| %>
     <div class="flex items-center mb-3 text-xl gap-2">
-      <%= form.radio_button "answer[question#{question.number}]", answer.value, required: :true %>
+      <%= form.radio_button "answer[question#{question.number}]", answer.value, required: :true, class: "radio radio-xs bg-white border border-black" %>
       <%= form.label "answer[question#{question.number}]_#{answer.value}", answer.text %>
     </div>
   <% end %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,11 +1,9 @@
-<div class="flex items-center justify-center min-h-screen">
-  <div class="border-white border-2 rounded-md p-10">
-    <div class="flex items-center justify-center">
-      <% if @question.number.to_i == Settings.question_type.multiple_choice %>
-        <%= render "question_multiple_choice", question: @question %>
-      <% else %>
-        <%= render "question_single_choice", question: @question %>
-      <% end %>
-    </div>
+<div class="flex flex-col items-center">
+  <div class="text-black border rounded-2xl border-black p-10 mt-20">
+    <% if @question.number.to_i == Settings.question_type.multiple_choice %>
+      <%= render "question_multiple_choice", question: @question %>
+    <% else %>
+      <%= render "question_single_choice", question: @question %>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
### 概要
AI提案ページのデザインブラッシュアップ、及びレスポンシブデザインの実装

---
### 背景・目的
スマホ操作を想定したレスポンシブデザインを実装するため

---

### 内容
- [x] 各要素の中央に配置
- [x] スマホ画面では要素が飛び出さないよう幅を設定
- [x] 他ページの入力フォーム（新規登録など）とデザインと統一

---
### 対応しないこと
- Heroku上では背景色がクリーム色になってしまっている（本来白になるべき）が、別issueで対応する

---
### 補足
This PR close #126 