### PR TITLE
デザインの微調整

### DIFF
--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -21,7 +21,7 @@
     </turbo-frame>
     <%= form.file_field :images, multiple: true, data: { previews_target: "input", action: "change->previews#preview" } %>
 
-    <%= form.submit "保存する" %>
+    <%= form.submit "保存する", class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
   <% end %>
 
   <% if album.images.attached? && album.persisted? %>

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -36,7 +36,7 @@
       </table>
     </div>
     <div class="flex justify-center my-4">
-      <%= link_to new_profile_album_path, class: "btn bg-peach text-black border-none shadow-lgl" do %>
+      <%= link_to new_profile_album_path, class: "btn bg-golden text-black border-none hover:bg-yellow-500" do %>
         <button>アルバムを作成</button>
       <% end %>
     </div>

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="drawer lg:drawer-open h-full">
   <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
-  <div class="drawer-content bg-white flex flex-col sm:flex h-full">
+  <div class="drawer-content bg-white flex flex-col md:flex h-full">
     <div>
       <table class="table table-fixed text-center mt-2">
         <tr>

--- a/app/views/events/_notification_off.html.erb
+++ b/app/views/events/_notification_off.html.erb
@@ -23,7 +23,7 @@
         </div>
       <% end %>
       <div class="flex justify-center">
-        <%= f.submit '登録する', class: "btn bg-slate-300 text-black border-none shadow-2xl" %>
+        <%= f.submit '登録する', class: "btn bg-slate-300 text-black border-none" %>
       </div>
     </fieldset>
   <% end %>

--- a/app/views/events/_notification_off.html.erb
+++ b/app/views/events/_notification_off.html.erb
@@ -28,7 +28,7 @@
     </fieldset>
   <% end %>
 </div>
-<div class="flex justify-center mt-10 text-sm sm:text-xl">
+<div class="flex justify-center mt-10 text-sm md:text-xl">
   <div class="text-center">
     <p>※マイページの通知設定がOFFになっているため、変更できません</p>
     マイページは<%= link_to "こちら", edit_user_path(@profile.user), class: "underline underline-offset-1" %>

--- a/app/views/events/_notification_on.html.erb
+++ b/app/views/events/_notification_on.html.erb
@@ -22,7 +22,7 @@
       </div>
     <% end %>
     <div class="flex justify-center">
-      <%= f.submit '登録する', class: "btn bg-slate-300 text-black border-none shadow-2xl" %>
+      <%= f.submit '登録する', class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
     </div>
   <% end %>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="drawer lg:drawer-open h-full">
   <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
-  <div class="drawer-content bg-white flex flex-col sm:flex h-full">
+  <div class="drawer-content bg-white flex flex-col md:flex h-full">
     <div class="flex items-center mt-2 ml-2 p-3">
       <%= image_tag @profile.avatar.variant(resize_to_limit: [50, 50]) if @profile.avatar.attached? %>
       <p class="text-lg"><%= @profile.name%></p>
@@ -12,7 +12,7 @@
     <% else %>
       <%= render "notification_on" %>
     <% end %>
-    <div class="flex flex-col items-center mt-10 sm:text-xl text-sm">
+    <div class="flex flex-col items-center mt-10 md:text-xl text-sm">
       <p>※通知機能を使うためには、LINEの友達登録が必要です。</p>
       <div>
         友達登録は

--- a/app/views/introductions/show.html.erb
+++ b/app/views/introductions/show.html.erb
@@ -1,13 +1,20 @@
 <% content_for(:tab_title, "AIメッセージ") %>
 
 <div class="flex flex-col items-center">
-  <div class="text-2xl text-black border rounded-2xl border-black p-10 mt-20">
-    <p>久しぶりに連絡を取り合いたい人を<br>
-        １人思い浮かべてください・・・</p>
-    <div class="text-center mt-5 flex justify-center">
-      <%= link_to question_path(1) do %>
-        <button class="btn bg-golden text-black border-none hover:bg-yellow-500">次へ</button>
-      <% end %>
-    </div>
+  <div class="text-center text-lg sm:text-2xl font-medium border rounded-3xl border-slate-100	p-8 sm:p-10 sm:mt-20 bg-opacity-10 shadow-2xl">
+    <p class="mb-10 sm:mb-14">むかしは仲が良かった。</p>
+    <p class="mb-2 sm:mb-3">でも、卒業・就職・引っ越しで、</p>
+    <p class="mb-2 sm:mb-3">いつの間にか、</p>
+    <p class="mb-10 sm:mb-14">連絡が途絶えてしまった。</p>
+    <p class="mb-2 sm:mb-3">そんなともだちを、</p>
+    <p class="mb-10 sm:mb-14">頭に１人思い浮かべてください・・・</p>
+    <p class="mb-2 sm:mb-3">今こそ、</p>
+    <p class="mb-2 sm:mb-3">あなたの大切なともだちに、</p>
+    <p>メッセージを送りましょう。</p>
+  </div>
+  <div class="text-center mt-4 sm:mt-10 flex justify-center">
+    <%= link_to question_path(1) do %>
+      <button class="btn bg-golden text-black border-none hover:bg-yellow-500">質問にすすむ</button>
+    <% end %>
   </div>
 </div>

--- a/app/views/introductions/show.html.erb
+++ b/app/views/introductions/show.html.erb
@@ -1,18 +1,18 @@
 <% content_for(:tab_title, "AIメッセージ") %>
 
 <div class="flex flex-col items-center">
