### PR TITLE
タブ表記の設定

### DIFF
--- a/app/views/albums/edit.html.erb
+++ b/app/views/albums/edit.html.erb
@@ -1,1 +1,3 @@
+<% content_for(:tab_title, "アルバム") %>
+
 <%= render 'form', profile: @profile, album: @album %>

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:tab_title, "アルバム") %>
+
 <div class="drawer lg:drawer-open h-full">
   <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
   <div class="drawer-content bg-white flex flex-col sm:flex h-full">

--- a/app/views/albums/new.html.erb
+++ b/app/views/albums/new.html.erb
@@ -1,1 +1,3 @@
+<% content_for(:tab_title, "アルバム") %>
+
 <%= render 'form', profile: @profile, album: @album %>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:tab_title, "アルバム") %>
+
 <%= @album.title %>
 <%= @album.date %>
 <%= @album.diary %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:tab_title, "通知設定") %>
+
 <div class="drawer lg:drawer-open h-full">
   <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
   <div class="drawer-content bg-white flex flex-col sm:flex h-full">

--- a/app/views/introductions/show.html.erb
+++ b/app/views/introductions/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:tab_title, "AIメッセージ") %>
+
 <div class="flex flex-col items-center">
   <div class="text-2xl text-black border rounded-2xl border-black p-10 mt-20">
     <p>久しぶりに連絡を取り合いたい人を<br>

--- a/app/views/openai_api/show.html.erb
+++ b/app/views/openai_api/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:tab_title, "AIメッセージ") %>
+
 <div class="flex flex-col items-center mt-20">
   <div class="text-lg sm:text-2xl font-bold border rounded-2xl border-black p-10 mb-10 w-2/3">
     <%= @message %>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:tab_title, "パスワード再設定") %>
+
 <div class="flex flex-col items-center">
     <h3 class="text-3xl font-bold pt-20 pb-10">パスワード再設定</h3>
     <%= form_with model: @user, url: password_reset_path(@token) do |f| %>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:tab_title, "パスワードリセット") %>
+
 <div class="flex flex-col items-center">
   <h3 class="text-3xl font-bold pt-20 pb-10">パスワードリセット申請</h3>
   <%= form_with url: password_resets_path, local: true, method: :post do |form| %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,1 +1,3 @@
+<% content_for(:tab_title, "連絡帳") %>
+
 <%= render 'form', profile: @profile %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:tab_title, "連絡帳") %>
+
 <div class="sm:flex sm:justify-around sm:items-center">
   <div class="border-2 border-black rounded-md p-2 m-4">
     <%= render "event_notice",

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,1 +1,3 @@
+<% content_for(:tab_title, "連絡帳") %>
+
 <%= render 'form', profile: @profile %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:tab_title, "連絡帳") %>
+
   <div class="drawer lg:drawer-open">
     <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
     <div class="drawer-content sm:flex justify-center">

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:tab_title, "AIメッセージ") %>
+
 <div class="flex flex-col items-center">
   <div class="text-black border rounded-2xl border-black p-10 mt-20">
     <% if @question.number.to_i == Settings.question_type.multiple_choice %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -2,7 +2,7 @@
   <nav class="flex justify-between items-center justify-center">
     <div class="ml-10">
       <%= link_to root_path do %>
-        <span class="text-3xl sm:text-4xl">Reconnect</span><span class="text-lg sm:text-xl">～ともだちと再びつながるアプリ～</span>
+        <span class="text-3xl sm:text-4xl">Stay Friends</span><span class="text-lg sm:text-xl">～ともだちと再びつながるアプリ～</span>
       <% end %>
     </div>
     <div class="font-bold space-x-8 mr-10">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,7 +2,7 @@
   <nav class="flex justify-between items-center justify-center">
     <div class="ml-10">
       <%= link_to root_path do %>
-        <span class="text-3xl sm:text-4xl">Reconnect</span><span class="text-lg sm:text-xl">～ともだちと再びつながるアプリ～</span>
+        <span class="text-3xl sm:text-4xl">Stay Friends</span><span class="text-lg sm:text-xl">～ともだちと再びつながるアプリ～</span>
       <% end %>
     </div>
     <div class="font-bold space-x-8 mr-10">

--- a/app/views/static_pages/line_qr_code.html.erb
+++ b/app/views/static_pages/line_qr_code.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:tab_title, "LINE QRコード") %>
+
 <div class="flex items-center flex-col mt-40">
   <p class="text-2xl mb-10">
     QRコードを読み込むか、ID検索をして友達登録してね！<br>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:tab_title, 'Stay Friends') %>
+<% content_for(:tab_title, "Stay Friends") %>
 
 <div class="h-screen bg-[url('top_second_bg.jpg')] bg-cover flex">
   <div id="left-side" class="w-1/2 flex flex-col justify-center">

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:tab_title, 'Reconnect') %>
+<% content_for(:tab_title, 'Stay Friends') %>
 
 <div class="h-screen bg-[url('top_second_bg.jpg')] bg-cover flex">
   <div id="left-side" class="w-1/2 flex flex-col justify-center">

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:tab_title, "ログイン") %>
+
 <div class="flex flex-col items-center">
   <h1 class="text-3xl font-bold pt-20 pb-10">ログイン</h1>
   <%= form_with url: login_path do |f| %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:tab_title, "マイページ") %>
+
 <div class="flex flex-col items-center">
   <h1 class="text-3xl font-bold pt-20 pb-10">マイページ</h1>
   <%= form_with model: @user, data: { turbo: false } do |f| %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:tab_title, "新規登録") %>
+
 <div class="flex flex-col items-center">
   <h1 class="text-3xl font-bold pt-20 pb-10">ユーザー登録</h1>
   <%= form_with model: @user do |f| %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:tab_title, "マイページ") %>
+
 <div class="flex flex-col items-center">
   <h1 class="text-3xl font-bold pt-20 pb-10">マイページ</h1>
   <div>


### PR DESCRIPTION
### 概要
各ページに対応するブラウザタブの表記を設定する

---
### 背景・目的
ユーザーがタブを見て、表示しているページの内容を理解できるようにするため

---
### 内容
- [x] アプリ名を変更　Reconnect -> Stay Friends
- [x] 各ページに対応するブラウザタブの表記を設定する
  - [x] TOPページ：Stay Friends
  - [x] AI関連：AIメッセージ
  - [x] 連絡帳関連：連絡帳
  - [x] アルバム関連：アルバム
  - [x] 通知設定：通知設定
  - [x] 新規登録：新規登録
  - [x] マイページ：マイページ
  - [x] ログイン：ログイン
  - [x] パスワードリセット：パスワードリセット
  - [x] パスワード再設定：パスワード再設定
  - [x] LINE QRコード：LINE QRコード

---
### 対応しないこと
- [ ] 

---
### 補足
This PR close #135 