### PR TITLE
グループのCRUD作成と、テーブル設計の見直し

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -22,9 +22,9 @@ class GroupsController < ApplicationController
     @group = current_user.groups.find(params[:id])
   end
 
-
   def update
     @group = current_user.groups.find(params[:id])
+
     if @group.update(group_params)
       flash[:success] = "グループを更新しました"
       redirect_to groups_path

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -6,10 +6,10 @@ class GroupsController < ApplicationController
   def create
     @group = current_user.groups.new(group_params)
     if @group.save
-      flash[:success] = "アルバムを登録しました"
+      flash[:success] = "グループを登録しました"
       redirect_to groups_path
     else
-      flash[:danger] = "連絡先を登録できませんでした"
+      flash[:danger] = "グループを登録できませんでした"
       render :new, status: :unprocessable_entity
     end
   end
@@ -26,10 +26,10 @@ class GroupsController < ApplicationController
   def update
     @group = current_user.groups.find(params[:id])
     if @group.update(group_params)
-      flash[:success] = "アルバムを更新しました"
+      flash[:success] = "グループを更新しました"
       redirect_to groups_path
     else
-      flash[:danger] = "アルバムを更新できませんでした"
+      flash[:danger] = "グループを更新できませんでした"
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,48 @@
+class GroupsController < ApplicationController
+  def new
+    @group = current_user.groups.new
+  end
+
+  def create
+    @group = current_user.groups.new(group_params)
+    if @group.save
+      flash[:success] = "アルバムを登録しました"
+      redirect_to groups_path
+    else
+      flash[:danger] = "連絡先を登録できませんでした"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def index
+    @groups = current_user.groups
+  end
+
+  def edit
+    @group = current_user.groups.find(params[:id])
+  end
+
+
+  def update
+    @group = current_user.groups.find(params[:id])
+    if @group.update(group_params)
+      flash[:success] = "アルバムを更新しました"
+      redirect_to groups_path
+    else
+      flash[:danger] = "アルバムを更新できませんでした"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @group = current_user.groups.find(params[:id])
+    @group.destroy!
+    redirect_to groups_path
+  end
+
+  private
+
+  def group_params
+    params.require(:group).permit(:name)
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,7 @@
 class ProfilesController < ApplicationController
   before_action :set_q, only: %i[index]
+  before_action :set_profile_record, only: %i[edit update destroy]
+
   def new
     @profile = Profile.new
     @profile.events.build(name: "誕生日")
@@ -20,21 +22,12 @@ class ProfilesController < ApplicationController
   def create
     @profile = current_user.profiles.new(profile_params.except(:group))
     @profile.group = Group.find(profile_params[:group][:id])
-    if @profile.save
-      flash[:success] = "連絡先を登録しました"
-      redirect_to profile_path(@profile)
-    else
-      flash[:danger] = "連絡先を登録できませんでした"
-      render :new, status: :unprocessable_entity
-    end
+    profile_save
   end
 
-  def edit
-    @profile = current_user.profiles.includes(:events).find(params[:id])
-  end
+  def edit; end
 
   def update
-    @profile = current_user.profiles.find(params[:id])
     @profile.group = Group.find(profile_params[:group][:id])
     if @profile.update(profile_params.except(:group))
       update_success
@@ -45,7 +38,6 @@ class ProfilesController < ApplicationController
   end
 
   def destroy
-    @profile = current_user.profiles.find(params[:id])
     @profile.destroy!
 
     respond_to do |format|
@@ -74,5 +66,19 @@ class ProfilesController < ApplicationController
     @q = current_user.profiles.ransack(params[:q])
     @q.combinator = "or"
     @q.sorts = "name asc" if @q.sorts.empty?
+  end
+
+  def set_profile_record
+    @profile = current_user.profiles.find(params[:id])
+  end
+
+  def profile_save
+    if @profile.save
+      flash[:success] = "連絡先を登録しました"
+      redirect_to profile_path(@profile)
+    else
+      flash[:danger] = "連絡先を登録できませんでした"
+      render :new, status: :unprocessable_entity
+    end
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -18,8 +18,8 @@ class ProfilesController < ApplicationController
   end
 
   def create