-  <div class="text-center text-lg sm:text-2xl font-medium border rounded-3xl border-slate-100	p-8 sm:p-10 sm:mt-20 bg-opacity-10 shadow-2xl">
-    <p class="mb-10 sm:mb-14">むかしは仲が良かった。</p>
-    <p class="mb-2 sm:mb-3">でも、卒業・就職・引っ越しで、</p>
-    <p class="mb-2 sm:mb-3">いつの間にか、</p>
-    <p class="mb-10 sm:mb-14">連絡が途絶えてしまった。</p>
-    <p class="mb-2 sm:mb-3">そんなともだちを、</p>
-    <p class="mb-10 sm:mb-14">頭に１人思い浮かべてください・・・</p>
-    <p class="mb-2 sm:mb-3">今こそ、</p>
-    <p class="mb-2 sm:mb-3">あなたの大切なともだちに、</p>
+  <div class="text-center text-lg md:text-2xl font-medium border rounded-3xl border-slate-100	p-8 md:p-10 md:mt-20 bg-opacity-10 shadow-2xl">
+    <p class="mb-10 md:mb-14">むかしは仲が良かった。</p>
+    <p class="mb-2 md:mb-3">でも、卒業・就職・引っ越しで、</p>
+    <p class="mb-2 md:mb-3">いつの間にか、</p>
+    <p class="mb-10 md:mb-14">連絡が途絶えてしまった。</p>
+    <p class="mb-2 md:mb-3">そんなともだちを、</p>
+    <p class="mb-10 md:mb-14">頭に１人思い浮かべてください・・・</p>
+    <p class="mb-2 md:mb-3">今こそ、</p>
+    <p class="mb-2 md:mb-3">あなたの大切なともだちに、</p>
     <p>メッセージを送りましょう。</p>
   </div>
-  <div class="text-center mt-4 sm:mt-10 flex justify-center">
+  <div class="text-center mt-4 md:mt-10 flex justify-center">
     <%= link_to question_path(1) do %>
       <button class="btn bg-golden text-black border-none hover:bg-yellow-500">質問にすすむ</button>
     <% end %>

--- a/app/views/introductions/show.html.erb
+++ b/app/views/introductions/show.html.erb
@@ -6,7 +6,7 @@
         １人思い浮かべてください・・・</p>
     <div class="text-center mt-5 flex justify-center">
       <%= link_to question_path(1) do %>
-        <button class="btn bg-slate-300 text-black border-none shadow-2xl">次へ</button>
+        <button class="btn bg-golden text-black border-none hover:bg-yellow-500">次へ</button>
       <% end %>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,7 @@
 
     <main class="flex-grow">
       <%= yield %>
-      <%= breadcrumbs separator: "&rsaquo;", class: "breadcrumbs text-center mt-4 sm:mt-10" %>
+      <%= breadcrumbs separator: "&rsaquo;", class: "breadcrumbs text-center mt-4 sm:mt-10 #{'hidden sm:block' if current_page?(ai_message_path)}" %>
     </main>
 
     <% if logged_in? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
     <script src="https://kit.fontawesome.com/ba69a80073.js" crossorigin="anonymous" defer></script>
   </head>
 
-  <body class="flex flex-col h-screen bg-white text-black relative">
+  <body class="flex flex-col h-screen bg-ivory-white text-black relative">
     <% if logged_in? %>
       <%= render 'shared/header' %>
     <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,7 @@
 
     <main class="flex-grow">
       <%= yield %>
-      <%= breadcrumbs separator: "&rsaquo;", class: "breadcrumbs text-center mt-4 sm:mt-10 #{'hidden sm:block' if current_page?(ai_message_path)}" %>
+      <%= breadcrumbs separator: "&rsaquo;", class: "breadcrumbs text-center mt-4 md:mt-10 #{'hidden md:block' if current_page?(ai_message_path)}" %>
     </main>
 
     <% if logged_in? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,7 @@
 
     <main class="flex-grow">
       <%= yield %>
-      <%= breadcrumbs separator: "&rsaquo;", class: "breadcrumbs text-center mt-4" %>
+      <%= breadcrumbs separator: "&rsaquo;", class: "breadcrumbs text-center mt-4 sm:mt-10" %>
     </main>
 
     <% if logged_in? %>

--- a/app/views/openai_api/show.html.erb
+++ b/app/views/openai_api/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:tab_title, "AIメッセージ") %>
 
-<div class="flex flex-col items-center mt-10 sm:mt-20">
-  <div class="text-lg sm:text-2xl font-bold border rounded-3xl border-slate-100 bg-opacity-10 shadow-2xl p-10 mb-10 w-2/3">
+<div class="flex flex-col items-center mt-6 sm:mt-20">
+  <div class="text-lg sm:text-2xl font-bold border rounded-3xl border-slate-100 bg-opacity-10 shadow-2xl p-10 mb-10 w-2/3 max-h-1/3 overflow-auto sm:h-fit">
     <%= @message %>
   </div>
   <div id="edit_form" data-controller="clipboard", class="flex flex-col items-center" >
@@ -14,7 +14,7 @@
     </button>
   </div>
 
-  <div class="flex mt-6 ml-2 mb-10 w-40">
+  <div class="flex mt-10 ml-2 sm:mb-10 w-40">
     <%= link_to "トップページ", root_path %>
     ｜
     <%= link_to "連絡帳", profiles_path %>

--- a/app/views/openai_api/show.html.erb
+++ b/app/views/openai_api/show.html.erb
@@ -9,7 +9,7 @@
       <%= form.label :message, "メッセージを編集する", class: "block font-medium mb-1 text-black w-11/12" %>
       <%= form.text_area :message, value: @message, rows: 2, cols: 100, data: { clipboard_target: "source" }, class: "textarea bg-white bg-slate-100 mb-3 w-11/12" %>
     <% end %>
-    <button type="button", data-action= "clipboard#copy", data-clipboard-target= "copy_button", class="btn bg-slate-300 text-black border-none shadow-2xl" >
+    <button type="button", data-action= "clipboard#copy", data-clipboard-target= "copy_button", class="btn bg-golden text-black border-none hover:bg-yellow-500" >
     コピーする
     </button>
   </div>

--- a/app/views/openai_api/show.html.erb
+++ b/app/views/openai_api/show.html.erb
@@ -14,14 +14,10 @@
     </button>
   </div>
 
-  <div class="mt-6 mb-10">
-    <%= link_to root_path do %>
-      <button>トップページに戻る</button>
-    <% end %>
+  <div class="flex mt-6 ml-2 mb-10 w-40">
+    <%= link_to "トップページ", root_path %>
     ｜
-    <%= link_to profiles_path do %>
-      <button>連絡帳</button>
-    <% end %>
+    <%= link_to "連絡帳", profiles_path %>
   </div>
 </div>
 

