### PR TITLE
グループでのフィルタリング機能

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,8 @@ class Group < ApplicationRecord
   has_many :profiles, dependent: :destroy
 
   validates :name, presence: true
+
+  def self.ransackable_attributes(_auth_object = nil)
+    ["id", "name"]
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,6 +5,6 @@ class Group < ApplicationRecord
   validates :name, presence: true
 
   def self.ransackable_attributes(_auth_object = nil)
-    ["id", "name"]
+    %w[id name]
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -26,4 +26,8 @@ class Profile < ApplicationRecord
   def self.ransackable_attributes(_auth_object = nil)
     %w[name furigana line_name last_contacted]
   end
+
+  def self.ransackable_associations(_auth_object = nil)
+    ["group"]
+  end
 end

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -52,6 +52,9 @@
                   <%= f.search_field :furigana_cont, placeholder: "ふりがな", class: "block p-2 text-sm text-gray-900 border border-gray-300 rounded-lg w-80 bg-gray-50 focus:ring-blue-500 focus:border-blue-500" %>
                 </div>
                 <div>
+                  <%= f.select :group_id_eq, options_from_collection_for_select(current_user.groups, :id, :name, @q.group_id_eq), {include_blank: "グループ名"}, class: "block p-2 text-sm text-gray-900 border border-gray-300 rounded-lg w-80 bg-gray-50 focus:ring-blue-500 focus:border-blue-500" %>
+                </div>
+                <div>
                   <button type="submit" class="p-2.5 ms-2 text-sm font-medium text-white bg-gray-600 rounded-lg border border-gray-600 hover:bg-gray-700">
                       <svg class="w-4 h-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
                           <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>


### PR DESCRIPTION
### 概要
グループでのフィルタリング機能

---
### 背景・目的
連絡帳をグループごとに見れるようにするため

---
### 内容
- [x] profile一覧ページに、セレクトボックスでgroupを検索できるようにする
- [x] 検索後は、検索されたグループ名が、セレクトボックスで選択されているようにする
- [x] profileモデルで、ransackがアソシエーション先のgroupも検索できるようにする(def self.ransackable_associationsの定義)
- [x] groupsモデルで、ransackが検索できるようにする(self.ransackable_attributesの定義)

---
### 対応しないこと
- 

---
### 補足
This PR close #316 