### PR TITLE
グループの非同期でのCRUD機能実装

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -35,6 +35,7 @@ class GroupsController < ApplicationController
   def destroy
     @group = current_user.groups.find(params[:id])
     @group.destroy!
+    flash[:success] = "グループを削除しました"
   end
 
   private

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,10 +24,9 @@ class GroupsController < ApplicationController
   def update
     @group = current_user.groups.find(params[:id])
     if @group.update(group_params)
-      flash[:success] = "グループを更新しました"
+      flash.now[:success] = "グループを更新しました"
     else
-      flash[:danger] = "グループを更新できませんでした"
-      render :edit, status: :unprocessable_entity
+      flash.now[:danger] = "グループを更新できませんでした"
     end
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,4 @@
 class GroupsController < ApplicationController
-
   def create
     @group = current_user.groups.new(group_params)
     if @group.save

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,7 +1,4 @@
 class GroupsController < ApplicationController
-  def new
-    @group = current_user.groups.new
-  end
 
   def create
     @group = current_user.groups.new(group_params)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -5,13 +5,13 @@ class GroupsController < ApplicationController
 
   def create
     @group = current_user.groups.new(group_params)
-    if @group.save
-      flash[:success] = "グループを登録しました"
-      redirect_to groups_path
-    else
-      flash[:danger] = "グループを登録できませんでした"
-      render :new, status: :unprocessable_entity
-    end
+    @group.save
+    # if @group.save
+    #   flash[:success] = "グループを登録しました"
+    # else
+    #   flash[:danger] = "グループを登録できませんでした"
+    #   render :new, status: :unprocessable_entity
+    # end
   end
 
   def index

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -6,10 +6,9 @@ class GroupsController < ApplicationController
   def create
     @group = current_user.groups.new(group_params)
     if @group.save
-      flash[:success] = "グループを登録しました"
+      flash.now[:success] = "グループを登録しました"
     else
-      flash[:danger] = "グループを登録できませんでした"
-      render :new, status: :unprocessable_entity
+      flash.now[:danger] = "グループを登録できませんでした"
     end
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,14 +24,12 @@ class GroupsController < ApplicationController
 
   def update
     @group = current_user.groups.find(params[:id])
-    @group.update(group_params)
-    # if @group.update(group_params)
-    #   flash[:success] = "グループを更新しました"
-    #   redirect_to groups_path
-    # else
-    #   flash[:danger] = "グループを更新できませんでした"
-    #   render :edit, status: :unprocessable_entity
-    # end
+    if @group.update(group_params)
+      flash[:success] = "グループを更新しました"
+    else
+      flash[:danger] = "グループを更新できませんでした"
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def destroy

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -38,7 +38,6 @@ class GroupsController < ApplicationController
   def destroy
     @group = current_user.groups.find(params[:id])
     @group.destroy!
-    redirect_to groups_path
   end
 
   private

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -5,13 +5,12 @@ class GroupsController < ApplicationController
 
   def create
     @group = current_user.groups.new(group_params)
-    @group.save
-    # if @group.save
-    #   flash[:success] = "グループを登録しました"
-    # else
-    #   flash[:danger] = "グループを登録できませんでした"
-    #   render :new, status: :unprocessable_entity
-    # end
+    if @group.save
+      flash[:success] = "グループを登録しました"
+    else
+      flash[:danger] = "グループを登録できませんでした"
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def index

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -15,6 +15,7 @@ class GroupsController < ApplicationController
   end
 
   def index
+    @group = current_user.groups.new
     @groups = current_user.groups
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -33,7 +33,7 @@ class GroupsController < ApplicationController
   def destroy
     @group = current_user.groups.find(params[:id])
     @group.destroy!
-    flash[:success] = "グループを削除しました"
+    flash.now[:success] = "グループを削除しました"
   end
 
   private

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -25,14 +25,14 @@ class GroupsController < ApplicationController
 
   def update
     @group = current_user.groups.find(params[:id])
-
-    if @group.update(group_params)
-      flash[:success] = "グループを更新しました"
-      redirect_to groups_path
-    else
-      flash[:danger] = "グループを更新できませんでした"
-      render :edit, status: :unprocessable_entity
-    end
+    @group.update(group_params)
+    # if @group.update(group_params)
+    #   flash[:success] = "グループを更新しました"
+    #   redirect_to groups_path
+    # else
+    #   flash[:danger] = "グループを更新できませんでした"
+    #   render :edit, status: :unprocessable_entity
+    # end
   end
 
   def destroy

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,6 @@
 class Group < ApplicationRecord
   belongs_to :user
   has_many :profiles, dependent: :destroy
