### PR TITLE
アルバム画像のサイズを調整

### DIFF
--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -9,7 +9,7 @@
       <% @albums.each do |album| %>
         <div class="h-44 md:h-72 bg-white border border-gray-200 rounded-lg shadow">
           <% if album.images.attached? %>
-            <%= image_tag album.images.first, class: "w-full h-24 md:h-48 object-cover rounded-t-lg" %>
+            <%= image_tag album.images.first.variant(resize_to_fill: [446, 192]), class: "rounded-t-lg" %>
           <% end %>
             <div class="flex flex-col p-2">
               <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 truncate ..."><%= album.title %></h5>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -20,7 +20,7 @@
       <div id="grid" class="h-2/3 grid grid-cols-1 md:grid-cols-3 gap-4 w-full p-5 overflow-auto">
         <% @album.images.each do |image| %>
           <div class="h-fit rounded-lg shadow">
-            <%= image_tag image.variant(resize_to_limit: [100, 100]), class: "w-full h-fit md:h-48 object-cover rounded-t-lg" %>
+            <%= image_tag image.variant(resize_to_fit: [300, 300]), class: "object-cover rounded-lg" %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
### 概要
表示する画像の大きさを調整する

---
### 背景・目的
アルバムに表示される画像がレイアウトにフィットしていなかった為（極端に拡大されていた）

---
### 内容
- [x] アルバム一覧では、resize_to_fill: [446, 192] を設定する
- [x] アルバム詳細では、resize_to_fill: [300, 300] を設定する

---
### 対応しないこと
- 

---
### 補足
This PR close #291 