--- a/app/views/openai_api/show.html.erb
+++ b/app/views/openai_api/show.html.erb
@@ -1,20 +1,20 @@
 <% content_for(:tab_title, "AIメッセージ") %>
 
-<div class="flex flex-col items-center mt-6 sm:mt-20">
-  <div class="text-lg sm:text-2xl font-bold border rounded-3xl border-slate-100 bg-opacity-10 shadow-2xl p-10 mb-10 w-2/3 max-h-1/3 overflow-auto sm:h-fit">
+<div class="flex flex-col items-center mt-6 md:mt-20">
+  <div class="text-lg md:text-2xl font-bold border rounded-3xl border-slate-100 bg-opacity-10 shadow-2xl p-10 mb-10 w-2/3 max-h-1/3 overflow-auto md:h-fit">
     <%= @message %>
   </div>
   <div id="edit_form" data-controller="clipboard", class="flex flex-col items-center" >
     <%= form_with url: "#", class: "flex flex-col items-center w-full", local: true do |form| %>
       <%= form.label :message, "メッセージを編集する", class: "block font-medium mb-1 text-black w-11/12" %>
-      <%= form.text_area :message, value: @message, rows: 2, cols: 100, data: { clipboard_target: "source" }, class: "textarea sm:text-lg bg-slate-100 mb-3 w-11/12" %>
+      <%= form.text_area :message, value: @message, rows: 2, cols: 100, data: { clipboard_target: "source" }, class: "textarea md:text-lg bg-slate-100 mb-3 w-11/12" %>
     <% end %>
     <button type="button", data-action= "clipboard#copy", data-clipboard-target= "copy_button", class="btn bg-golden text-black border-none hover:bg-yellow-500" >
     コピーする
     </button>
   </div>
 
-  <div class="flex mt-10 ml-2 sm:mb-10 w-40">
+  <div class="flex mt-10 ml-2 md:mb-10 w-40">
     <%= link_to "トップページ", root_path %>
     ｜
     <%= link_to "連絡帳", profiles_path %>

--- a/app/views/openai_api/show.html.erb
+++ b/app/views/openai_api/show.html.erb
@@ -7,7 +7,7 @@
   <div id="edit_form" data-controller="clipboard", class="flex flex-col items-center" >
     <%= form_with url: "#", class: "flex flex-col items-center w-full", local: true do |form| %>
       <%= form.label :message, "メッセージを編集する", class: "block font-medium mb-1 text-black w-11/12" %>
-      <%= form.text_area :message, value: @message, rows: 2, cols: 100, data: { clipboard_target: "source" }, class: "textarea bg-white bg-slate-100 mb-3 w-11/12" %>
+      <%= form.text_area :message, value: @message, rows: 2, cols: 100, data: { clipboard_target: "source" }, class: "textarea sm:text-lg bg-slate-100 mb-3 w-11/12" %>
     <% end %>
     <button type="button", data-action= "clipboard#copy", data-clipboard-target= "copy_button", class="btn bg-golden text-black border-none hover:bg-yellow-500" >
     コピーする

--- a/app/views/openai_api/show.html.erb
+++ b/app/views/openai_api/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:tab_title, "AIメッセージ") %>
 
-<div class="flex flex-col items-center mt-20">
-  <div class="text-lg sm:text-2xl font-bold border rounded-2xl border-black p-10 mb-10 w-2/3">
+<div class="flex flex-col items-center mt-10 sm:mt-20">
+  <div class="text-lg sm:text-2xl font-bold border rounded-3xl border-slate-100 bg-opacity-10 shadow-2xl p-10 mb-10 w-2/3">
     <%= @message %>
   </div>
   <div id="edit_form" data-controller="clipboard", class="flex flex-col items-center" >

--- a/app/views/profiles/_event_notice.html.erb
+++ b/app/views/profiles/_event_notice.html.erb
@@ -1,5 +1,5 @@
 <!---スマホ画面用のテーブル--->
-<table class="w-full sm:hidden">
+<table class="w-full md:hidden">
   <tr>
     <td class="w-1/2 text-center">今月のイベント！</td>
     <td class="w-1/2 text-center">来月のイベント！</td>
@@ -41,7 +41,7 @@
 </table>
 
 <!---PC画面用のテーブル--->
-<table class="hidden sm:table">
+<table class="hidden md:table">
   <tr>
     <td>今月のイベント！</td>
     <% profiles_birthdays_this_month.each do |profile| %>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -68,7 +68,7 @@
       </div>
 
       <div class="flex justify-center">
-        <%= profile_form.submit '登録する', class: "btn bg-slate-300 text-black border-none shadow-2xl" %>
+        <%= profile_form.submit '登録する', class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
       </div>
     <% end %>
   </div>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:tab_title, "連絡帳") %>
 
-<div class="sm:flex sm:justify-around sm:items-center">
+<div class="md:flex md:justify-around md:items-center">
   <div class="border-2 border-black rounded-md p-2 m-4">
     <%= render "event_notice",
         profiles_birthdays_this_month: @profiles_birthdays_this_month,
@@ -21,7 +21,7 @@
 </div>
 
 <!---スマホ画面用のブロック--->
-<div class="flex flex-col sm:hidden pb-20">
+<div class="flex flex-col md:hidden pb-20">
   <% @profiles.each do |profile| %>
     <div class="flex h-24 my-5">
       <div class="w-1/12 flex items-center justify-center">
@@ -67,7 +67,7 @@
 
 <!---PC画面用のテーブル--->
 <div class="max-h-screen overflow-auto">
-  <table class="table table-fixed text-center hidden sm:table">
+  <table class="table table-fixed text-center hidden md:table">
     <tr class="bg-white sticky top-0">
       <th class="w-1/12">連絡済み</th>
       <th class="w-1/12"></th>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -14,7 +14,7 @@
   </div>
 
   <div class="flex justify-center my-4">
-    <%= link_to new_profile_path, class: "btn bg-peach text-black border-none shadow-lgl" do %>
+    <%= link_to new_profile_path, class: "btn bg-golden text-black border-none hover:bg-yellow-500" do %>
       <button>連絡先を作成</button>
     <% end %>
   </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,30 +2,30 @@
 
   <div class="drawer lg:drawer-open">
     <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