+
+  validates :name, presence: true
 end

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -1,6 +1,5 @@
-<%= form_with model: group do |f| %>
-  <%= render 'shared/error_messages', model: f.object %>
-  <%= f.label :name %>
-  <%= f.text_field :name %>
-  <%= f.submit %>
+<%= form_with model: group, id: group_form_id do |f| %>
+  <%= render "shared/error_messages", model: f.object %>
+  <%= f.text_field :name, placeholder: "アルバム名" %>
+  <%= f.submit "保存" %>
 <% end %>

--- a/app/views/groups/_group.html.erb
+++ b/app/views/groups/_group.html.erb
@@ -1,5 +1,5 @@
 <div id="<%= dom_id group %>">
   <%= group.name %>
-  <%= link_to "編集", edit_group_path(group) %>
+  <%= link_to "編集", edit_group_path(group), data: { turbo_stream: true}  %>
   <%= link_to "削除", group_path(group), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
 </div>

--- a/app/views/groups/_group.html.erb
+++ b/app/views/groups/_group.html.erb
@@ -1,0 +1,5 @@
+<div id="<%= dom_id group %>">
+  <%= group.name %>
+  <%= link_to "編集", edit_group_path(group) %>
+  <%= link_to "削除", group_path(group), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
+</div>

--- a/app/views/groups/create.turbo_stream.erb
+++ b/app/views/groups/create.turbo_stream.erb
@@ -1,5 +1,7 @@
 <% if @group.errors.any? %>
   <%= turbo_stream.replace "group_form", partial: "form", locals: { group: current_user.groups.new, group_form_id: "group_form" } %>
+  <%= turbo_stream.replace "error_message", partial: "shared/error_messages", locals: { model: @group } %>
+  <%= turbo_stream.replace "flash_message", partial: "shared/flash_message" %>
 <% else %>
   <%= turbo_stream.replace "group_form", partial: "form", locals: { group: current_user.groups.new, group_form_id: "group_form" } %>
   <%= turbo_stream.replace "flash_message", partial: "shared/flash_message" %>

--- a/app/views/groups/create.turbo_stream.erb
+++ b/app/views/groups/create.turbo_stream.erb
@@ -2,5 +2,6 @@
   <%= turbo_stream.replace "group_form", partial: "form", locals: { group: current_user.groups.new, group_form_id: "group_form" } %>
 <% else %>
   <%= turbo_stream.replace "group_form", partial: "form", locals: { group: current_user.groups.new, group_form_id: "group_form" } %>
+  <%= turbo_stream.replace "flash_message", partial: "shared/flash_message" %>
   <%= turbo_stream.append "groups", partial: "group", locals: { group: @group } %>
 <% end %>

--- a/app/views/groups/create.turbo_stream.erb
+++ b/app/views/groups/create.turbo_stream.erb
@@ -1,0 +1,6 @@
+<% if @group.errors.any? %>
+  <%= turbo_stream.replace "group_form", partial: "form", locals: { group: current_user.groups.new, group_form_id: "group_form" } %>
+<% else %>
+  <%= turbo_stream.replace "group_form", partial: "form", locals: { group: current_user.groups.new, group_form_id: "group_form" } %>
+  <%= turbo_stream.append "groups", partial: "group", locals: { group: @group } %>
+<% end %>

--- a/app/views/groups/destroy.turbo_stream.erb
+++ b/app/views/groups/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove "group_#{@group.id}" %>

--- a/app/views/groups/destroy.turbo_stream.erb
+++ b/app/views/groups/destroy.turbo_stream.erb
@@ -1,1 +1,2 @@
 <%= turbo_stream.remove "group_#{@group.id}" %>
+<%= turbo_stream.replace "flash_message", partial: "shared/flash_message" %>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,1 +1,0 @@
-<%= render "form", group: @group%>

--- a/app/views/groups/edit.turbo_stream.erb
+++ b/app/views/groups/edit.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.update "group_#{@group.id}", partial: "form", locals: { group: @group, group_form_id: "group_form_#{@group.id}" } %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,11 +1,9 @@
 <%= render "form", group: @group%>
 
 <div id="groups">
-  <% @groups.each do |g| %>
-    <% if g.persisted?%>
-      <%= g.name %>
-      <%= link_to "編集", edit_group_path(g) %>
-      <%= link_to "削除", group_path(g), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
+  <% @groups.each do |group| %>
+    <% if group.persisted?%>
+      <%= render group %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,4 +1,4 @@
-<%= render "form", group: @group%>
+<%= render "form", group: @group, group_form_id: 'group_form' %>
 
 <div id="groups">
   <% @groups.each do |group| %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,5 +1,9 @@
-<% @groups.each do |group| %>
-  <%= group.name %>
-  <%= link_to "編集", edit_group_path(group) %>
-  <%= link_to "削除", group_path(group), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
+<%= render "form", group: @group%>
+
+<% @groups.each do |g| %>
+  <% if g.persisted?%>
+    <%= g.name %>
+    <%= link_to "編集", edit_group_path(g) %>
+    <%= link_to "削除", group_path(g), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
+  <% end %>
 <% end %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,9 +1,11 @@
 <%= render "form", group: @group%>
 
