### PR TITLE
Feature/#271 line id registration by line login

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -10,15 +10,8 @@ class OauthsController < ApplicationController
 
   def callback
     provider = auth_params[:provider]
-    if @user = current_user
-      get_line_id(provider)
-      if @user.update(line_user_id: @user_hash[:uid])
-        flash[:success] = "ラインIDを登録しました"
-        redirect_back_or_to root_path
-      else
-        flash[:danger] = "ラインID登録に失敗しました"
-        redirect_back_or_to root_path
-      end
+    if (@user = current_user)
+      save_line_id(provider)
     elsif (@user = login_from(provider))
       redirect_back_or_to root_path, notice: "Logged in from #{provider.titleize}!"
     else
@@ -43,16 +36,17 @@ class OauthsController < ApplicationController
     redirect_to root_path, alert: "Failed to login from #{provider.titleize}!"
   end
 
-  def save_line_id
+  def save_line_id(provider)
     get_line_id(provider)
     if @user.update(line_user_id: @user_hash[:uid])
-      redirect_back_or_to root_path, notice: "ラインIDを登録しました"
+      flash[:success] = "ラインIDを登録しました"
     else
-      redirect_back_or_to root_path, notice: "ラインID登録に失敗しました"
+      flash[:danger] = "ラインID登録に失敗しました"
     end
+    redirect_back_or_to root_path
   end
 
-  def get_line_id(provider_name, should_remember = false)
+  def get_line_id(provider_name, _should_remember: false)
     sorcery_fetch_user_hash provider_name
   end
 end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -41,6 +41,15 @@ class OauthsController < ApplicationController
     redirect_to root_path, alert: "Failed to login from #{provider.titleize}!"
   end
 
+  def save_line_id
+    get_line_id(provider)
+    if @user.update(line_user_id: @user_hash[:uid])
+      redirect_back_or_to root_path, notice: "ラインIDを登録しました"
+    else
+      redirect_back_or_to root_path, notice: "ラインID登録に失敗しました"
+    end
+  end
+
   def get_line_id(provider_name, should_remember = false)
     sorcery_fetch_user_hash provider_name
   end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -10,7 +10,14 @@ class OauthsController < ApplicationController
 
   def callback
     provider = auth_params[:provider]
-    if (@user = login_from(provider))
+    if @user = current_user
+      get_line_id(provider)
+      if @user.update(line_user_id: @user_hash[:uid])
+        redirect_back_or_to root_path, notice: "ラインIDを登録しました"
+      else
+        redirect_back_or_to root_path, notice: "ラインID登録に失敗しました"
+      end
+    elsif (@user = login_from(provider))
       redirect_back_or_to root_path, notice: "Logged in from #{provider.titleize}!"
     else
       new_user_login(provider)
@@ -32,5 +39,9 @@ class OauthsController < ApplicationController
     redirect_back_or_to root_path, notice: "Logged in from #{provider.titleize}!"
   rescue StandardError
     redirect_to root_path, alert: "Failed to login from #{provider.titleize}!"
+  end
+
+  def get_line_id(provider_name, should_remember = false)
+    sorcery_fetch_user_hash provider_name
   end
 end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -13,9 +13,11 @@ class OauthsController < ApplicationController
     if @user = current_user
       get_line_id(provider)
       if @user.update(line_user_id: @user_hash[:uid])
-        redirect_back_or_to root_path, notice: "ラインIDを登録しました"
+        flash[:success] = "ラインIDを登録しました"
+        redirect_back_or_to root_path
       else
-        redirect_back_or_to root_path, notice: "ラインID登録に失敗しました"
+        flash[:danger] = "ラインID登録に失敗しました"
+        redirect_back_or_to root_path
       end
     elsif (@user = login_from(provider))
       redirect_back_or_to root_path, notice: "Logged in from #{provider.titleize}!"

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,15 +10,15 @@ class Event < ApplicationRecord
   end
 
   def scheduled_to_notify_today?
-    change_to_current_year - change_utc_to_jst(DateTime.now).to_date == notification_timing
+    event_date_this_year - today_utc_to_jst.to_date == notification_timing
   end
 