-    <div class="drawer-content sm:flex justify-center">
+    <div class="drawer-content md:flex justify-center">
       <!-- Page content here -->
-      <div role="tablist" class="tabs tabs-bordered mt-3 sm:hidden">
+      <div role="tablist" class="tabs tabs-bordered mt-3 md:hidden">
         <%= link_to "基本情報", profile_path(@profile), role: "tab", class: "tab #{"tab-active" if current_page?(profile_path(@profile))}" %>
         <%= link_to "アルバム", profile_albums_path(@profile), role: "tab #{"tab-active" if current_page?(profile_path(@profile))}", class: "tab" %>
         <%= link_to "通知設定", profile_events_path(@profile), role: "tab #{"tab-active" if current_page?(profile_path(@profile))}", class: "tab" %>
       </div>
-      <div class="mt-8 sm:flex">
-        <div id="avatar" class="flex justify-center sm:items-center sm:pr-10">
+      <div class="mt-8 md:flex">
+        <div id="avatar" class="flex justify-center md:items-center md:pr-10">
           <% if @profile.avatar.attached? %>
             <%= image_tag @profile.avatar.variant(resize_to_limit: [200, 200]) %>
           <% end %>
         </div>
         <div id ="profile_info" class="flex flex-col flex-grow items-left justify-center mt-5">
-          <div class="sm:flex">
+          <div class="md:flex">
             <div class="text-center">
               <div class="text-2xl tracking-widest">
                 <%= @profile.furigana %>
               </div>
-              <div class="text-6xl sm:text-8xl">
+              <div class="text-6xl md:text-8xl">
                 <%= @profile.name %>
               </div>
             </div>
-            <div class="flex flex-col items-center mt-4 sm:justify-end">
+            <div class="flex flex-col items-center mt-4 md:justify-end">
               <div>
                 <%= link_to edit_profile_path(@profile) do %>
                   <i class="fa-solid fa-pen-to-square fa-lg"></i>
@@ -41,23 +41,23 @@
             <div>
               <div class="my-5 text-left">
                 <i class="fa-solid fa-phone fa-lg"></i>
-                <span class="text-xl sm:text-2xl"><%= @profile.phone %></span>
+                <span class="text-xl md:text-2xl"><%= @profile.phone %></span>
               </div>
               <div class="my-5 text-left">
                 <i class="fa-regular fa-envelope fa-lg"></i>
-                <span class="text-xl sm:text-2xl"><%= @profile.email %></span>
+                <span class="text-xl md:text-2xl"><%= @profile.email %></span>
               </div>
               <div class="my-5 text-left">
                 <i class="fa-solid fa-location-dot fa-lg"></i>
-                <span class="text-xl sm:text-2xl"><%= @profile.address %></span>
+                <span class="text-xl md:text-2xl"><%= @profile.address %></span>
               </div>
               <div class="my-5 text-left">
                 <i class="fa-solid fa-cake-candles fa-lg"></i>
-                <span class="text-xl sm:text-2xl"><%= @profile.events.first.date %></span>
+                <span class="text-xl md:text-2xl"><%= @profile.events.first.date %></span>
               </div>
               <div class="my-5 text-left">
                 <i class="fa-solid fa-calendar-check fa-lg"></i>
-                <span class="text-xl sm:text-2xl"><%= @profile.events.last.date %></span>
+                <span class="text-xl md:text-2xl"><%= @profile.events.last.date %></span>
               </div>
             </div>
           </div>

--- a/app/views/questions/_question_multiple_choice.html.erb
+++ b/app/views/questions/_question_multiple_choice.html.erb
@@ -1,17 +1,17 @@
 <%= form_with url: answers_path, method: :post, data: { turbo: false }, id: 'ai_questions' do |form| %>
-  <div class="text-2xl font-bold mb-10 text-center">
+  <div class="text-2xl font-bold mb-6 sm:mb-10 text-center">
     <h1><%= question.text %></h1>
     <h2 class="text-base mt-2">※複数選択可</h2>
   </div>
 
   <% @answers.each do |answer| %>
     <div class="flex items-center mb-3 text-xl gap-2">
-      <%= form.check_box "answer[question#{question.number}]", { multiple: true, class: "checkbox checkbox-xs bg-white border border-black" }, answer.value, nil %>
+      <%= form.check_box "answer[question#{question.number}]", { multiple: true, class: "checkbox checkbox-xs border border-black" }, answer.value, nil %>
       <%= form.label "answer[question#{question.number}]_#{answer.value}", answer.text %>
     </div>
   <% end %>
 
-  <div class="flex justify-center mt-10">
+  <div class="flex justify-center mt-2 sm:mt-10">
     <%= form.submit '次へ', class:"btn bg-golden text-black border-none hover:bg-yellow-500" %>
   </div>
 <% end %>

--- a/app/views/questions/_question_multiple_choice.html.erb
+++ b/app/views/questions/_question_multiple_choice.html.erb
@@ -12,7 +12,7 @@
   <% end %>
 
   <div class="flex justify-center mt-10">
-    <%= form.submit '次へ', class:"btn bg-slate-300 text-black border-none shadow-2xl" %>
+    <%= form.submit '次へ', class:"btn bg-golden text-black border-none hover:bg-yellow-500" %>
   </div>
 <% end %>
 

--- a/app/views/questions/_question_multiple_choice.html.erb
+++ b/app/views/questions/_question_multiple_choice.html.erb
@@ -1,5 +1,5 @@
 <%= form_with url: answers_path, method: :post, data: { turbo: false }, id: 'ai_questions' do |form| %>
-  <div class="text-2xl font-bold mb-6 sm:mb-10 text-center">
+  <div class="text-2xl font-bold mb-6 md:mb-10 text-center">
     <h1><%= question.text %></h1>
     <h2 class="text-base mt-2">※複数選択可</h2>
   </div>
@@ -11,7 +11,7 @@
     </div>
   <% end %>
 
