### PR TITLE
使い方説明ページをヘッダー・フッターに入れる

### DIFF
--- a/app/views/introductions/show.html.erb
+++ b/app/views/introductions/show.html.erb
@@ -2,12 +2,12 @@
 
 <div class="flex flex-col items-center">
   <div class="text-center text-lg md:text-2xl font-medium border rounded-3xl border-slate-100	p-8 md:p-10 md:mt-20 bg-opacity-10 shadow-2xl">
-    <p class="mb-10 md:mb-14">むかしは仲が良かった。</p>
+    <p class="mb-10 md:mb-14">昔、とても仲が良かったともだち。</p>
     <p class="mb-2 md:mb-3">でも、卒業・就職・引っ越しで、</p>
     <p class="mb-2 md:mb-3">いつの間にか、</p>
-    <p class="mb-10 md:mb-14">連絡が途絶えてしまった。</p>
-    <p class="mb-2 md:mb-3">そんなともだちを、</p>
-    <p class="mb-10 md:mb-14">頭に１人思い浮かべてください・・・</p>
+    <p class="mb-10 md:mb-14">連絡をすることも少なくなってしまった。</p>
+    <p class="mb-2 md:mb-3">そんなともだちは、</p>
+    <p class="mb-10 md:mb-14">いませんか？</p>
     <p class="mb-2 md:mb-3">今こそ、</p>
     <p class="mb-2 md:mb-3">あなたの大切なともだちに、</p>
     <p>メッセージを送りましょう。</p>

--- a/app/views/shared/_before_login_footer.html.erb
+++ b/app/views/shared/_before_login_footer.html.erb
@@ -18,6 +18,12 @@
       <div>連絡帳</div>
     </div>
     <div class="flex flex-col justify-center text-center">
+      <%= link_to how_to_use_path do %>
+        <i class="fa-regular fa-circle-question fa-lg"></i>
+      <% end %>
+      <div>使い方</div>
+    </div>
+    <div class="flex flex-col justify-center text-center">
       <%= link_to login_path do %>
         <i class="fa-solid fa-arrow-right-to-bracket fa-lg"></i>
       <% end %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -9,6 +9,10 @@
     <div class="font-bold space-x-8 mr-10 hidden md:block">
       <%= link_to "AIメッセージ作成", introduction_path(1) %>
       <%= link_to "連絡帳", profiles_path %>
+      <%= link_to how_to_use_path do %>
+        使い方
+        <i class="fa-regular fa-circle-question"></i>
+      <% end %>
       <%= link_to "ログイン", login_path %>
       <%= link_to new_user_path do %>
         <button class="btn bg-ivory-white text-black border-none hover:bg-peach-red <%= "hover:bg-slate-300" if current_page?(root_path) %>">新規登録</button>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -26,6 +26,12 @@
       <div>マイページ</div>
     </div>
     <div class="flex flex-col justify-center text-center">
+      <%= link_to how_to_use_path do %>
+        <i class="fa-regular fa-circle-question fa-lg"></i>
+      <% end %>
+      <div>使い方</div>
+    </div>
+    <div class="flex flex-col justify-center text-center">
       <div>
         <%= link_to logout_path, data: { turbo_method: :delete } do %>
           <i class="fa-solid fa-arrow-right-from-bracket fa-lg"></i>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,6 +9,10 @@
     <div class="font-bold space-x-8 mr-10 hidden md:block">
       <%= link_to "AIメッセージ作成", introduction_path(1) %>
       <%= link_to "連絡帳", profiles_path %>
+      <%= link_to how_to_use_path do %>
+        使い方
+        <i class="fa-regular fa-circle-question"></i>
+      <% end %>
       <%= link_to "マイページ", user_path(current_user)  %>
       <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete } %>
     </div>


### PR DESCRIPTION
### 概要
使い方説明ページをヘッダー・フッターに入れる

---
### 背景・目的
ユーザーの目につく場所に、使い方を設置するため
---

### 内容
- [x] ヘッダーに設置
- [x] フッターに設置

---
### 対応しないこと
- 

---
### 補足
‐ AIメッセージのイントロ文言も微修正