### PR TITLE
保存した画像を非同期で削除しようとすると発生するエラーの解消、フォーム調整

### DIFF
--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -36,6 +36,7 @@
               <% end %>
             </turbo-frame>
             <%= form.file_field :images, multiple: true, data: { previews_target: "input", action: "change->previews#preview" } %>
+            <p class="text-center p-4">※写真は３枚まで保存できます</p>
           </div>
 
           <!--DBに保存済みの写真を表示する-->

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -3,7 +3,7 @@
   <%= render "shared/top_tab", profile: profile, album: album %>
 
   <div id="right-section" class="flex flex-col w-full items-center mt-5 md:mt-10 mb-20 md:mb-10">
-    <div id="card" class="md:border md:rounded-3xl md:border-slate-100 md:p-10 md:mt-10 md:bg-opacity-10 md:shadow-2xl">
+    <div id="card" class="md:border md:rounded-3xl md:border-slate-100 md:p-10 md:mt-10 md:bg-opacity-10 md:shadow-2xl h-fit overflow-auto">
       <div>
         <h1 class="text-3xl font-bold pt-10 md:pt-0 pb-10">アルバムフォーム</h1>
       </div>
@@ -58,7 +58,7 @@
           <!--アップロードした写真を表示する-->
           <div data-previews-target="previewContainer" class="flex justify-center space-x-4 mb-4" ></div>
 
-          <div class="flex justify-center mb-20">
+          <div class="flex justify-center mb-20 md:mb-0">
             <%= form.submit "保存する", class: "btn bg-golden text-black border-none hover:bg-yellow-500" %>
           </div>
         <% end %>

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -8,7 +8,7 @@
         <h1 class="text-3xl font-bold pt-10 md:pt-0 pb-10">アルバムフォーム</h1>
       </div>
       <div data-controller="previews" class="flex flex-col">
-        <%= form_with(model: [profile, album], data: { turbo: false }) do |form| %>
+        <%= form_with(model: [profile, album]) do |form| %>
           <%= render 'shared/error_messages', model: form.object %>
 
           <div class="mb-4">


### PR DESCRIPTION
### 概要
保存した画像を非同期で削除しようとする発生するエラーの解消

---
### 背景・目的
[![Image from Gyazo](https://i.gyazo.com/ce27e9bd8e7ce02420a038f3f1dc9d1d.gif)](https://gyazo.com/ce27e9bd8e7ce02420a038f3f1dc9d1d)
---

### 内容
- [x] albumのformからturbo: falseを削除する
- [x] フォームの微調整
- [x] 登録できる画像枚数は３枚までという注意書きを追加

---
### 対応しないこと
- 

---
### 補足
This PR close #289 