-  <div class="flex justify-center mt-2 sm:mt-10">
+  <div class="flex justify-center mt-2 md:mt-10">
     <%= form.submit '次へ', class:"btn bg-golden text-black border-none hover:bg-yellow-500" %>
   </div>
 <% end %>

--- a/app/views/questions/_question_single_choice.html.erb
+++ b/app/views/questions/_question_single_choice.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 
   <div class="flex justify-center mt-10">
-    <%= form.submit '次へ', class:"btn bg-slate-300 text-black border-none shadow-2xl" %>
+    <%= form.submit '次へ', class:"btn bg-golden text-black border-none hover:bg-yellow-500" %>
   </div>
 <% end %>
 

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:tab_title, "AIメッセージ") %>
 
 <div class="flex flex-col items-center">
-  <div class="text-black border rounded-2xl border-black p-10 mt-20">
+  <div class="text-black border rounded-3xl border-slate-100 p-10 mt-10 sm:mt-20 bg-opacity-10 shadow-2xl">
     <% if @question.number.to_i == Settings.question_type.multiple_choice %>
       <%= render "question_multiple_choice", question: @question %>
     <% else %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:tab_title, "AIメッセージ") %>
 
 <div class="flex flex-col items-center">
-  <div class="text-black border rounded-3xl border-slate-100 p-10 mt-10 sm:mt-20 bg-opacity-10 shadow-2xl">
+  <div class="text-black border rounded-3xl border-slate-100 p-10 mt-10 md:mt-20 bg-opacity-10 shadow-2xl">
     <% if @question.number.to_i == Settings.question_type.multiple_choice %>
       <%= render "question_multiple_choice", question: @question %>
     <% else %>

--- a/app/views/shared/_before_login_footer.html.erb
+++ b/app/views/shared/_before_login_footer.html.erb
@@ -1,6 +1,6 @@
 <!---スマホ画面用のフッター--->
-<footer class="fixed bottom-0 h-20 bg-black w-full sm:hidden">
-  <div class="flex justify-center space-x-8 text-white my-4">
+<footer class="fixed bottom-0 flex items-center justify-center h-12 bg-black w-full sm:hidden">
+  <div class="flex justify-around text-white text-xs w-full">
     <div class="flex flex-col justify-center text-center">
       <div>
         <%= link_to introduction_path(1) do %>

--- a/app/views/shared/_before_login_footer.html.erb
+++ b/app/views/shared/_before_login_footer.html.erb
@@ -34,8 +34,8 @@
 
 
 <!---PC画面用のフッター--->
-<footer class="bottom-0 bg-opacity-20 bg-black w-full left-0 hidden sm:block h-6">
-  <div class="flex justify-center space-x-8 text-white">
+<footer class="bottom-0 bg-cream-pink w-full left-0 hidden sm:block h-6">
+  <div class="flex justify-center space-x-8">
     <%= link_to "利用規約", terms_path %>
     <%= link_to "プライバシーポリシー", privacy_policy_path %>
     <%= link_to "お問い合わせ", "https://forms.gle/jj8fcaibi2Tvb9Yt7" %>

--- a/app/views/shared/_before_login_footer.html.erb
+++ b/app/views/shared/_before_login_footer.html.erb
@@ -1,5 +1,5 @@
 <!---スマホ画面用のフッター--->
-<footer class="fixed bottom-0 flex items-center justify-center h-12 bg-black w-full sm:hidden">
+<footer class="fixed bottom-0 flex items-center justify-center h-12 bg-zinc-600 w-full sm:hidden">
   <div class="flex justify-around text-white text-xs w-full">
     <div class="flex flex-col justify-center text-center">
       <div>

--- a/app/views/shared/_before_login_footer.html.erb
+++ b/app/views/shared/_before_login_footer.html.erb
@@ -1,5 +1,5 @@
 <!---スマホ画面用のフッター--->
-<footer class="fixed bottom-0 flex items-center justify-center h-12 bg-zinc-600 w-full sm:hidden">
+<footer class="fixed bottom-0 flex items-center justify-center h-12 bg-zinc-600 w-full md:hidden">
   <div class="flex justify-around text-white text-xs w-full">
     <div class="flex flex-col justify-center text-center">
       <div>
@@ -34,7 +34,7 @@
 
 
 <!---PC画面用のフッター--->
-<footer class="bottom-0 bg-cream-pink w-full left-0 hidden sm:block h-6">
+<footer class="bottom-0 bg-cream-pink w-full left-0 hidden md:block h-6">
   <div class="flex justify-center space-x-8">
     <%= link_to "利用規約", terms_path %>
     <%= link_to "プライバシーポリシー", privacy_policy_path %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -3,7 +3,7 @@
     <div class="flex sm:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>
-        <span class="text-2xl sm:text-4xl">Stay Friends</span><span class="text-lg sm:text-xl"> ～ともだちと再びつながるアプリ～</span>
+        <span class="text-xl sm:text-4xl">Stay Friends</span><span class="sm:text-xl"> ～ともだちと再びつながるアプリ～</span>
       <% end %>
     </div>
     <div class="font-bold space-x-8 mr-10 hidden sm:block">

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,4 +1,4 @@
-<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 sm:block flex justify-center">
+<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 sm:block flex justify-center bg-almond">
   <nav class="flex justify-between items-center justify-center h-14">
     <div class="flex items-center sm:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -3,7 +3,7 @@
     <div class="flex sm:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>
-        <span class="text-2xl sm:text-4xl">Stay Friends</span><span class="text-lg sm:text-xl">～ともだちと再びつながるアプリ～</span>
+        <span class="text-2xl sm:text-4xl">Stay Friends</span><span class="text-lg sm:text-xl"> ～ともだちと再びつながるアプリ～</span>
       <% end %>
     </div>
     <div class="font-bold space-x-8 mr-10 hidden sm:block">

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,5 +1,5 @@
-<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-fit hidden sm:block">
-  <nav class="flex justify-between items-center justify-center">
+<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 hidden sm:block">
+  <nav class="flex justify-between items-center justify-center h-14">
     <div class="flex ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,12 +1,12 @@
-<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 hidden sm:block">
+<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 sm:block flex justify-center">
   <nav class="flex justify-between items-center justify-center h-14">
