### PR TITLE
アルバム関連ページ　デザイン調整

### DIFF
--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:tab_title, "アルバム") %>
 
-<div class="flex h-full flex-col md:flex-row">
+<div id="outer-frame" class="flex h-full flex-col md:flex-row">
   <%= render "shared/sidebar", profile: @profile%>
   <%= render "shared/top_tab", profile: @profile%>
 
-  <div class="flex flex-col w-full items-center mt-5 md:mt-10 mb-20 md:mb-10">
-    <div class="md:border md:rounded-3xl md:border-slate-100 md:p-10 md:mt-10 md:bg-opacity-10 md:shadow-2xl">
+  <div id="right-section" class="flex flex-col w-full items-center mt-5 md:mt-10 mb-20 md:mb-10">
+    <div id="card" class="md:border md:rounded-3xl md:border-slate-100 md:p-10 md:mt-10 md:bg-opacity-10 md:shadow-2xl">
       <div data-controller="previews" class="flex flex-col">
         <%= form_with(model: [profile, album], data: { turbo: false }) do |form| %>
           <%= render 'shared/error_messages', model: form.object %>

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="flex flex-col items-center mb-20 md:mb-10">
+<div class="flex flex-col items-center mt-10 mb-20 md:mb-10">
   <div class="md:border md:rounded-3xl md:border-slate-100 md:p-10 md:mt-10 md:mt-10 md:bg-opacity-10 md:shadow-2xl">
     <div data-controller="previews" class="flex flex-col">
       <%= form_with(model: [profile, album], data: { turbo: false }) do |form| %>
@@ -37,8 +37,10 @@
             <% album.images.each do |image| %>
               <div id="<%= "#{dom_id(album)}-#{image.id}" %>">
                 <% if image.persisted? %>
-                  <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
-                  <%= link_to "削除", image_path(image), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
+                  <div class="flex flex-col text-center">
+                    <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
+                    <%= link_to "削除", image_path(image), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
+                  </div>
                 <% end %>
               </div>
             <% end %>

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -1,38 +1,52 @@
-<div data-controller="previews">
-  <%= form_with(model: [profile, album], data: { turbo: false }) do |form| %>
-    <%= render 'shared/error_messages', model: form.object %>
+<div class="flex flex-col items-center mb-20 md:mb-10">
+  <div class="md:border md:rounded-3xl md:border-slate-100 md:p-10 md:mt-10 md:mt-10 md:bg-opacity-10 md:shadow-2xl">
+    <div data-controller="previews" class="flex flex-col">
+      <%= form_with(model: [profile, album], data: { turbo: false }) do |form| %>
+        <%= render 'shared/error_messages', model: form.object %>
 
-    <%= form.label :date, "日付" %>
-    <%= form.date_field :date %>
+        <div class="mb-4">
+          <%= form.label :date, "日付", class: "block font-medium mb-1 text-black" %>
+          <%= form.date_field :date, class: "block font-medium mb-5 bg-button-gray text-white border border-gray-400 rounded" %>
+        </div>
 
-    <%= form.label :title, "タイトル" %>
-    <%= form.text_field :title %>
+        <div class="mb-4">
+          <%= form.label :title, "タイトル", class: "block font-medium mb-1 text-black" %>
+          <%= form.text_field :title, class: "w-full rounded p-2 bg-white border border-gray-400" %>
+        </div>
 
-    <%= form.label :diary, "ノート" %>
-    <%= form.text_area :diary %>
+        <div class="mb-4">
+          <%= form.label :diary, "ノート", class: "block font-medium mb-1 text-black" %>
+          <%= form.text_area :diary, class: "w-full rounded p-2 bg-white border border-gray-400" %>
+        </div>
 
-    <%= form.label :image, "写真" %>
-    <turbo-frame id="album_hidden_fields">
-      <% album.images.each do |image| %>
-        <% if image.persisted? %>
-          <%= form.hidden_field :images, multiple: true, value: image.signed_id %>
+        <div class="mb-4">
+          <%= form.label :image, "写真", class: "block font-medium mb-1 text-black" %>
+          <turbo-frame id="album_hidden_fields">
+            <% album.images.each do |image| %>
+              <% if image.persisted? %>
+                <%= form.hidden_field :images, multiple: true, value: image.signed_id %>
+              <% end %>
+            <% end %>
+          </turbo-frame>
+          <%= form.file_field :images, multiple: true, data: { previews_target: "input", action: "change->previews#preview" } %>
+        </div>
+
+        <div class="flex justify-center">
+          <%= form.submit "保存する", class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
+        </div>
+      <% end %>
+
+      <% if album.images.attached? && album.persisted? %>
+        <% album.images.each do |image| %>
+          <div id="<%= "#{dom_id(album)}-#{image.id}" %>">
+          <% if image.persisted? %>
+            <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
+            <%= link_to "削除", image_path(image), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
+          <% end %>
+          </div>
         <% end %>
       <% end %>
-    </turbo-frame>
-    <%= form.file_field :images, multiple: true, data: { previews_target: "input", action: "change->previews#preview" } %>
-
-    <%= form.submit "保存する", class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
-  <% end %>
-
-  <% if album.images.attached? && album.persisted? %>
-    <% album.images.each do |image| %>
-      <div id="<%= "#{dom_id(album)}-#{image.id}" %>">
-      <% if image.persisted? %>
-        <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
-        <%= link_to "削除", image_path(image), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
-      <% end %>
-      </div>
-    <% end %>
-  <% end %>
-  <div data-previews-target="previewContainer"></div>
+      <div data-previews-target="previewContainer"></div>
+    </div>
+  </div>
 </div>

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -1,26 +1,7 @@
 <% content_for(:tab_title, "アルバム") %>
 
 <div class="flex h-full flex-col md:flex-row">
