### PR TITLE
スマホ画面での利用規約・プライバシーポリシー・問い合わせリンク

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,9 +1,9 @@
 <header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 md:block flex justify-center bg-peach-light">
-  <nav class="flex justify-between items-center justify-center h-14">
+  <nav class="flex justify-between items-center h-14 w-full">
     <div class="flex items-center md:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>
-        <span class="text-xl md:text-4xl">Stay Friends</span><span class="md:text-xl"> ～ともだちと再びつながるアプリ～</span>
+        <span class="text-xl md:text-4xl">Stay Friends</span><span class="text-xs md:text-xl"> ～ともだちと再びつながるアプリ～</span>
       <% end %>
     </div>
     <div class="font-bold space-x-8 mr-10 hidden md:block">
@@ -17,6 +17,41 @@
       <%= link_to new_user_path do %>
         <button class="btn bg-ivory-white text-black border-none hover:bg-peach-red <%= "hover:bg-slate-300" if current_page?(root_path) %>">新規登録</button>
       <% end %>
+    </div>
+    <div class="navbar-end drawer-end w-fit md:hidden">
+      <input id="my-drawer-4" type="checkbox" class="drawer-toggle" />
+      <div class="drawer-content">
+        <!-- Page content here -->
+        <label for="my-drawer-4" class="drawer-button btn btn-ghost">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="black" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 12.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 18.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5Z" /></svg>  
+        </label>
+      </div>
+      <div class="drawer-side z-50">
+        <label for="my-drawer-4" aria-label="close sidebar" class="drawer-overlay"></label>
+        <div class="p-4 pt-10 w-fit min-h-full bg-ivory-white text-black text-sm">
+          <!-- Sidebar content here -->
+          <div><%= link_to "AIメッセージ作成", introduction_path(1) %></div>
+          <div><%= link_to "連絡帳", profiles_path %></div>
+          <div class="divider divider-neutral"></div>
+          <div>
+            <%= link_to how_to_use_path do %>
+              使い方
+              <i class="fa-regular fa-circle-question"></i>
+            <% end %>
+          </div>
+          <div><%= link_to "ログイン", login_path %></div>
+          <div>
+            <%= link_to "新規登録", new_user_path %>
+          </div>
+          <div class="divider divider-neutral"></div>
+          <div><%= link_to "利用規約", terms_path %></div>
+          <div><%= link_to "プライバシーポリシー", privacy_policy_path %></div>
+          <div><%= link_to "お問い合わせ", "https://forms.gle/jj8fcaibi2Tvb9Yt7" %></div>
+
+          <div class="divider divider-neutral"></div>
+          <div><p>©️ 2024 - Stay Friends</p></div>
+        </div>
+      </div>
     </div>
   </nav>
 </header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,7 +3,7 @@
     <div class="flex items-center md:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>
-        <span class="text-xl md:text-4xl">Stay Friends</span><span class="md:text-xl"> ～ともだちと再びつながるアプリ～</span>
+        <span class="text-xl md:text-4xl">Stay Friends</span><span class="text-xs md:text-xl"> ～ともだちと再びつながるアプリ～</span>
       <% end %>
     </div>
     <div class="font-bold space-x-8 mr-10 hidden md:block">
@@ -15,6 +15,41 @@
       <% end %>
       <%= link_to "マイページ", user_path(current_user)  %>
       <%= link_to "ログアウト", logout_path, data: { turbo_method: :delete } %>
+    </div>
+
+    <div class="navbar-end drawer-end w-fit md:hidden">
+      <input id="my-drawer-4" type="checkbox" class="drawer-toggle" />
+      <div class="drawer-content">
+        <!-- Page content here -->
+        <label for="my-drawer-4" class="drawer-button btn btn-ghost">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="black" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 12.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 18.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5Z" /></svg>  
+        </label>
+      </div>
+      <div class="drawer-side">
+        <label for="my-drawer-4" aria-label="close sidebar" class="drawer-overlay"></label>
+        <div class="p-4 pt-10 w-fit min-h-full bg-ivory-white text-black text-xs">
+          <!-- Sidebar content here -->
+          <div><%= link_to "AIメッセージ作成", introduction_path(1) %></div>
+          <div><%= link_to "連絡帳", profiles_path %></div>
+          <div class="divider divider-neutral"></div>
+          <div>
+            <%= link_to how_to_use_path do %>
+              使い方
+              <i class="fa-regular fa-circle-question"></i>
+            <% end %>
+          </div>
+          <div><%= link_to "マイページ", user_path(current_user)  %></div>
+          <div><%= link_to "ログアウト", logout_path, data: { turbo_method: :delete } %></div>
+
+          <div class="divider divider-neutral"></div>
+          <div><%= link_to "利用規約", terms_path %></div>
+          <div><%= link_to "プライバシーポリシー", privacy_policy_path %></div>
+          <div><%= link_to "お問い合わせ", "https://forms.gle/jj8fcaibi2Tvb9Yt7" %></div>
+
+          <div class="divider divider-neutral"></div>
+          <div><p>©️ 2024 - Stay Friends</p></div>
+        </div>
+      </div>
     </div>
   </nav>
 </header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -25,9 +25,9 @@
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="black" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 12.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 18.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5Z" /></svg>  
         </label>
       </div>
-      <div class="drawer-side">
+      <div class="drawer-side z-50">
         <label for="my-drawer-4" aria-label="close sidebar" class="drawer-overlay"></label>
-        <div class="p-4 pt-10 w-fit min-h-full bg-ivory-white text-black text-xs">
+        <div class="p-4 pt-10 w-fit min-h-full bg-ivory-white text-black text-sm">
           <!-- Sidebar content here -->
           <div><%= link_to "AIメッセージ作成", introduction_path(1) %></div>
           <div><%= link_to "連絡帳", profiles_path %></div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <header class="<%= "absolute bg-white bg-opacity-30" if current_page?(root_path) %> top-0 left-0 w-full h-14 md:block flex justify-center bg-peach-light">
-  <nav class="flex justify-between items-center justify-center h-14">
-    <div class="flex items-center md:ml-10">
+  <nav class="flex justify-between items-center h-14 w-full">
+    <div class="flex items-center ml-2 md:ml-10">
       <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>
         <span class="text-xl md:text-4xl">Stay Friends</span><span class="text-xs md:text-xl"> ～ともだちと再びつながるアプリ～</span>


### PR DESCRIPTION
### 概要
スマホ画面での利用規約・プライバシーポリシー・問い合わせにアクセスできるようにする。

---
### 背景・目的
スマホ画面では、フッター（利用規約・プライバシーポリシー・問い合わせリンクがある）が隠れるようになっており、アクセスできなかった為
---

### 内容
- [x] スマホ画面でのヘッダーに、サイドメニューボタンを追加
- [x] サイドメニュー（ログイン前）
  - [x] AIメッセージ作成
  - [x] 連絡帳
  - [x] 使い方
  - [x] ログイン
  - [x] 新規登録
  - [x] 利用規約
  - [x] プライバシーポリシー
  - [x] 問い合わせ
- [x] サイドメニュー（ログイン後）
  - [x] AIメッセージ作成
  - [x] 連絡帳
  - [x] 使い方
  - [x] マイページ
  - [x] ログアウト
  - [x] 利用規約
  - [x] プライバシーポリシー
  - [x] 問い合わせ

---
### 対応しないこと
- 

---
### 補足