-    @profile = current_user.profiles.new(profile_params)
-
+    @profile = current_user.profiles.new(profile_params.except(:group))
+    @profile.group = Group.find(profile_params[:group][:id])
     if @profile.save
       flash[:success] = "連絡先を登録しました"
       redirect_to profile_path(@profile)
@@ -56,7 +56,7 @@ class ProfilesController < ApplicationController
   private
 
   def profile_params
-    params.require(:profile).permit(:avatar, :name, :furigana, :phone, :email, :line_name, :address, :last_contacted, :note, events_attributes: %i[name date id])
+    params.require(:profile).permit(:avatar, :name, :furigana, :phone, :email, :line_name, :address, :last_contacted, :note, group: %i[id], events_attributes: %i[name date id])
   end
 
   def update_success

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -35,7 +35,8 @@ class ProfilesController < ApplicationController
 
   def update
     @profile = current_user.profiles.find(params[:id])
-    if @profile.update(profile_params)
+    @profile.group = Group.find(profile_params[:group][:id])
+    if @profile.update(profile_params.except(:group))
       update_success
     else
       flash[:danger] = "連絡先を更新できませんでした"

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,4 @@
 class Group < ApplicationRecord
   belongs_to :user
-  has_many :groups_profiles, dependent: :destroy
-  has_many :profiles, through: :groups_profiles
+  has_many :profiles, dependent: :destroy
 end

--- a/app/models/groups_profile.rb
+++ b/app/models/groups_profile.rb
@@ -1,4 +1,0 @@
-class GroupsProfile < ApplicationRecord
-  belongs_to :group
-  belongs_to :profile
-end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,8 +1,6 @@
 class Profile < ApplicationRecord
   belongs_to :user
   belongs_to :group
-  has_many :groups_profiles, dependent: :destroy
-  has_many :groups, through: :groups_profiles
   has_many :albums, dependent: :destroy
   has_many :events, dependent: :destroy
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,5 +1,6 @@
 class Profile < ApplicationRecord
   belongs_to :user
+  belongs_to :group
   has_many :groups_profiles, dependent: :destroy
   has_many :groups, through: :groups_profiles
   has_many :albums, dependent: :destroy

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -1,0 +1,6 @@
+<%= form_with model: group do |f| %>
+  <%= render 'shared/error_messages', model: f.object %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render "form", group: @group%>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,0 +1,5 @@
+<% @groups.each do |group| %>
+  <%= group.name %>
+  <%= link_to "編集", edit_group_path(group) %>
+  <%= link_to "削除", group_path(group), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
+<% end %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,0 +1,1 @@
+<%= render "form", group: @group%>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -42,7 +42,7 @@
             <% end %>
           <% end %>
 
-          <%= profile_form.fields_for :group do |group_form| %>
+          <%= profile_form.fields_for :group, profile.group do |group_form| %>
             <%= group_form.select :id, Group.pluck(:name, :id) %>
           <% end %>
 

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -42,6 +42,10 @@
             <% end %>
           <% end %>
 
+          <%= profile_form.fields_for :group do |group_form| %>
+            <%= group_form.select :id, Group.pluck(:name, :id) %>
+          <% end %>
+
           <div class="mb-4">
             <div class="flex mb-1 items-center">
               <i class="fa-solid fa-phone fa-sm"></i>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
     resources :albums
   end
   resources :calendars, only: [:index]
+  resources :groups, only: [:new, :create, :index, :edit, :update, :destroy]
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'

--- a/db/migrate/20240927013330_drop_groups_profiles.rb
+++ b/db/migrate/20240927013330_drop_groups_profiles.rb
@@ -1,0 +1,5 @@
+class DropGroupsProfiles < ActiveRecord::Migration[7.1]
+  def change
+    drop_table :groups_profiles
+  end
+end

--- a/db/migrate/20240927031307_remove_index_on_group_id_from_profiles.rb
+++ b/db/migrate/20240927031307_remove_index_on_group_id_from_profiles.rb
@@ -1,0 +1,5 @@
+class RemoveIndexOnGroupIdFromProfiles < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :profiles, :group_id
+  end
+end

