### PR TITLE
通知画面のデザイン調整

### DIFF
--- a/app/views/events/_notification_off.html.erb
+++ b/app/views/events/_notification_off.html.erb
@@ -30,7 +30,7 @@
   <% end %>
 </div>
 <div class="flex justify-center mt-10 text-sm md:text-xl">
-  <div class="text-center">
+  <div class="text-center text-red-500">
     <p>※マイページの通知設定がOFFになっているため、変更できません</p>
     マイページは<%= link_to "こちら", edit_user_path(@profile.user), class: "underline underline-offset-1" %>
   </div>

--- a/app/views/events/_notification_off.html.erb
+++ b/app/views/events/_notification_off.html.erb
@@ -10,7 +10,7 @@
           </div>
           <div class="flex items-center space-x-1">
             <%= i.select :notification_timing, [0,1,3,7,14,30,60], selected: i.object.notification_timing, class: "text-black w-full" %>
-            <p>日前に、</p>
+            <p>日前に</p>
           </div>
           <div class="flex items-center space-x-1 col-span-2 col-start-2 md:col-span-1">
             <p>通知</p>

--- a/app/views/events/_notification_off.html.erb
+++ b/app/views/events/_notification_off.html.erb
@@ -1,19 +1,20 @@
-<div class="pt-40 max-w-md mx-auto text-black text-2xl">
+<div class="w-full text-black text-sm md:text-2xl">
   <%= form_with model: @form, url: update_all_profile_events_path, method: :patch, data: { turbo: false } do |f| %>
     <fieldset disabled="disabled">
       <%= render 'shared/error_messages', model: f.object %>
 
       <%= f.fields_for :events do |i| %>
-        <div class="grid grid-cols-3 items-center gap-2 mb-4">
-          <div class="col-span-1">
+        <div class="grid grid-cols-2 md:grid-cols-3 items-center gap-1 mb-4 text-center">
+          <div>
             <%= "#{i.object.name}の" %>
           </div>
-          <div class="col-span-1">
-            <%= i.select :notification_timing, [0,1,3,7,14,30,60], selected: i.object.notification_timing, class: "text-black w-full" %>日前に、
+          <div class="flex items-center space-x-1">
+            <%= i.select :notification_timing, [0,1,3,7,14,30,60], selected: i.object.notification_timing, class: "text-black w-full" %>
+            <p>日前に、</p>
           </div>
-          <div class="col-span-1 flex items-center">
-            通知
-          <%= i.select :notification_enabled, ["しない"] %>
+          <div class="flex items-center space-x-1 col-span-2 col-start-2 md:col-span-1">
+            <p>通知</p>
+            <%= i.select :notification_enabled, ["しない"], class: "p-0" %>
           </div>
           <div>
             <%= i.hidden_field :date, value: i.object.date %>

--- a/app/views/events/_notification_on.html.erb
+++ b/app/views/events/_notification_on.html.erb
@@ -9,7 +9,7 @@
         </div>
         <div class="flex items-center space-x-1">
           <%= i.select :notification_timing, [0,1,3,7,14,30,60], selected: i.object.notification_timing, class: "text-black w-full" %>
-          <p>日前に、</p>
+          <p>日前に</p>
         </div>
         <div class="flex items-center space-x-1 col-span-2 col-start-2 md:col-span-1">
           <p>通知</p>

--- a/app/views/events/_notification_on.html.erb
+++ b/app/views/events/_notification_on.html.erb
@@ -1,17 +1,18 @@
-<div class="pt-40 max-w-md mx-auto text-2xl">
+<div class="w-full text-black text-sm md:text-2xl">
   <%= form_with model: @form, url: update_all_profile_events_path, method: :patch, data: { turbo: false } do |f| %>
     <%= render 'shared/error_messages', model: f.object %>
 
     <%= f.fields_for :events do |i| %>
-      <div class="grid grid-cols-3 items-center gap-2 mb-4">
-        <div class="col-span-1">
+      <div class="grid grid-cols-2 md:grid-cols-3 items-center gap-1 mb-4 text-center">
+        <div>
           <%= "#{i.object.name}の" %>
         </div>
-        <div class="col-span-1 text-white">
-          <%= i.select :notification_timing, [0,1,3,7,14,30,60], selected: i.object.notification_timing %><span class="text-black">日前に、</span>
+        <div class="flex items-center space-x-1">
+          <%= i.select :notification_timing, [0,1,3,7,14,30,60], selected: i.object.notification_timing, class: "text-black w-full" %>
+          <p>日前に、</p>
         </div>