-  <aside id="default-sidebar" class="w-64 h-full transition-transform -translate-x-full sm:translate-x-0 hidden md:block" aria-label="Sidebar">
-    <div class="h-full py-14 px-4  overflow-y-auto bg-stone-200 text-gray-900">
-        <ul class="space-y-10 font-medium text-lg">
-          <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
-            <%= link_to "基本情報", profile_path(@profile), class: "block w-full h-full" %>
-          </li>
-          <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
-            <%= link_to "アルバム", profile_albums_path(@profile), class: "block w-full h-full" %>
-          </li>
-          <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
-            <%= link_to "通知設定", profile_events_path(@profile), class: "block w-full h-full" %>
-          </li>
-          <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
-            <%= link_to profiles_path, class: "block w-full h-full" do %>
-              連絡先一覧
-            <% end %>
-          </li>
-        </ul>
-    </div>
-  </aside>
+  <%= render "shared/sidebar", profile: @profile%>
 
   <div role="tablist" class="tabs tabs-bordered mt-3 md:hidden">
     <%= link_to "基本情報", profile_path(@profile), role: "tab", class: "tab #{"tab-active" if current_page?(profile_path(@profile))}" %>
@@ -28,7 +9,7 @@
     <%= link_to "通知設定", profile_events_path(@profile), role: "tab #{"tab-active" if current_page?(profile_path(@profile))}", class: "tab" %>
   </div>
 
-  <div class="flex flex-col w-full items-center mt-5 mb-20 md:mb-10">
+  <div class="flex flex-col w-full items-center mt-5 md:mt-10 mb-20 md:mb-10">
     <div class="md:border md:rounded-3xl md:border-slate-100 md:p-10 md:mt-10 md:bg-opacity-10 md:shadow-2xl">
       <div data-controller="previews" class="flex flex-col">
         <%= form_with(model: [profile, album], data: { turbo: false }) do |form| %>

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -1,62 +1,90 @@
 <% content_for(:tab_title, "アルバム") %>
 
-<div class="flex flex-col items-center mt-10 mb-20 md:mb-10">
-  <div class="md:border md:rounded-3xl md:border-slate-100 md:p-10 md:mt-10 md:mt-10 md:bg-opacity-10 md:shadow-2xl">
-    <div data-controller="previews" class="flex flex-col">
-      <%= form_with(model: [profile, album], data: { turbo: false }) do |form| %>
-        <%= render 'shared/error_messages', model: form.object %>
+<div class="flex h-full flex-col md:flex-row">
+  <aside id="default-sidebar" class="w-64 h-full transition-transform -translate-x-full sm:translate-x-0 hidden md:block" aria-label="Sidebar">
+    <div class="h-full py-14 px-4  overflow-y-auto bg-stone-200 text-gray-900">
+        <ul class="space-y-10 font-medium text-lg">
+          <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
+            <%= link_to "基本情報", profile_path(@profile), class: "block w-full h-full" %>
+          </li>
+          <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
+            <%= link_to "アルバム", profile_albums_path(@profile), class: "block w-full h-full" %>
+          </li>
+          <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
+            <%= link_to "通知設定", profile_events_path(@profile), class: "block w-full h-full" %>
+          </li>
+          <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
+            <%= link_to profiles_path, class: "block w-full h-full" do %>
+              連絡先一覧
+            <% end %>
+          </li>
+        </ul>
+    </div>
+  </aside>
 
-        <div class="mb-4">
-          <%= form.label :date, "日付", class: "block font-medium mb-1 text-black" %>
-          <%= form.date_field :date, class: "block font-medium mb-5 bg-button-gray text-white border border-gray-400 rounded" %>
-        </div>
+  <div role="tablist" class="tabs tabs-bordered mt-3 md:hidden">
+    <%= link_to "基本情報", profile_path(@profile), role: "tab", class: "tab #{"tab-active" if current_page?(profile_path(@profile))}" %>
+    <%= link_to "アルバム", profile_albums_path(@profile), role: "tab #{"tab-active" if current_page?(profile_path(@profile))}", class: "tab" %>
+    <%= link_to "通知設定", profile_events_path(@profile), role: "tab #{"tab-active" if current_page?(profile_path(@profile))}", class: "tab" %>
+  </div>
 
-        <div class="mb-4">
-          <%= form.label :title, "タイトル", class: "block font-medium mb-1 text-black" %>
-          <%= form.text_field :title, class: "w-full rounded p-2 bg-white border border-gray-400" %>
-        </div>
+  <div class="flex flex-col w-full items-center mt-5 mb-20 md:mb-10">
+    <div class="md:border md:rounded-3xl md:border-slate-100 md:p-10 md:mt-10 md:bg-opacity-10 md:shadow-2xl">
+      <div data-controller="previews" class="flex flex-col">
+        <%= form_with(model: [profile, album], data: { turbo: false }) do |form| %>
+          <%= render 'shared/error_messages', model: form.object %>
 
-        <div class="mb-4">
-          <%= form.label :diary, "ノート", class: "block font-medium mb-1 text-black" %>
-          <%= form.text_area :diary, class: "w-full rounded p-2 bg-white border border-gray-400" %>
-        </div>
+          <div class="mb-4">
+            <%= form.label :date, "日付", class: "block font-medium mb-1 text-black" %>
+            <%= form.date_field :date, class: "block font-medium mb-5 bg-button-gray text-white border border-gray-400 rounded" %>
+          </div>
 