--- a/db/migrate/20240927031307_remove_index_on_group_id_from_profiles.rb
+++ b/db/migrate/20240927031307_remove_index_on_group_id_from_profiles.rb
@@ -1,5 +1,7 @@
 class RemoveIndexOnGroupIdFromProfiles < ActiveRecord::Migration[7.1]
-  def change
+  if index_exists?(:profiles, :group_id)
     remove_index :profiles, :group_id
+  else
+    puts "Index does not exist, skipping migration."
   end
 end

--- a/db/migrate/20240927031440_remove_group_id_from_profiles.rb
+++ b/db/migrate/20240927031440_remove_group_id_from_profiles.rb
@@ -5,4 +5,5 @@ class RemoveGroupIdFromProfiles < ActiveRecord::Migration[7.1]
     else
       puts "group_id column does not exist, skipping removal."
     end
+  end
 end

--- a/db/migrate/20240927031440_remove_group_id_from_profiles.rb
+++ b/db/migrate/20240927031440_remove_group_id_from_profiles.rb
@@ -1,0 +1,5 @@
+class RemoveGroupIdFromProfiles < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :profiles, :group_id
+  end
+end

--- a/db/migrate/20240927031440_remove_group_id_from_profiles.rb
+++ b/db/migrate/20240927031440_remove_group_id_from_profiles.rb
@@ -1,5 +1,8 @@
 class RemoveGroupIdFromProfiles < ActiveRecord::Migration[7.1]
   def change
-    remove_column :profiles, :group_id
-  end
+    if column_exists?(:profiles, :group_id)
+      remove_column :profiles, :group_id
+    else
+      puts "group_id column does not exist, skipping removal."
+    end
 end

--- a/db/migrate/20240927031542_add_group_id_to_profiles.rb
+++ b/db/migrate/20240927031542_add_group_id_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddGroupIdToProfiles < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :profiles, :group, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_13_014135) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_27_013330) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -86,15 +86,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_13_014135) do
     t.index ["user_id"], name: "index_groups_on_user_id"
   end
 
-  create_table "groups_profiles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "group_id", null: false
-    t.bigint "profile_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["group_id"], name: "index_groups_profiles_on_group_id"
-    t.index ["profile_id"], name: "index_groups_profiles_on_profile_id"
-  end
-
   create_table "profiles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "furigana"
@@ -138,7 +129,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_13_014135) do
   add_foreign_key "answers", "questions"
   add_foreign_key "events", "profiles"
   add_foreign_key "groups", "users"
-  add_foreign_key "groups_profiles", "groups"
-  add_foreign_key "groups_profiles", "profiles"
   add_foreign_key "profiles", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_27_013330) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_27_031542) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -98,7 +98,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_27_013330) do
     t.datetime "updated_at", null: false
     t.integer "last_contacted"
     t.text "note"
-    t.bigint "group_id", null: false
+    t.bigint "group_id"
     t.index ["group_id"], name: "index_profiles_on_group_id"
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
@@ -131,5 +131,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_27_013330) do
   add_foreign_key "answers", "questions"
   add_foreign_key "events", "profiles"
   add_foreign_key "groups", "users"
+  add_foreign_key "profiles", "groups"
   add_foreign_key "profiles", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -98,6 +98,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_27_013330) do
     t.datetime "updated_at", null: false
     t.integer "last_contacted"
     t.text "note"
+    t.bigint "group_id", null: false
+    t.index ["group_id"], name: "index_profiles_on_group_id"
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 


### PR DESCRIPTION
### 概要
グループのCRUD作成と、テーブル設計の見直し

---
### 背景・目的
各profileをグループに割り当てるようにするため

---

### 内容
- [x] groups_profilesテーブルの削除
- [x] groupとprofilesを一対多にする
- [x] groupのCRUD機能を実装する（new, create, index, edit, update, destroy）

---
### 対応しないこと
- 

---
### 補足
This PR close #305 