-        <div class="col-span-1 flex items-center text-white">
-          <span class="text-black">通知</span>
+        <div class="flex items-center space-x-1 col-span-2 col-start-2 md:col-span-1">
+          <p>通知</p>
         <%= i.select :notification_enabled, [["する", "on"], ["しない", "off"]] %>
         </div>
         <div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,36 +1,31 @@
 <% content_for(:tab_title, "通知設定") %>
 
-<div class="drawer lg:drawer-open h-full">
-  <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
-  <div class="drawer-content bg-white flex flex-col md:flex h-full">
-    <div class="flex items-center mt-2 ml-2 p-3">
-      <%= image_tag @profile.avatar.variant(resize_to_limit: [50, 50]) if @profile.avatar.attached? %>
-      <p class="text-lg"><%= @profile.name%></p>
+<div id="outer-frame" class="flex h-full flex-col md:flex-row">
+  <%= render "shared/sidebar", profile: @profile%>
+  <%= render "shared/top_tab", profile: @profile%>
+
+  <div id="right-section" class="h-full w-full flex md:items-center justify-center">
+    <div id="card" class="w-full mt-5 md:p-10 md:flex flex-col md:border md:rounded-3xl md:border-slate-100 md:bg-opacity-10 md:shadow-2xl md:w-2/3 mb-20 md:mb-0">
+      <% if @profile.user.notification_enabled == "off" %>
+        <%= render "notification_off" %>
+      <% else %>
+        <%= render "notification_on" %>
+      <% end %>
+      <div id="notice" class="flex flex-col items-center mt-10 md:text-xl text-sm">
+        <p>※通知機能を使うためには、LINEの友達登録が必要です。</p>
+        <div>
+          友達登録は
+          <%= link_to line_qr_code_path, class:"underline underline-offset-1"	do %>
+            こちらから
+          <% end %>
+        </div>
     </div>
-    <% if @profile.user.notification_enabled == "off" %>
-      <%= render "notification_off" %>
-    <% else %>
-      <%= render "notification_on" %>
-    <% end %>
-    <div class="flex flex-col items-center mt-10 md:text-xl text-sm">
-      <p>※通知機能を使うためには、LINEの友達登録が必要です。</p>
-      <div>
-        友達登録は
-        <%= link_to line_qr_code_path, class:"underline underline-offset-1"	do %>
-          こちらから
-        <% end %>
-      </div>
-    </div>
-  </div>
-  <div class="drawer-side h-full">
-    <ul class="menu bg-base-200 text-base-content min-h-full w-80 p-4 text-lg justify-center items-center text-3xl">
-      <li class="m-3"><%= link_to "基本情報", profile_path(@profile), class: (current_page?(profile_path(@profile)) ? "text-red-400 underline underline-offset-8" : "") %></li>
-      <li class="m-3"><%= link_to "アルバム", profile_albums_path(@profile), class: (current_page?(profile_albums_path(@profile)) ? "text-red-400 underline underline-offset-8" : "") %></li>
-      <li class="m-3"><%= link_to "通知設定", profile_events_path(@profile), class: (current_page?(profile_events_path(@profile)) ? "text-red-400 underline underline-offset-8" : "") %></li>
-      <li class="m-3"><%= link_to profiles_path, class: (current_page?(profiles_path) ? "text-red-400 underline underline-offset-8" : "") do %>
-        <i class="fa-solid fa-backward"></i>連絡先一覧
-        <% end %>
-      </li>
-    </ul>
   </div>
 </div>
+
+<!--
+<div class="flex items-center mt-2 ml-2 p-3">
+  <%= image_tag @profile.avatar.variant(resize_to_limit: [50, 50]) if @profile.avatar.attached? %>
+  <p class="text-lg"><%= @profile.name%></p>
+</div>
+-->


### PR DESCRIPTION
### 概要
通知画面のデザイン調整

---
### 背景・目的
他ページとのデザインを統一する

---

### 内容
- [x] サイドバーを表示（PC用）
- [x] トップタブを表示（スマホ用）
- [x] 通知を表示するグリッドを調整
- [x] 「マイページでの通知設定がオフとなっています」というアラートを赤字にする
- [x] 「日前に、」→「日前に」に変更（句読点削除）

---
### 対応しないこと
- 

---
### 補足
This PR close #263 