-        <div class="mb-4">
-          <%= form.label :image, "写真", class: "block font-medium mb-1 text-black" %>
-          <turbo-frame id="album_hidden_fields">
-            <% album.images.each do |image| %>
-              <% if image.persisted? %>
-                <%= form.hidden_field :images, multiple: true, value: image.signed_id %>
+          <div class="mb-4">
+            <%= form.label :title, "タイトル", class: "block font-medium mb-1 text-black" %>
+            <%= form.text_field :title, class: "w-full rounded p-2 bg-white border border-gray-400" %>
+          </div>
+
+          <div class="mb-4">
+            <%= form.label :diary, "ノート", class: "block font-medium mb-1 text-black" %>
+            <%= form.text_area :diary, class: "w-full rounded p-2 bg-white border border-gray-400" %>
+          </div>
+
+          <div class="mb-4">
+            <%= form.label :image, "写真", class: "block font-medium mb-1 text-black" %>
+            <turbo-frame id="album_hidden_fields">
+              <% album.images.each do |image| %>
+                <% if image.persisted? %>
+                  <%= form.hidden_field :images, multiple: true, value: image.signed_id %>
+                <% end %>
+              <% end %>
+            </turbo-frame>
+            <%= form.file_field :images, multiple: true, data: { previews_target: "input", action: "change->previews#preview" } %>
+          </div>
+
+          <!--DBに保存済みの写真を表示する-->
+          <div class="flex justify-center space-x-4 mb-4">
+            <% if album.images.attached? && album.persisted? %>
+              <% album.images.each do |image| %>
+                <div id="<%= "#{dom_id(album)}-#{image.id}" %>">
+                  <% if image.persisted? %>
+                    <div class="flex flex-col text-center">
+                      <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
+                      <%= link_to "削除", image_path(image), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
+                    </div>
+                  <% end %>
+                </div>
               <% end %>
             <% end %>
-          </turbo-frame>
-          <%= form.file_field :images, multiple: true, data: { previews_target: "input", action: "change->previews#preview" } %>
-        </div>
+          </div>
 
-        <!--DBに保存済みの写真を表示する-->
-        <div class="flex justify-center space-x-4 mb-4">
-          <% if album.images.attached? && album.persisted? %>
-            <% album.images.each do |image| %>
-              <div id="<%= "#{dom_id(album)}-#{image.id}" %>">
-                <% if image.persisted? %>
-                  <div class="flex flex-col text-center">
-                    <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
-                    <%= link_to "削除", image_path(image), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
-                  </div>
-                <% end %>
-              </div>
-            <% end %>
-          <% end %>
-        </div>
+          <!--アップロードした写真を表示する-->
+          <div data-previews-target="previewContainer" class="flex justify-center space-x-4 mb-4" ></div>
 
-        <!--アップロードした写真を表示する-->
-        <div data-previews-target="previewContainer" class="flex justify-center space-x-4 mb-4" ></div>
-
-        <div class="flex justify-center">
-          <%= form.submit "保存する", class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
-        </div>
-      <% end %>
-
+          <div class="flex justify-center mb-20">
+            <%= form.submit "保存する", class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -31,22 +31,28 @@
           <%= form.file_field :images, multiple: true, data: { previews_target: "input", action: "change->previews#preview" } %>
         </div>
 
+        <!--DBに保存済みの写真を表示する-->
+        <div class="flex justify-center space-x-4 mb-4">
+          <% if album.images.attached? && album.persisted? %>
+            <% album.images.each do |image| %>
+              <div id="<%= "#{dom_id(album)}-#{image.id}" %>">
+                <% if image.persisted? %>
+                  <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
+                  <%= link_to "削除", image_path(image), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
+                <% end %>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+
+        <!--アップロードした写真を表示する-->
+        <div data-previews-target="previewContainer" class="flex justify-center space-x-4 mb-4" ></div>
+
         <div class="flex justify-center">
           <%= form.submit "保存する", class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
         </div>
       <% end %>
 
-      <% if album.images.attached? && album.persisted? %>
-        <% album.images.each do |image| %>
-          <div id="<%= "#{dom_id(album)}-#{image.id}" %>">
-          <% if image.persisted? %>
-            <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
-            <%= link_to "削除", image_path(image), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
-          <% end %>
-          </div>
-        <% end %>
-      <% end %>
-      <div data-previews-target="previewContainer"></div>
     </div>
   </div>
 </div>

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -1,3 +1,5 @@
+<% content_for(:tab_title, "アルバム") %>
+
 <div class="flex flex-col items-center mt-10 mb-20 md:mb-10">
   <div class="md:border md:rounded-3xl md:border-slate-100 md:p-10 md:mt-10 md:mt-10 md:bg-opacity-10 md:shadow-2xl">
     <div data-controller="previews" class="flex flex-col">

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -2,12 +2,7 @@
 
 <div class="flex h-full flex-col md:flex-row">
   <%= render "shared/sidebar", profile: @profile%>
