### PR TITLE
バナーの閉じるボタンにidを付け、JSでバナーを隠すように実装

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -19,14 +19,14 @@ document.addEventListener("DOMContentLoaded", function() {
   });
 });
 
-document.querySelector('[data-dismiss-target="#sticky-banner-pc"]').addEventListener('click', function() {
+document.getElementById('close-banner-btn-pc').addEventListener('click', function() {
   var banner = document.getElementById('sticky-banner-pc');
   if (banner) {
       banner.style.display = 'none';
   }
 });
 
-document.querySelector('[data-dismiss-target="#sticky-banner-mb"]').addEventListener('click', function() {
+document.getElementById('close-banner-btn-mb').addEventListener('click', function() {
   var banner = document.getElementById('sticky-banner-mb');
   if (banner) {
       banner.style.display = 'none';

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -29,12 +29,12 @@
           </p>
       </div>
       <div class="flex items-center">
-          <button data-dismiss-target="#sticky-banner-pc" type="button" class="flex-shrink-0 inline-flex justify-center w-7 h-7 items-center text-gray-400 hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5">
-              <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
-                  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
-              </svg>
-              <span class="sr-only">Close banner</span>
-          </button>
+        <button id="close-banner-btn-pc" type="button" class="flex-shrink-0 inline-flex justify-center w-7 h-7 items-center text-gray-400 hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5">
+            <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
+            </svg>
+            <span class="sr-only">Close banner</span>
+        </button>
       </div>
   </div>
 
@@ -191,12 +191,12 @@
         </p>
       </div>
       <div class="flex items-center">
-          <button data-dismiss-target="#sticky-banner-mb" type="button" class="flex-shrink-0 inline-flex justify-center w-7 h-7 items-center text-gray-400 hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5">
-              <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
-                  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
-              </svg>
-              <span class="sr-only">Close banner</span>
-          </button>
+        <button id="close-banner-btn-mb" type="button" class="flex-shrink-0 inline-flex justify-center w-7 h-7 items-center text-gray-400 hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5">
+            <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
+            </svg>
+            <span class="sr-only">Close banner</span>
+        </button>
       </div>
   </div>
 


### PR DESCRIPTION
### 概要
バナーが消えないバグの解消

---
### 背景・目的
プロフィール一覧で表示するバナーの✕ボタンを押しても、バナーが消えない

---

### 内容
- [x] プロフィール一覧で表示するバナーの✕ボタンを押したら、バナーが消えるように修正する

---
### 対応しないこと
- 

---
### 補足
This PR close #268 