-    <div class="flex ml-10">
+    <div class="flex sm:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>
-        <span class="text-3xl sm:text-4xl">Stay Friends</span><span class="text-lg sm:text-xl">～ともだちと再びつながるアプリ～</span>
+        <span class="text-2xl sm:text-4xl">Stay Friends</span><span class="text-lg sm:text-xl">～ともだちと再びつながるアプリ～</span>
       <% end %>
     </div>
-    <div class="font-bold space-x-8 mr-10">
+    <div class="font-bold space-x-8 mr-10 hidden sm:block">
       <%= link_to "AIメッセージ作成", introduction_path(1) %>
       <%= link_to "連絡帳", profiles_path %>
       <%= link_to "ログイン", login_path %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,4 +1,4 @@
-<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 sm:block flex justify-center bg-almond">
+<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 sm:block flex justify-center bg-peach-light">
   <nav class="flex justify-between items-center justify-center h-14">
     <div class="flex items-center sm:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,12 +1,12 @@
-<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 sm:block flex justify-center bg-peach-light">
+<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 md:block flex justify-center bg-peach-light">
   <nav class="flex justify-between items-center justify-center h-14">
-    <div class="flex items-center sm:ml-10">
+    <div class="flex items-center md:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>
-        <span class="text-xl sm:text-4xl">Stay Friends</span><span class="sm:text-xl"> ～ともだちと再びつながるアプリ～</span>
+        <span class="text-xl md:text-4xl">Stay Friends</span><span class="md:text-xl"> ～ともだちと再びつながるアプリ～</span>
       <% end %>
     </div>
-    <div class="font-bold space-x-8 mr-10 hidden sm:block">
+    <div class="font-bold space-x-8 mr-10 hidden md:block">
       <%= link_to "AIメッセージ作成", introduction_path(1) %>
       <%= link_to "連絡帳", profiles_path %>
       <%= link_to "ログイン", login_path %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,6 +1,6 @@
 <header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 sm:block flex justify-center">
   <nav class="flex justify-between items-center justify-center h-14">
-    <div class="flex sm:ml-10">
+    <div class="flex items-center sm:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>
         <span class="text-xl sm:text-4xl">Stay Friends</span><span class="sm:text-xl"> ～ともだちと再びつながるアプリ～</span>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -11,7 +11,7 @@
       <%= link_to "連絡帳", profiles_path %>
       <%= link_to "ログイン", login_path %>
       <%= link_to new_user_path do %>
-        <button class="btn bg-black text-white my-1">新規登録</button>
+        <button class="btn bg-ivory-white text-black border-none hover:bg-peach-red <%= "hover:bg-slate-300" if current_page?(root_path) %>">新規登録</button>
       <% end %>
     </div>
   </nav>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,5 +1,11 @@
 <% flash.each do |message_type, message| %>
-  <div class="alert alert-<%= message_type %> border border-2 border-white <%= "absolute top-14" if current_page?(root_path) %>">
-    <%= message %>
+  <div role= alert class="alert bg-ivory-white border border-4
+    <%= case message_type
+        when "success" then "alert-success border-green-600"
+        when "warning" then "alert-warning border-orange-600"
+        when "danger" then "alert-danger border-red-600"
+        end %>
+    <%= "absolute top-14" if current_page?(root_path) %>">
+    <div class="text-black font-bold"><%= message %></div>
   </div>
 <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,6 @@
 <!---スマホ画面用のフッター--->
-<footer class="fixed bottom-0 h-20 bg-black w-full sm:hidden">
-  <div class="flex justify-center space-x-8 text-white my-4">
+<footer class="fixed bottom-0 flex items-center justify-center h-12 bg-black w-full sm:hidden">
+  <div class="flex justify-around text-white text-xs w-full">
     <div class="flex flex-col justify-center text-center">
       <div>
         <%= link_to introduction_path(1) do %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -38,8 +38,8 @@
 
 
 <!---PC画面用のフッター--->
-<footer class="bottom-0 bg-opacity-20 bg-black w-full left-0 hidden sm:block h-6">
-  <div class="flex justify-center space-x-8 text-white">
+<footer class="bottom-0 bg-cream-pink w-full left-0 hidden sm:block h-6">
+  <div class="flex justify-center space-x-8">
     <%= link_to "利用規約", terms_path %>
     <%= link_to "プライバシーポリシー", privacy_policy_path %>
     <%= link_to "お問い合わせ", "https://forms.gle/jj8fcaibi2Tvb9Yt7" %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,5 @@
 <!---スマホ画面用のフッター--->
-<footer class="fixed bottom-0 flex items-center justify-center h-12 bg-zinc-600 w-full sm:hidden">
+<footer class="fixed bottom-0 flex items-center justify-center h-12 bg-zinc-600 w-full md:hidden">
   <div class="flex justify-around text-white text-xs w-full">
     <div class="flex flex-col justify-center text-center">
       <div>
@@ -38,7 +38,7 @@
 
 
 <!---PC画面用のフッター--->
-<footer class="bottom-0 bg-cream-pink w-full left-0 hidden sm:block h-6">
+<footer class="bottom-0 bg-cream-pink w-full left-0 hidden md:block h-6">
   <div class="flex justify-center space-x-8">
     <%= link_to "利用規約", terms_path %>
     <%= link_to "プライバシーポリシー", privacy_policy_path %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,5 @@
 <!---スマホ画面用のフッター--->
-<footer class="fixed bottom-0 flex items-center justify-center h-12 bg-black w-full sm:hidden">
+<footer class="fixed bottom-0 flex items-center justify-center h-12 bg-zinc-600 w-full sm:hidden">
   <div class="flex justify-around text-white text-xs w-full">
     <div class="flex flex-col justify-center text-center">
       <div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,9 +1,9 @@
 <header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 sm:block flex justify-center">
   <nav class="flex justify-between items-center justify-center h-14">