-
-  <div role="tablist" class="tabs tabs-bordered mt-3 md:hidden">
-    <%= link_to "基本情報", profile_path(@profile), role: "tab", class: "tab #{"tab-active" if current_page?(profile_path(@profile))}" %>
-    <%= link_to "アルバム", profile_albums_path(@profile), role: "tab #{"tab-active" if current_page?(profile_path(@profile))}", class: "tab" %>
-    <%= link_to "通知設定", profile_events_path(@profile), role: "tab #{"tab-active" if current_page?(profile_path(@profile))}", class: "tab" %>
-  </div>
+  <%= render "shared/top_tab", profile: @profile%>
 
   <div class="flex flex-col w-full items-center mt-5 md:mt-10 mb-20 md:mb-10">
     <div class="md:border md:rounded-3xl md:border-slate-100 md:p-10 md:mt-10 md:bg-opacity-10 md:shadow-2xl">

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -1,27 +1,7 @@
 <% content_for(:tab_title, "アルバム") %>
 
 <div class="flex h-full flex-col md:flex-row">
-  <aside id="default-sidebar" class="w-64 h-full transition-transform -translate-x-full sm:translate-x-0 hidden md:block" aria-label="Sidebar">
-    <div class="h-full py-14 px-4  overflow-y-auto bg-stone-200 text-gray-900">
-        <ul class="space-y-10 font-medium text-lg">
-          <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
-            <%= link_to "基本情報", profile_path(@profile), class: "block w-full h-full" %>
-          </li>
-          <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
-            <%= link_to "アルバム", profile_albums_path(@profile), class: "block w-full h-full" %>
-          </li>
-          <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
-            <%= link_to "通知設定", profile_events_path(@profile), class: "block w-full h-full" %>
-          </li>
-          <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
-            <%= link_to profiles_path, class: "block w-full h-full" do %>
-              連絡先一覧
-            <% end %>
-          </li>
-        </ul>
-    </div>
-  </aside>
-
+  <%= render "shared/sidebar", profile: @profile%>
 
 <div class="flex w-full items-center flex-col">
   <div class="grid grid-cols-2 md:grid-cols-3 gap-4 w-full overflow-auto p-5 flex-grow">

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -1,96 +1,33 @@
 <% content_for(:tab_title, "アルバム") %>
 
-<div class="flex h-full flex-col md:flex-row">
+<div id="outer-frame" class="flex h-full flex-col md:flex-row">
   <%= render "shared/sidebar", profile: @profile%>
+  <%= render "shared/top_tab", profile: @profile%>
 
-<div class="flex w-full items-center flex-col">
-  <div class="grid grid-cols-2 md:grid-cols-3 gap-4 w-full overflow-auto p-5 flex-grow">
-    <% @albums.each do |album| %>
-      <div class="h-44 md:h-72 bg-white border border-gray-200 rounded-lg shadow">
-        <% if album.images.attached? %>
-          <%= image_tag album.images.first, class: "w-full h-24 md:h-48 object-cover rounded-t-lg" %>
-        <% end %>
-          <div class="flex flex-col p-2">
-            <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 truncate ..."><%= album.title %></h5>
-            <div class="flex justify-end space-x-2">
-              <div><%= album.date %></div>
-              <%= link_to profile_album_path(@profile, album) do %>
-                <i class="fa-solid fa-circle-info fa-lg"></i>
-              <% end %>
-              <%= link_to edit_profile_album_path(@profile, album) do %>
-                <i class="fa-solid fa-pen-to-square fa-lg"></i>
-              <% end %>
+  <div id="right-section" class="flex w-full items-center flex-col">
+    <div class="grid grid-cols-2 md:grid-cols-3 gap-4 w-full overflow-auto p-5 flex-grow">
+      <% @albums.each do |album| %>
+        <div class="h-44 md:h-72 bg-white border border-gray-200 rounded-lg shadow">
+          <% if album.images.attached? %>
+            <%= image_tag album.images.first, class: "w-full h-24 md:h-48 object-cover rounded-t-lg" %>
+          <% end %>
+            <div class="flex flex-col p-2">
+              <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 truncate ..."><%= album.title %></h5>
+              <div class="flex justify-end space-x-2">
+                <div><%= album.date %></div>
+                <%= link_to profile_album_path(@profile, album) do %>
+                  <i class="fa-solid fa-circle-info fa-lg"></i>
+                <% end %>
+                <%= link_to edit_profile_album_path(@profile, album) do %>
+                  <i class="fa-solid fa-pen-to-square fa-lg"></i>
+                <% end %>
+              </div>
             </div>
-          </div>
-      </div>
+        </div>
+      <% end %>
+    </div>
+    <%= link_to new_profile_album_path, class: "btn bg-golden text-black border-none hover:bg-yellow-500 mb-16 md:mb-5" do %>
+      <button>アルバムを作成</button>
     <% end %>
   </div>
-  <%= link_to new_profile_album_path, class: "btn bg-golden text-black border-none hover:bg-yellow-500 mb-16 md:mb-5" do %>
-    <button>アルバムを作成</button>
-  <% end %>
 </div>
