### PR TITLE
フラッシュメッセージがサイドバーを押し下げる問題

### DIFF
--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,6 +1,6 @@
 <div class="flex justify-center">
   <% flash.each do |message_type, message| %>
-    <div role= alert class="alert bg-ivory-white border border-4 w-11/12
+    <div role= alert class="alert bg-ivory-white border border-4
       <%= case message_type
           when "success" then "alert-success border-green-600"
           when "warning" then "alert-warning border-orange-600"


### PR DESCRIPTION
### 概要
フラッシュメッセージがサイドバーを押し下げる問題

---
### 背景・目的
[![Image from Gyazo](https://i.gyazo.com/3ca3e557078b4b626d08fd86a84d4d96.png)](https://gyazo.com/3ca3e557078b4b626d08fd86a84d4d96)
---

### 内容
- [x] サイドバーを押し下げることは解消できなかった為、スクリーンの幅いっぱいにフラッシュメッセージを表示することで、サイドバーが下がった時の余白を見せないようにする

---
### 対応しないこと

---
### 補足