-    <div class="flex sm:ml-10">
+    <div class="flex items-center sm:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>
-        <span class="text-2xl sm:text-4xl">Stay Friends</span><span class="text-lg sm:text-xl"> ～ともだちと再びつながるアプリ～</span>
+        <span class="text-xl sm:text-4xl">Stay Friends</span><span class="sm:text-xl"> ～ともだちと再びつながるアプリ～</span>
       <% end %>
     </div>
     <div class="font-bold space-x-8 mr-10 hidden sm:block">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
-<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-fit hidden sm:block">
-  <nav class="flex justify-between items-center justify-center">
+<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 hidden sm:block">
+  <nav class="flex justify-between items-center justify-center h-14 <%= "mt-2" if current_page?(root_path) %>">
     <div class="flex ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 sm:block flex justify-center">
+<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 sm:block flex justify-center bg-almond">
   <nav class="flex justify-between items-center justify-center h-14">
     <div class="flex items-center sm:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,7 +3,7 @@
     <div class="flex sm:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>
-        <span class="text-2xl sm:text-4xl">Stay Friends</span><span class="text-lg sm:text-xl">～ともだちと再びつながるアプリ～</span>
+        <span class="text-2xl sm:text-4xl">Stay Friends</span><span class="text-lg sm:text-xl"> ～ともだちと再びつながるアプリ～</span>
       <% end %>
     </div>
     <div class="font-bold space-x-8 mr-10 hidden sm:block">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 sm:block flex justify-center">
-  <nav class="flex justify-between items-center justify-center h-14 <%= "mt-2" if current_page?(root_path) %>">
+  <nav class="flex justify-between items-center justify-center h-14">
     <div class="flex sm:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 sm:block flex justify-center bg-almond">
+<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 sm:block flex justify-center bg-peach-light">
   <nav class="flex justify-between items-center justify-center h-14">
     <div class="flex items-center sm:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,12 +1,12 @@
-<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 sm:block flex justify-center bg-peach-light">
+<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 md:block flex justify-center bg-peach-light">
   <nav class="flex justify-between items-center justify-center h-14">
-    <div class="flex items-center sm:ml-10">
+    <div class="flex items-center md:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>
-        <span class="text-xl sm:text-4xl">Stay Friends</span><span class="sm:text-xl"> ～ともだちと再びつながるアプリ～</span>
+        <span class="text-xl md:text-4xl">Stay Friends</span><span class="md:text-xl"> ～ともだちと再びつながるアプリ～</span>
       <% end %>
     </div>
-    <div class="font-bold space-x-8 mr-10 hidden sm:block">
+    <div class="font-bold space-x-8 mr-10 hidden md:block">
       <%= link_to "AIメッセージ作成", introduction_path(1) %>
       <%= link_to "連絡帳", profiles_path %>
       <%= link_to "マイページ", user_path(current_user)  %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,12 +1,12 @@
-<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 hidden sm:block">
+<header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 sm:block flex justify-center">
   <nav class="flex justify-between items-center justify-center h-14 <%= "mt-2" if current_page?(root_path) %>">
-    <div class="flex ml-10">
+    <div class="flex sm:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>
-        <span class="text-3xl sm:text-4xl">Stay Friends</span><span class="text-lg sm:text-xl">～ともだちと再びつながるアプリ～</span>
+        <span class="text-2xl sm:text-4xl">Stay Friends</span><span class="text-lg sm:text-xl">～ともだちと再びつながるアプリ～</span>
       <% end %>
     </div>
-    <div class="font-bold space-x-8 mr-10">
+    <div class="font-bold space-x-8 mr-10 hidden sm:block">
       <%= link_to "AIメッセージ作成", introduction_path(1) %>
       <%= link_to "連絡帳", profiles_path %>
       <%= link_to "マイページ", user_path(current_user)  %>

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-white p-6 mx-auto flex justify-center mb-20 sm:mb-0">
+<div class="bg-white p-6 mx-auto flex justify-center mb-20 md:mb-0">
   <div class="w-full max-w-screen-lg">
     <h1 class="text-3xl font-bold mb-6 text-center">プライバシーポリシー</h1>
     <div class="mb-6">

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-white p-6 mx-auto flex justify-center mb-20 sm:mb-0">
+<div class="bg-white p-6 mx-auto flex justify-center mb-20 md:mb-0">
   <div class="w-full max-w-screen-lg">
     <h1 class="text-3xl font-bold mb-6 text-center">利用規約</h1>
     <p class="mb-4">この利用規約（以下、「本規約」といいます。）は、「Stay Friends」（以下、「当社」といいます。）がこのウェブサイト上で提供するサービス（以下、「本サービス」といいます）の利用条件を定めるものです。ユーザーの皆さま（以下、「ユーザー」といいます。）には、本規約に従って、本サービスをご利用いただきます。</p>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -4,8 +4,8 @@
   <div id="left-side" class="w-1/2 flex flex-col justify-center">
     <div id="left-text">
       <div class="text-white text-center pt-32">
-        <h1 class="text-5xl sm:text-5xl mb-10">また、つながろう。</h1>
-        <h1 class="text-5xl sm:text-5xl mb-12">私の大切なともだちと</h1>
+        <h1 class="text-5xl md:text-5xl mb-10">また、つながろう。</h1>
+        <h1 class="text-5xl md:text-5xl mb-12">私の大切なともだちと</h1>
         <p class="text-xl mb-10">昔のともだちに、連絡を取ってみませんか？<br>３つの質問に答えるだけで、最適なメッセージを提案します</p>
       </div>
       <div class="flex justify-center">
@@ -25,8 +25,8 @@
     </div>
     <div id="right-text">
       <div class="text-white text-center">
-        <h1 class="text-5xl sm:text-5xl mb-10">つながりつづけよう</h1>
-        <h1 class="text-5xl sm:text-5xl mb-12">これからも、ずっと</h1>
+        <h1 class="text-5xl md:text-5xl mb-10">つながりつづけよう</h1>
+        <h1 class="text-5xl md:text-5xl mb-12">これからも、ずっと</h1>
         <p class="text-xl mb-10 text-center">ともだちの大切な日を登録して<br>リマインダー通知を受け取ろう</p>
       </div>
       <div class="flex justify-center">
@@ -40,8 +40,8 @@
 <!---
   <div class="w-1/2 flex-col items-center ">
     <div class="justify-center text-white text-center">