-
-
-<!---
-  <div class="flex w-full justify-center">
-    <div class="w-8/12 shadow-lg border rounded-3xl border-slate-100 mt-8">
-      <div class="flex justify-center my-4">
-        <%= link_to new_profile_album_path, class: "btn bg-golden text-black border-none hover:bg-yellow-500" do %>
-          <button>アルバムを作成</button>
-        <% end %>
-      </div>
-      <table class="w-full text-sm text-left rtl:text-right text-gray-500">
-          <thead class="text-gray-700 uppercase bg-gray-100">
-              <tr>
-                  <th scope="col" class="px-1 py-3 w-32">
-                      日付
-                  </th>
-                  <th scope="col" class="px-6 py-3">
-                      タイトル
-                  </th>
-                  <th scope="col" class="px-6 py-3">
-                      サムネイル
-                  </th>
-                  <th scope="col" class="px-6 py-3">
-                  </th>
-              </tr>
-          </thead>
-          <tbody>
-            <% @albums.each do |album| %>
-              <tr id="album_<%= album.id %>" class="bg-white border-b hover:bg-gray-50">
-                <td class="px-6 py-4 font-semibold">
-                    <%= album.date %>
-                </td>
-                <td class="px-6 py-4 font-semibold">
-                    <%= album.title %>
-                </td>
-                <th scope="row" class="flex items-center px-6 py-4 text-gray-900 whitespace-nowrap">
-                  <%= image_tag album.images.first.variant(resize_to_limit: [100, 100]) if album.images.attached? %>
-                </th>
-                <td class="px-6 py-4 font-semibold">
-                  <div class="flex justify-around">
-                    <div>
-                      <%= link_to profile_album_path(@profile, album) do %>
-                        <i class="fa-solid fa-circle-info fa-lg"></i>
-                      <% end %>
-                    </div>
-                    <div>
-                      <%= link_to edit_profile_album_path(@profile, album) do %>
-                        <i class="fa-solid fa-pen-to-square fa-lg"></i>
-                      <% end %>
-                    </div>
-                    <div>
-                        <%= link_to profile_album_path(@profile, album), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
-                        <i class="fa-solid fa-trash fa-lg"></i>
-                      <% end %>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-      </table>
-    </div>
-  </div>
-</div>
---->

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -3,26 +3,29 @@
   <%= render "shared/sidebar", profile: @profile%>
 
   <div id="right-section" class="h-full w-full flex md:items-center justify-center">
-    <div id="card" class="md:flex md:flex-col md:items-center md:border md:rounded-3xl md:border-slate-100 md:bg-opacity-10 md:shadow-2xl w-2/3 mb-20 md:mb-0">
-    <div id="title" class="flex flex-col mt-5">
-      <div class="text-3xl w-full"><%= @album.title %></div>
-      <div class="text-center w-full"><%= @album.date %></div>
+    <div id="card" class="flex flex-col items-center md:border md:rounded-3xl md:border-slate-100 md:bg-opacity-10 md:shadow-2xl w-2/3 mb-20 md:mb-0">
+      <div id="title" class="flex flex-col mt-5">
+        <div class="text-3xl text-center w-full"><%= @album.title %></div>
+        <div class="text-center w-full"><%= @album.date %></div>
+      </div>
+      <div id="icon" class="flex justify-center space-x-2">
+        <%= link_to edit_profile_album_path(@profile, @album) do %>
+          <i class="fa-solid fa-pen-to-square fa-lg"></i>
+        <% end %>
+        <%= link_to profile_album_path(@profile, @album), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
+          <i class="fa-solid fa-trash fa-lg"></i>
+        <% end %>
+      </div>
+      <div id="grid" class="h-2/3 grid grid-cols-1 md:grid-cols-3 gap-4 w-full p-5 overflow-auto">
+        <% @album.images.each do |image| %>
+          <div class="h-fit rounded-lg shadow">
+            <%= image_tag image.variant(resize_to_limit: [100, 100]), class: "w-full h-fit md:h-48 object-cover rounded-t-lg" %>
+          </div>
+        <% end %>
+      </div>
+      <div id="diary" class="h-20 w-11/12 rounded bg-white md:m-5 border border-gray-200 border-2 p-2">
+        <%= @album.diary %>
+      </div>
     </div>
-    <div id="icon" class="flex space-x-2">
-      <%= link_to edit_profile_album_path(@profile, @album) do %>
-        <i class="fa-solid fa-circle-info fa-lg"></i>
-      <% end %>
-      <%= link_to profile_album_path(@profile, @album), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
-        <i class="fa-solid fa-pen-to-square fa-lg"></i>
-      <% end %>
-    </div>
-    <div id="grid" class="grid grid-cols-2 md:grid-cols-3 gap-4 w-full overflow-auto p-5 flex-grow">
-      <% @album.images.each do |image| %>
-        <div class="h-fit rounded-lg shadow">
-          <%= image_tag image.variant(resize_to_limit: [100, 100]), class: "w-full h-24 md:h-48 object-cover rounded-t-lg" %>
-        </div>
-      <% end %>
-    </div>
-    <div id="diary" class="w-11/12 rounded bg-white m-5 border border-gray-200 border-2 p-4"><%= @album.diary %></div>
   </div>
 </div>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -1,6 +1,7 @@
 <% content_for(:tab_title, "アルバム") %>
 <div id="outer-frame" class="flex h-full flex-col md:flex-row">
   <%= render "shared/sidebar", profile: @profile%>
+  <%= render "shared/top_tab", profile: @profile%>
 
   <div id="right-section" class="h-full w-full flex md:items-center justify-center">
     <div id="card" class="flex flex-col items-center md:border md:rounded-3xl md:border-slate-100 md:bg-opacity-10 md:shadow-2xl w-2/3 mb-20 md:mb-0">

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -1,14 +1,28 @@
 <% content_for(:tab_title, "アルバム") %>
+<div id="outer-frame" class="flex h-full flex-col md:flex-row">
+  <%= render "shared/sidebar", profile: @profile%>
 
