### PR TITLE
LINE友達登録ページのデザイン調整

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -4,8 +4,8 @@
   <%= render "shared/sidebar", profile: @profile%>
   <%= render "shared/top_tab", profile: @profile%>
 
-  <div id="right-section" class="h-full w-full flex md:items-center justify-center">
-    <div id="card" class="w-full mt-5 md:p-10 md:flex flex-col md:border md:rounded-3xl md:border-slate-100 md:bg-opacity-10 md:shadow-2xl md:w-2/3 mb-20 md:mb-0">
+  <div id="right-section" class="h-full w-full flex justify-center">
+    <div id="card" class="w-full h-fit mt-20 md:p-10 md:flex flex-col md:border md:rounded-3xl md:border-slate-100 md:bg-opacity-10 md:shadow-2xl md:w-2/3 mb-20 md:mb-0">
       <% if @profile.user.notification_enabled == "off" %>
         <%= render "notification_off" %>
       <% else %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -12,13 +12,14 @@
         <%= render "notification_on" %>
       <% end %>
       <div id="notice" class="flex flex-col items-center mt-10 md:text-xl text-sm">
-        <p>※通知機能を使うためには、LINEの友達登録が必要です。</p>
+        <p>※LINE通知機能を使うためには、LINE友達登録が必要です。</p>
         <div>
           友達登録は
           <%= link_to line_qr_code_path, class:"underline underline-offset-1"	do %>
             こちらから
           <% end %>
         </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/static_pages/line_qr_code.html.erb
+++ b/app/views/static_pages/line_qr_code.html.erb
@@ -1,16 +1,24 @@
 <% content_for(:tab_title, "LINE QRコード") %>
 
-<div class="flex items-center flex-col mt-40">
-  <p class="text-2xl mb-10">
-    QRコードを読み込むか、ID検索をして友達登録してね！<br>
-    登録した誕生日や大切な日にLINE通知を受けとることができるよ！
-  </p>
-  <%= image_tag 'line_qr_code.png' %>
-  <p class="text-xl mt-2">LINE公式アカウントID:@589vljjq</p>
-
-  <%= link_to auth_at_provider_path(provider: :line) do %>
-    <%= image_tag "btn_login_base.png", class:"w-32 h-auto mt-6"%>
-  <% end %>
-
-  <%= link_to '前の画面に戻る', request.referer, class:"mt-5" %>
+<h1 class="text-2xl md:text-4xl font-semibold text-center mt-10">LINE通知を受けとる設定</h1>
+<div id="main" class="flex w-full h-fit mt-20">
+  <div id="left-side" class="flex w-1/2 items-center flex-col h-1/2 p-2">
+    <h2 class="text-xl md:text-3xl font-semibold text-center mb-16">設定①</h2>
+    <p class="text-md md:text-2xl text-center mb-4">Stay FriendsのLINE公式アカウントに、友達登録をしてね！</p>
+    <%= image_tag "line_qr_code.png", class:"w-24 h-auto md:w-48 md:mb-8" %>
+    <p class="text-xs md:text-xl">LINE公式アカウントID: @589vljjq</p>
+  </div>
+  <div id="right-side" class="flex w-1/2 items-center flex-col h-1/2 p-2">
+    <h2 class="text-xl md:text-3xl font-semibold text-center mb-16">設定②</h2>
+    <p class="text-md md:text-2xl text-center">LINEログインをしてね！</p>
+    <p class="text-sm md:text-lg text-center mb-16">※メールアドレスでアカウント登録した人のみ</p>
+    <div class="flex justify-center">
+      <%= link_to auth_at_provider_path(provider: :line) do %>
+        <%= image_tag "btn_login_base.png", class:"w-24 md:w-32 h-auto"%>
+      <% end %>
+    </div>
+  </div>
+</div>
+<div class="flex justify-center w-full mt-10">
+  <%= link_to '前の画面に戻る', request.referer, class:"text-center" %>
 </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,39 +1,43 @@
 <% content_for(:tab_title, "マイページ") %>
-
 <div class="flex flex-col items-center">
-  <h1 class="text-3xl font-bold pt-20 pb-10">マイページ</h1>
-  <%= form_with model: @user, data: { turbo: false } do |f| %>
-    <div class="mb-4">
-      <%= f.label :name, "名前", class: "block font-medium mb-1 text-black" %>
-      <%= f.text_field :name, class: "w-full rounded p-2 bg-white border border-black" %>
-    </div>
+  <div id="card" class="md:border md:rounded-3xl md:border-slate-100 md:p-10 md:mt-10 md:bg-opacity-10 md:shadow-2xl h-full overflow-auto">
+    <div class="flex flex-col items-center">
+      <h1 class="text-3xl font-bold pt-10 md:pt-0 pb-10">マイページ</h1>
+      <%= form_with model: @user, data: { turbo: false } do |f| %>
+        <div class="mb-4">
+          <%= f.label :name, "名前", class: "block font-medium mb-1 text-black" %>
+          <%= f.text_field :name, class: "w-full rounded p-2 bg-white border border-black" %>
+        </div>
 