-      <h1 class="text-5xl sm:text-5xl mb-12 mt-44">また、つながろう。</h1>
-      <h1 class="text-5xl sm:text-5xl mb-20">私の大切なともだちと</h1>
+      <h1 class="text-5xl md:text-5xl mb-12 mt-44">また、つながろう。</h1>
+      <h1 class="text-5xl md:text-5xl mb-20">私の大切なともだちと</h1>
       <p class="text-xl mb-10 text-center">昔のともだちに、連絡を取ってみませんか？<br>３つの質問に答えるだけで、あなたに最適なメッセージを提案します</p>
     </div>
     <div>
@@ -58,8 +58,8 @@
       写真
     </div>
     <div>
-      <h1 class="text-5xl sm:text-5xl mb-12 mt-44">つながりつづけよう</h1>
-      <h1 class="text-5xl sm:text-5xl mb-20">これからも、ずっと</h1>
+      <h1 class="text-5xl md:text-5xl mb-12 mt-44">つながりつづけよう</h1>
+      <h1 class="text-5xl md:text-5xl mb-20">これからも、ずっと</h1>
       <p class="text-xl mb-10 text-center">ともだちの大切な日を登録して<br>リマインダー通知を受け取ろう</p>
     </div>
     <div>
@@ -74,8 +74,8 @@
   <div class="w-1/2"></div>
   <div class="w-1/2 flex-col justify-center items-center text-white text-center">
     <div>
-      <h1 class="text-5xl sm:text-5xl mb-12 mt-44">つながりつづけよう</h1>
-      <h1 class="text-5xl sm:text-5xl mb-20">これからも、ずっと</h1>
+      <h1 class="text-5xl md:text-5xl mb-12 mt-44">つながりつづけよう</h1>
+      <h1 class="text-5xl md:text-5xl mb-20">これからも、ずっと</h1>
       <p class="text-xl mb-10 text-center">ともだちの大切な日を登録して<br>リマインダー通知を受け取ろう</p>
     </div>
     <div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -10,7 +10,7 @@
       </div>
       <div class="flex justify-center">
         <%= link_to introduction_path(1) do %>
-          <button class="btn bg-slate-300 text-black border-none shadow-2xl">メッセージを作成する</button>
+          <button class="btn bg-golden text-black border-none hover:bg-yellow-500 shadow-2xl">メッセージを作成する</button>
         <% end %>
       </div>
     </div>
@@ -31,7 +31,7 @@
       </div>
       <div class="flex justify-center">
         <%= link_to profiles_path do %>
-          <button class="btn bg-slate-300 text-black border-none shadow-2xl">ともだち帳をひらく</button>
+          <button class="btn bg-peach-red text-black border-none hover:bg-red-500 shadow-2xl">ともだち帳をひらく</button>
         <% end %>
       </div>
     </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -12,7 +12,7 @@
       <%= f.password_field :password, class: "w-full rounded p-2 bg-white border border-black" %>
     </div>
     <div class="flex justify-center">
-      <%= f.submit "ログイン", class: "btn bg-slate-300 text-black border-none shadow-2xl" %>
+      <%= f.submit "ログイン", class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
     </div>
   <% end %>
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -16,7 +16,7 @@
     </div>
 
     <div class="flex justify-center">
-      <%= f.submit "更新", class: "btn bg-slate-300 text-black border-none shadow-2xl" %>
+      <%= f.submit "更新", class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
     </div>
   <% end %>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -22,7 +22,7 @@
       <%= f.password_field :password_confirmation, class: "w-full rounded p-2 bg-white border border-black" %>
     </div>
     <div class="flex justify-center">
-      <%= f.submit "登録", class: "btn bg-slate-300 text-black border-none shadow-2xl" %>
+      <%= f.submit "登録", class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
     </div>
   <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,6 +15,6 @@
 
   </div>
   <div class="mt-6">
-    <%= link_to "編集", edit_user_path(@user), class: "btn bg-slate-300 text-black border-none shadow-2xl" %>
+    <%= link_to "編集", edit_user_path(@user), class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
   </div>
 </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,7 +13,7 @@ module.exports = {
         'peach-light': '#FFCFC4',
         'ivory-white': '#FFFFF7',
         'almond': '#FFEBCD',
-        'sienna': '#C19A6B'
+        'cream-pink': '#FFF1ED'
       }
     }
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,9 +9,11 @@ module.exports = {
     extend: {
       colors: {
         'golden': '#FFD700',
-        'peach': '#FF6F61',
+        'peach-red': '#ff6f61',
+        'peach-light': '#FFCFC4',
         'ivory-white': '#FFFFF7',
-        'almond': '#FFEBCD'
+        'almond': '#FFEBCD',
+        'sienna': '#C19A6B'
       }
     }
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,7 +10,8 @@ module.exports = {
       colors: {
         'golden': '#FFD700',
         'peach': '#FF6F61',
-        'ivory': '#FFFFF0'
+        'ivory-white': '#FFFFF7',
+        'almond': '#FFEBCD'
       }
     }
   },


### PR DESCRIPTION
### 概要
デザインの微調整を行う

---
### 背景・目的
これまで大まかなデザインを実装してきたが、色やスマホ画面での若干の配置のズレなどは残っていた為。

---

### 内容
- [x] ヘッダーの高さを、ログイン前・ログイン後同じにそろえる
- [x] 「Stay Friends～ともだちと再びつながるアプリ～」のFriendsと~の間にスペースを空ける
- [x] スマホ画面でも、ヘッダーを表示させる
- [x] フラッシュメッセージのデザインを統一する
- [x] ベースカラー、アクセントカラー、メインカラーを当てていく
  - [x] ページの背景色（ivory-white）
  - [x] ヘッダーの背景色（almond）
- [x] フッター
  - [x] 背景色を設定する
  - [x] 高さを調整
- [x] レスポンシブデザインのブレイクポイントをsm->mdへ変更
- [x] ボタンの色を黄色にする

---
### 対応しないこと
- 連絡帳のデザインは別イシューで対応

---
### 補足
This PR close #251 