-<%= @album.title %>
-<%= @album.date %>
-<%= @album.diary %>
-<% @album.images.each do |image| %>
-  <%= image_tag image.variant(resize_to_limit: [100, 100]) %>
-<% end %>
-<%= link_to edit_profile_album_path(@profile, @album) do %>
-  <button class="btn bg-slate-300 text-black border-none shadow-2xl">編集</button>
-<% end %>
-<%= link_to profile_album_path(@profile, @album), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
-  <button class="btn bg-slate-300 text-black border-none shadow-2xl">削除</button>
-<% end %>
+  <div id="right-section" class="h-full w-full flex md:items-center justify-center">
+    <div id="card" class="md:flex md:flex-col md:items-center md:border md:rounded-3xl md:border-slate-100 md:bg-opacity-10 md:shadow-2xl w-2/3 mb-20 md:mb-0">
+    <div id="title" class="flex flex-col mt-5">
+      <div class="text-3xl w-full"><%= @album.title %></div>
+      <div class="text-center w-full"><%= @album.date %></div>
+    </div>
+    <div id="icon" class="flex space-x-2">
+      <%= link_to edit_profile_album_path(@profile, @album) do %>
+        <i class="fa-solid fa-circle-info fa-lg"></i>
+      <% end %>
+      <%= link_to profile_album_path(@profile, @album), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
+        <i class="fa-solid fa-pen-to-square fa-lg"></i>
+      <% end %>
+    </div>
+    <div id="grid" class="grid grid-cols-2 md:grid-cols-3 gap-4 w-full overflow-auto p-5 flex-grow">
+      <% @album.images.each do |image| %>
+        <div class="h-fit rounded-lg shadow">
+          <%= image_tag image.variant(resize_to_limit: [100, 100]), class: "w-full h-24 md:h-48 object-cover rounded-t-lg" %>
+        </div>
+      <% end %>
+    </div>
+    <div id="diary" class="w-11/12 rounded bg-white m-5 border border-gray-200 border-2 p-4"><%= @album.diary %></div>
+  </div>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,77 +1,74 @@
 <% content_for(:tab_title, "連絡帳") %>
 
 
-<div class="flex h-full flex-col md:flex-row">
+<div id="outer-frame" class="flex h-full flex-col md:flex-row">
   <%= render "shared/sidebar", profile: @profile%>
   <%= render "shared/top_tab", profile: @profile%>
 
-  <div class="h-full w-full flex md:items-center justify-center">
-      <div class="flex justify-center w-full h-full md:items-center mt-5 md:mt-0">
-        <div class="md:flex md:border md:rounded-3xl md:border-slate-100 md:bg-opacity-10 md:shadow-2xl w-2/3 mb-20 md:mb-0">
-          <div id ="profile_info" class="flex flex-col flex-grow items-left justify-center md:mt-5">
-            <div class="md:flex md:mb-16 justify-center">
-              <div class="flex items-center ">
-                <div id="avatar" class="mt-7">
-                  <% if @profile.avatar.attached? %>
-                    <%= image_tag @profile.avatar.variant(resize_to_limit: [200, 200]), class: "w-20 h-auto" %>
-                  <% end %>
-                </div>
-                <div class="flex flex-col">
-                  <div class="text-xl tracking-widest">
-                    <%= @profile.furigana %>
-                  </div>
-                  <div class="text-4xl md:text-6xl">
-                    <%= @profile.name %>
-                  </div>
-                </div>
+  <div id="right-section" class="h-full w-full flex md:items-center justify-center">
+    <div id="card" class="md:flex md:border md:rounded-3xl md:border-slate-100 md:bg-opacity-10 md:shadow-2xl w-2/3 mb-20 md:mb-0">
+      <div id ="profile" class="flex flex-col flex-grow items-left justify-center md:mt-5">
+        <div class="md:flex md:mb-16 justify-center">
+          <div id="name" class="flex items-center ">
+            <div id="avatar" class="mt-7">
+              <% if @profile.avatar.attached? %>
+                <%= image_tag @profile.avatar.variant(resize_to_limit: [200, 200]), class: "w-20 h-auto" %>
+              <% end %>
+            </div>
+            <div class="flex flex-col">
+              <div class="text-xl tracking-widest">
+                <%= @profile.furigana %>
               </div>
-              <div class="flex flex-col items-center md:justify-end mx-2">
-                <div>
-                  <%= link_to edit_profile_path(@profile) do %>
-                    <i class="fa-solid fa-pen-to-square fa-lg"></i>
-                  <% end %>
-                  <%= link_to profile_path(@profile), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
-                    <i class="fa-regular fa-trash-can fa-lg"></i>
-                  <% end %>
-                </div>
+              <div class="text-4xl md:text-6xl">
+                <%= @profile.name %>
               </div>
             </div>
+          </div>
+          <div id="icon" class="flex flex-col items-center md:justify-end mx-2">
+            <div>
+              <%= link_to edit_profile_path(@profile) do %>
+                <i class="fa-solid fa-pen-to-square fa-lg"></i>
+              <% end %>
+              <%= link_to profile_path(@profile), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
+                <i class="fa-regular fa-trash-can fa-lg"></i>
+              <% end %>
+            </div>
+          </div>
+        </div>
 