-    <div class="mb-4">
-      <%= f.label :notification_enabled, "LINE通知", class: "block font-medium mb-1 text-black" %>
-      <div class="col-span-1 flex items-center text-white">
-        <%= f.select :notification_enabled, [["ON", "on"], ["OFF", "off"]] %>
+        <div class="mb-4">
+          <%= f.label :notification_enabled, "LINE通知", class: "block font-medium mb-1 text-black" %>
+          <div class="col-span-1 flex items-center">
+            <%= f.select :notification_enabled, [["ON", "on"], ["OFF", "off"]] %>
+          </div>
+        </div>
+
+        <div class="flex justify-center">
+          <%= f.submit "更新", class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
+        </div>
+      <% end %>
+
+      <div class="mt-6">
+        <% unless @user.authentications.exists? %>
+          <%= link_to new_password_reset_path do %>
+            パスワードの変更は<span class="underline underline-offset-1">こちら</span>から
+          <% end %>
+        <% end %>
       </div>
-    </div>
-
-    <div class="flex justify-center">
-      <%= f.submit "更新", class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
-    </div>
-  <% end %>
-
-  <div class="mt-6">
-    <% unless @user.authentications.exists? %>
-      <%= link_to new_password_reset_path do %>
-        パスワードの変更は<span class="underline underline-offset-1">こちら</span>から
-      <% end %>
-    <% end %>
-  </div>
-  <div id="notice" class="flex flex-col items-center mt-6">
-    <p>※LINE通知機能を使うためには、LINE友達登録が必要です。</p>
-    <div>
-      友達登録は
-      <%= link_to line_qr_code_path, class:"underline underline-offset-1"	do %>
-        こちらから
-      <% end %>
+      <div id="notice" class="flex flex-col items-center mt-6 text-center">
+        <p>※LINE通知機能を使うためには、</p>
+        <p>LINE友達登録が必要です。</p>
+        <div>
+          友達登録は
+          <%= link_to line_qr_code_path, class:"underline underline-offset-1"	do %>
+            こちらから
+          <% end %>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -26,5 +26,14 @@
         パスワードの変更は<span class="underline underline-offset-1">こちら</span>から
       <% end %>
     <% end %>
-</div>
+  </div>
+  <div id="notice" class="flex flex-col items-center mt-6">
+    <p>※LINE通知機能を使うためには、LINE友達登録が必要です。</p>
+    <div>
+      友達登録は
+      <%= link_to line_qr_code_path, class:"underline underline-offset-1"	do %>
+        こちらから
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,20 +1,22 @@
 <% content_for(:tab_title, "マイページ") %>
 
 <div class="flex flex-col items-center">
-  <h1 class="text-3xl font-bold pt-20 pb-10">マイページ</h1>
-  <div>
-    <div class="mb-4">
-      <p class="block font-medium mb-1 text-black">ユーザー名</p>
-      <%= @user.name %>
-    </div>
+  <div id="card" class="md:border md:rounded-3xl md:border-slate-100 md:px-28 py-20 md:mt-10 md:bg-opacity-10 md:shadow-2xl h-full overflow-auto">
+    <h1 class="text-3xl font-bold pt-10 md:pt-0 pb-10">マイページ</h1>
+    <div>
+      <div class="mb-4">
+        <p class="block font-medium mb-1 text-black">ユーザー名</p>
+        <%= @user.name %>
+      </div>
 
-    <div class="mb-4">
-      <p class="block font-medium mb-1 text-black">LINE通知設定</p>
-      <%= @user.notification_enabled == "on" ? "ON" : "OFF" %>
-    </div>
+      <div class="mb-4">
+        <p class="block font-medium mb-1 text-black">LINE通知設定</p>
+        <%= @user.notification_enabled == "on" ? "ON" : "OFF" %>
+      </div>
 
-  </div>
-  <div class="mt-6">
-    <%= link_to "編集", edit_user_path(@user), class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
+    </div>
+    <div class="mt-6 flex justify-center">
+      <%= link_to "編集", edit_user_path(@user), class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
### 概要
LINE友達登録ページのデザイン調整

---
### 背景・目的
LINE友達登録ページのUIを改善し、LINE通知を受けとるための設定を分かりやすくする

---
### 内容
- [x] LINE友達登録ページ
  - [x] LINEログインリンクを設置
  - [x] 左右に分割で、設定手順を説明
- [x] マイページ
  - [x] 編集画面
    - [x] デザイン調整
    - [x] LINEログインリンクを設置
  - [x] 詳細画面
    - [x] LINEログインリンクを設置
    

---
### 対応しないこと
- 

---
### 補足
This PR close #163 