-<% @groups.each do |g| %>
-  <% if g.persisted?%>
-    <%= g.name %>
-    <%= link_to "編集", edit_group_path(g) %>
-    <%= link_to "削除", group_path(g), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
+<div id="groups">
+  <% @groups.each do |g| %>
+    <% if g.persisted?%>
+      <%= g.name %>
+      <%= link_to "編集", edit_group_path(g) %>
+      <%= link_to "削除", group_path(g), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
+    <% end %>
   <% end %>
-<% end %>
+</div>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,1 +1,0 @@
-<%= render "form", group: @group%>

--- a/app/views/groups/update.turbo_stream.erb
+++ b/app/views/groups/update.turbo_stream.erb
@@ -1,0 +1,5 @@
+<% if @group.errors.any? %>
+  <%= turbo_stream.replace "group_form_#{@group.id}", partial: "form", locals: { group: @group, group_form_id: "group_form_#{@group.id}" } %>
+<% else %>
+  <%= turbo_stream.replace dom_id(@group), partial: "group", locals: { group: @group } %>
+<% end %>

--- a/app/views/groups/update.turbo_stream.erb
+++ b/app/views/groups/update.turbo_stream.erb
@@ -1,5 +1,6 @@
 <% if @group.errors.any? %>
   <%= turbo_stream.replace "group_form_#{@group.id}", partial: "form", locals: { group: @group, group_form_id: "group_form_#{@group.id}" } %>
+  <%= turbo_stream.replace "flash_message", partial: "shared/flash_message" %>
 <% else %>
   <%= turbo_stream.replace "flash_message", partial: "shared/flash_message" %>
   <%= turbo_stream.replace dom_id(@group), partial: "group", locals: { group: @group } %>

--- a/app/views/groups/update.turbo_stream.erb
+++ b/app/views/groups/update.turbo_stream.erb
@@ -1,5 +1,6 @@
 <% if @group.errors.any? %>
   <%= turbo_stream.replace "group_form_#{@group.id}", partial: "form", locals: { group: @group, group_form_id: "group_form_#{@group.id}" } %>
 <% else %>
+  <%= turbo_stream.replace "flash_message", partial: "shared/flash_message" %>
   <%= turbo_stream.replace dom_id(@group), partial: "group", locals: { group: @group } %>
 <% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,9 +1,9 @@
-<% if model.errors.any? %>
-  <div class="text-red-500">
+<div class="text-red-500" id="error_message">
+  <% if model.errors.any? %>
     <ul>
       <% model.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>
     </ul>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,4 +1,4 @@
-<div class="flex justify-center">
+<div class="flex justify-center" id="flash_message" >
   <% flash.each do |message_type, message| %>
     <div role= alert class="alert bg-ivory-white border border-4
       <%= case message_type

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -31,6 +31,8 @@ ja:
         password_confirmation: "確認用パスワード"
         line_user_id: "LINE ID"
         notification_enabled: "通知設定"
+      group:
+        name: "グループ名"
     errors:
       models:
         user:
@@ -48,3 +50,7 @@ ja:
               confirmation: "パスワードと一致しません"
             notification_enabled:
               blank: "通知を設定してください"
+        group:
+          attributes:
+            name:
+              blank: "を入力してください"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
     resources :albums
   end
   resources :calendars, only: [:index]
-  resources :groups, only: [:new, :create, :index, :edit, :update, :destroy]
+  resources :groups, only: [:create, :index, :edit, :update, :destroy]
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'

--- a/db/migrate/20240928040514_add_null_false_to_name_in_groups.rb
+++ b/db/migrate/20240928040514_add_null_false_to_name_in_groups.rb
@@ -1,0 +1,5 @@
+class AddNullFalseToNameInGroups < ActiveRecord::Migration[7.1]
+  def change
+    change_column :groups, :name, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_27_031542) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_28_040514) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -79,7 +79,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_27_031542) do
   end
 
   create_table "groups", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
### 概要
グループのCRUD機能を非同期に変更する

---
### 背景・目的
連絡先をグループ分けできるように、グループのCRUD機能を提供するため（非同期でUXを向上させる）

---
### 内容
- [x] 非同期通信でも、フラッシュメッセージを表示する
- [x] 非同期通信でも、エラーメッセージを表示する
- [x] 非同期でgroupを作成・更新・削除できるようにする
- [x] 非同期でgroupを作成する際は、一覧の先頭に作成されたgroupを表示する
- [x] newアクションと、それに関連するルーティング、ビューファイルを削除する
- [x] editビューファイルを削除する
- [x] groupのnameにnull制約を付ける（DB,モデル側共に）

---
### 対応しないこと
- 

---
### 補足
This PR close #314 