### PR TITLE
登録していない連絡先がバナーに表示される

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -13,8 +13,9 @@ class ProfilesController < ApplicationController
     @q = current_user.profiles.ransack(params[:q])
     @q.combinator = "or"
     @profiles = @q.result(distinct: true).includes(:events).order(created_at: :desc)
-    @profiles_birthdays_this_month = Profile.with_birthday_this_month
-    @profiles_special_day_this_month = Profile.with_special_day_this_month
+
+    @profiles_birthdays_this_month = current_user.profiles.select(&:birthdays_this_month)
+    @profiles_special_day_this_month = current_user.profiles.select(&:special_days_this_month)
   end
 
   def create

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -16,13 +16,13 @@ class Profile < ApplicationRecord
                      size: { less_than: 1.megabytes, message: "is too large" },
                      limit: { max: 1 }
 
-  scope :with_birthday_this_month, lambda {
-    joins(:events).where("events.name LIKE ? AND MONTH(events.date) = ?", "誕生日", Date.today.month)
-  }
+  def birthdays_this_month
+    events.first.date.month == Date.today.month
+  end
 
-  scope :with_special_day_this_month, lambda {
-    joins(:events).where("events.name NOT LIKE ? AND MONTH(events.date) = ?", "誕生日", Date.today.month)
-  }
+  def special_days_this_month
+    events.last.date.month == Date.today.month
+  end
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[name furigana line_name]

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -17,11 +17,11 @@ class Profile < ApplicationRecord
                      limit: { max: 1 }
 
   def birthdays_this_month
-    events.first.date.month == Date.today.month
+    events.first.date&.month == Date.today.month
   end
 
   def special_days_this_month
-    events.last.date.month == Date.today.month
+    events.last.date&.month == Date.today.month
   end
 
   def self.ransackable_attributes(_auth_object = nil)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -20,16 +20,8 @@ class Profile < ApplicationRecord
     joins(:events).where("events.name LIKE ? AND MONTH(events.date) = ?", "誕生日", Date.today.month)
   }
 
-  scope :with_birthday_next_month, lambda {
-    joins(:events).where("events.name LIKE ? AND MONTH(events.date) = ?", "誕生日", Date.today.next_month.month)
-  }
-
   scope :with_special_day_this_month, lambda {
     joins(:events).where("events.name NOT LIKE ? AND MONTH(events.date) = ?", "誕生日", Date.today.month)
-  }
-
-  scope :with_special_day_next_month, lambda {
-    joins(:events).where("events.name NOT LIKE ? AND MONTH(events.date) = ?", "誕生日", Date.today.next_month.month)
   }
 
   def self.ransackable_attributes(_auth_object = nil)


### PR DESCRIPTION
### 概要
登録していない連絡先がバナーに表示される問題の解消

---
### 背景・目的
[![Image from Gyazo](https://i.gyazo.com/67343f1b8bb0771cf120809abcfa7885.png)](https://gyazo.com/67343f1b8bb0771cf120809abcfa7885)

---
### 内容
#### 原因
クラスメソッドを使い、Profileテーブル全体に検索を掛けていた為、他のユーザーが登録した連絡先が表示されていた
```
@profiles_birthdays_this_month = Profile.with_birthday_this_month
@profiles_special_day_this_month = Profile.with_special_day_this_month
```

- [x] current_userからprofilesを呼び出す
- [x] インスタンスメソッドで、今月のイベントの検索を掛ける

---
### 対応しないこと
- 

---
### 補足
This PR close #273 