-            <div class="flex md:px-44 py-4 md:py-2">
-              <div>
-                <div class="my-3 text-left">
-                  <i class="fa-solid fa-phone fa-lg mr-2"></i>
-                  <span class="text-base md:text-lg"><%= @profile.phone %></span>
-                </div>
-                <div class="my-3 text-left">
-                  <i class="fa-regular fa-envelope fa-lg mr-2"></i>
-                  <span class="text-base md:text-lg"><%= @profile.email %></span>
-                </div>
-                <div class="my-3 text-left">
-                  <i class="fa-solid fa-location-dot fa-lg mr-2"></i>
-                  <span class="text-base md:text-lg"><%= @profile.address %></span>
-                </div>
-                <div class="my-3 text-left">
-                  <i class="fa-brands fa-line fa-lg mr-2"></i>
-                  <span class="text-base md:text-lg"><%= @profile.line_name %></span>
-                </div>
-                <div class="my-3 text-left">
-                  <i class="fa-solid fa-check fa-lg mr-2"></i>
-                  <span class="text-base md:text-lg"><%= @profile.last_contacted_i18n %></span>
-                </div>
-                <div class="my-3 text-left">
-                  <i class="fa-solid fa-cake-candles fa-lg mr-2"></i>
-                  <span class="text-base md:text-lg"><%= @profile.events.first.date %></span>
-                </div>
-                <div class="my-3 text-left">
-                  <i class="fa-solid fa-calendar-check fa-lg mr-2"></i>
-                  <span class="text-base md:text-lg"><%= @profile.events.last.date %></span>
-                </div>
-                <div class="my-3 text-left w-full md:h-40 overflow-auto">
-                  <i class="fa-solid fa-pencil fa-lg mr-2"></i>
-                  <span class="text-base md:text-lg"><%= @profile.note %></span>
-                </div>
-              </div>
+        <div id="info" class="flex md:px-44 py-4 md:py-2">
+          <div>
+            <div class="my-3 text-left">
+              <i class="fa-solid fa-phone fa-lg mr-2"></i>
+              <span class="text-base md:text-lg"><%= @profile.phone %></span>
+            </div>
+            <div class="my-3 text-left">
+              <i class="fa-regular fa-envelope fa-lg mr-2"></i>
+              <span class="text-base md:text-lg"><%= @profile.email %></span>
+            </div>
+            <div class="my-3 text-left">
+              <i class="fa-solid fa-location-dot fa-lg mr-2"></i>
+              <span class="text-base md:text-lg"><%= @profile.address %></span>
+            </div>
+            <div class="my-3 text-left">
+              <i class="fa-brands fa-line fa-lg mr-2"></i>
+              <span class="text-base md:text-lg"><%= @profile.line_name %></span>
+            </div>
+            <div class="my-3 text-left">
+              <i class="fa-solid fa-check fa-lg mr-2"></i>
+              <span class="text-base md:text-lg"><%= @profile.last_contacted_i18n %></span>
+            </div>
+            <div class="my-3 text-left">
+              <i class="fa-solid fa-cake-candles fa-lg mr-2"></i>
+              <span class="text-base md:text-lg"><%= @profile.events.first.date %></span>
+            </div>
+            <div class="my-3 text-left">
+              <i class="fa-solid fa-calendar-check fa-lg mr-2"></i>
+              <span class="text-base md:text-lg"><%= @profile.events.last.date %></span>
+            </div>
+            <div class="my-3 text-left w-full md:h-40 overflow-auto">
+              <i class="fa-solid fa-pencil fa-lg mr-2"></i>
+              <span class="text-base md:text-lg"><%= @profile.note %></span>
             </div>
           </div>
         </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,26 +2,7 @@
 
 
 <div class="flex h-full flex-col md:flex-row">
-  <aside id="default-sidebar" class="w-64 h-full transition-transform -translate-x-full sm:translate-x-0 hidden md:block" aria-label="Sidebar">
-    <div class="h-full py-14 px-4  overflow-y-auto bg-stone-200 text-gray-900">
-        <ul class="space-y-10 font-medium text-lg">
-          <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
-            <%= link_to "基本情報", profile_path(@profile), class: "block w-full h-full" %>
-          </li>
-          <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
-            <%= link_to "アルバム", profile_albums_path(@profile), class: "block w-full h-full" %>
-          </li>
-          <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
-            <%= link_to "通知設定", profile_events_path(@profile), class: "block w-full h-full" %>
-          </li>
-          <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
-            <%= link_to profiles_path, class: "block w-full h-full" do %>
-              連絡先一覧
-            <% end %>
-          </li>
-        </ul>
-    </div>
-  </aside>
+  <%= render "shared/sidebar", profile: @profile%>
 
   <div role="tablist" class="tabs tabs-bordered mt-3 md:hidden">
     <%= link_to "基本情報", profile_path(@profile), role: "tab", class: "tab #{"tab-active" if current_page?(profile_path(@profile))}" %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -3,12 +3,7 @@
 
 <div class="flex h-full flex-col md:flex-row">
   <%= render "shared/sidebar", profile: @profile%>
-
-  <div role="tablist" class="tabs tabs-bordered mt-3 md:hidden">
-    <%= link_to "基本情報", profile_path(@profile), role: "tab", class: "tab #{"tab-active" if current_page?(profile_path(@profile))}" %>
-    <%= link_to "アルバム", profile_albums_path(@profile), role: "tab #{"tab-active" if current_page?(profile_path(@profile))}", class: "tab" %>
-    <%= link_to "通知設定", profile_events_path(@profile), role: "tab #{"tab-active" if current_page?(profile_path(@profile))}", class: "tab" %>
-  </div>
+  <%= render "shared/top_tab", profile: @profile%>
 
   <div class="h-full w-full flex md:items-center justify-center">
       <div class="flex justify-center w-full h-full md:items-center mt-5 md:mt-0">

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -4,7 +4,7 @@
         <li class="px-4 py-2 rounded-lg hover:bg-gray-100 <%= "bg-stone-500 text-white hover:bg-gray-100 hover:text-black" if current_page?(profile_path(profile))%>">
           <%= link_to "基本情報", profile_path(profile), class: "block w-full h-full" %>
         </li>