-  def change_to_current_year
+  def event_date_this_year
     Date.new(Date.today.year, date.mon, date.mday)
   end
 
-  def change_utc_to_jst(datetime)
-    datetime + 9.hours
+  def today_utc_to_jst
+    DateTime.now + 9.hours
   end
 
   def check_number_of_events

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,14 +10,14 @@ class Event < ApplicationRecord
   end
 
   def scheduled_to_notify_today?
-    event_date_this_year - today_utc_to_jst.to_date == notification_timing
+    event_date_this_year - utc_today_to_jst.to_date == notification_timing
   end
 
   def event_date_this_year
     Date.new(Date.today.year, date.mon, date.mday)
   end
 
-  def today_utc_to_jst
+  def utc_today_to_jst
     DateTime.now + 9.hours
   end
 

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,11 +1,13 @@
-<% flash.each do |message_type, message| %>
-  <div role= alert class="alert bg-ivory-white border border-4
-    <%= case message_type
-        when "success" then "alert-success border-green-600"
-        when "warning" then "alert-warning border-orange-600"
-        when "danger" then "alert-danger border-red-600"
-        end %>
-    <%= "absolute top-14" if current_page?(root_path) %>">
-    <div class="text-black font-bold"><%= message %></div>
-  </div>
-<% end %>
+<div class="flex justify-center">
+  <% flash.each do |message_type, message| %>
+    <div role= alert class="alert bg-ivory-white border border-4 w-11/12
+      <%= case message_type
+          when "success" then "alert-success border-green-600"
+          when "warning" then "alert-warning border-orange-600"
+          when "danger" then "alert-danger border-red-600"
+          end %>
+      <%= "absolute top-14" if current_page?(root_path) %>">
+      <div class="text-black font-bold"><%= message %></div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/static_pages/line_qr_code.html.erb
+++ b/app/views/static_pages/line_qr_code.html.erb
@@ -8,5 +8,9 @@
   <%= image_tag 'line_qr_code.png' %>
   <p class="text-xl mt-2">LINE公式アカウントID:@589vljjq</p>
 
+  <%= link_to auth_at_provider_path(provider: :line) do %>
+    <%= image_tag "btn_login_base.png", class:"w-32 h-auto mt-6"%>
+  <% end %>
+
   <%= link_to '前の画面に戻る', request.referer, class:"mt-5" %>
 </div>

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,5 +1,5 @@
 sorcery:
   # URL末尾に、/oauth/callback?provider=lineを付けること！
-  line_callback_url: "https://398f-111-188-249-255.ngrok-free.app/oauth/callback?provider=line"
+  line_callback_url: "https://23be-111-188-250-245.ngrok-free.app/oauth/callback?provider=line"
 default_url_options:
   host: "localhost:3000"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,2 +1,2 @@
 sorcery:
-  line_callback_url: "https://41ec-111-188-249-157.ngrok-free.app/oauth/callback?provider=line"
+  line_callback_url: "https://23be-111-188-250-245.ngrok-free.app/oauth/callback?provider=line"


### PR DESCRIPTION
### 概要
LINEログインを使って、LINE IDをユーザー情報に登録する

---
### 背景・目的
現状、メールアドレスを使って登録したユーザーに対して、LINE公式アカウントにメールアドレスを送信することで、
ユーザ情報にLINE IDを登録する仕組みにしている。
しかし、他のユーザーのメールアドレスを送信すると、他人のユーザーの通知が自分に届いてしまうため、セキュリティ面で課題がある。

---
### 内容
- [x] ログイン済みユーザーの場合、LINEログインからLINE IDを取得し、DBのline_user_idにLINE IDを保存する
- [x] LINE公式アカウントからのあいさつメッセージを編集
- [x] ログイン後ユーザーに対して、LINEログインリンクを表示
- [x] eventモデルメソッドの命名を分かりやすいものに変更
  - [x] change_utc_to_jst(datetime)　→　utc_today_to_jst
  - [x] change_to_current_year　→　event_date_this_year

---
### 対応しないこと
- 

---
### 補足
This PR close #271 