-        <li class="px-4 py-2 rounded-lg hover:bg-gray-100 <%= "bg-stone-500 text-white hover:bg-gray-100 hover:text-black" if current_page?( profile_albums_path(profile))%>">
+        <li class="px-4 py-2 rounded-lg hover:bg-gray-100 <%= "bg-stone-500 text-white hover:bg-gray-100 hover:text-black" if current_page?(profile_albums_path(profile))%>">
           <%= link_to "アルバム", profile_albums_path(profile), class: "block w-full h-full" %>
         </li>
         <li class="px-4 py-2 rounded-lg hover:bg-gray-100 <%= "bg-stone-500 text-white hover:bg-gray-100 hover:text-black" if current_page?(profile_events_path(profile))%>">

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,0 +1,20 @@
+<aside id="default-sidebar" class="w-64 h-full transition-transform -translate-x-full sm:translate-x-0 hidden md:block" aria-label="Sidebar">
+  <div class="h-full py-14 px-4  overflow-y-auto bg-stone-200 text-gray-900">
+      <ul class="space-y-10 font-medium text-lg">
+        <li class="px-4 py-2 rounded-lg hover:bg-gray-100 <%= "bg-stone-500 text-white hover:bg-gray-100 hover:text-black" if current_page?(profile_path(profile))%>">
+          <%= link_to "基本情報", profile_path(profile), class: "block w-full h-full" %>
+        </li>
+        <li class="px-4 py-2 rounded-lg hover:bg-gray-100 <%= "bg-stone-500 text-white hover:bg-gray-100 hover:text-black" if current_page?( profile_albums_path(profile))%>">
+          <%= link_to "アルバム", profile_albums_path(profile), class: "block w-full h-full" %>
+        </li>
+        <li class="px-4 py-2 rounded-lg hover:bg-gray-100 <%= "bg-stone-500 text-white hover:bg-gray-100 hover:text-black" if current_page?(profile_events_path(profile))%>">
+          <%= link_to "通知設定", profile_events_path(profile), class: "block w-full h-full" %>
+        </li>
+        <li class="px-4 py-2 rounded-lg hover:bg-gray-100">
+          <%= link_to profiles_path, class: "block w-full h-full" do %>
+            連絡先一覧
+          <% end %>
+        </li>
+      </ul>
+  </div>
+</aside>

--- a/app/views/shared/_top_tab.html.erb
+++ b/app/views/shared/_top_tab.html.erb
@@ -1,0 +1,5 @@
+<div role="tablist" class="tabs tabs-bordered mt-3 px-1 md:hidden">
+  <%= link_to "基本情報", profile_path(profile), role: "tab", class: "tab text-black rounded #{"bg-stone-500 text-white font-medium" if current_page?(profile_path(profile))}" %>
+  <%= link_to "アルバム", profile_albums_path(profile), role: "tab", class: "tab text-black rounded #{"bg-stone-500 text-white font-medium" if current_page?(profile_albums_path(profile))}" %>
+  <%= link_to "通知設定", profile_events_path(profile), role: "tab", class: "tab text-black rounded #{"bg-stone-500 text-white font-medium" if current_page?(profile_events_path(profile))}" %>
+</div>

--- a/app/views/shared/_top_tab.html.erb
+++ b/app/views/shared/_top_tab.html.erb
@@ -1,5 +1,14 @@
 <div role="tablist" class="tabs tabs-bordered mt-3 px-1 md:hidden">
-  <%= link_to "基本情報", profile_path(profile), role: "tab", class: "tab text-black rounded #{"bg-stone-500 text-white font-medium" if current_page?(profile_path(profile))}" %>
-  <%= link_to "アルバム", profile_albums_path(profile), role: "tab", class: "tab text-black rounded #{"bg-stone-500 text-white font-medium" if current_page?(profile_albums_path(profile))}" %>
-  <%= link_to "通知設定", profile_events_path(profile), role: "tab", class: "tab text-black rounded #{"bg-stone-500 text-white font-medium" if current_page?(profile_events_path(profile))}" %>
+  <%= link_to "基本情報",
+              profile_path(profile),
+              role: "tab",
+              class: "tab text-black rounded #{"bg-stone-500 text-white font-medium" if current_page?(profile_path(profile))}" %>
+  <%= link_to "アルバム",
+              profile_albums_path(profile),
+              role: "tab",
+              class: "tab text-black rounded #{"bg-stone-500 text-white font-medium" if current_page?(profile_albums_path(profile))}" %>
+  <%= link_to "通知設定",
+              profile_events_path(profile),
+              role: "tab",
+              class: "tab text-black rounded #{"bg-stone-500 text-white font-medium" if current_page?(profile_events_path(profile))}" %>
 </div>


### PR DESCRIPTION
### 概要
アルバム関連ページ　デザイン調整

---
### 背景・目的
アルバム関連ページ　デザイン調整

---

### 内容
- [x] アルバム作成フォームのレイアウトを他のフォームと統一
- [x] PCにはサイドバー、スマホにはトップバーを表示
- [x] サイドバーをパーシャルで作成し、各ページからレンダリングする
- [x] トップタブをパーシャルで作成し、ページでレンダリングする
- [x] 各要素にidを付け、構造を明確化する

---
### 対応しないこと
- 

---
### 補足
This PR close #261 