### PR TITLE
グループ関連ページのデザインを実装する

### DIFF
--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -2,7 +2,7 @@
   <%= form_with model: group, id: group_form_id do |f| %>
     <%= render "shared/error_messages", model: f.object %>
     <div class="flex justify-between">
-      <%= f.text_field :name, placeholder: "グループ名", class: "flex-grow block p-2 text-sm text-gray-900 border border-gray-300 rounded-lg w-32 bg-gray-50 focus:ring-blue-500 focus:border-blue-500" %>
+      <%= f.text_field :name, placeholder: "新しいグループ名", class: "flex-grow block p-2 text-sm text-gray-900 border border-gray-300 rounded-lg w-32 bg-gray-50 focus:ring-blue-500 focus:border-blue-500" %>
       <%= f.submit "保存", class: "btn bg-golden text-black border-none hover:bg-yellow-500 mx-2" %>
     </div>
   <% end %>

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -1,5 +1,9 @@
-<%= form_with model: group, id: group_form_id do |f| %>
-  <%= render "shared/error_messages", model: f.object %>
-  <%= f.text_field :name, placeholder: "アルバム名" %>
-  <%= f.submit "保存" %>
-<% end %>
+<div class="mb-10">
+  <%= form_with model: group, id: group_form_id do |f| %>
+    <%= render "shared/error_messages", model: f.object %>
+    <div class="flex justify-between">
+      <%= f.text_field :name, placeholder: "グループ名", class: "flex-grow block p-2 text-sm text-gray-900 border border-gray-300 rounded-lg w-32 bg-gray-50 focus:ring-blue-500 focus:border-blue-500" %>
+      <%= f.submit "保存", class: "btn bg-golden text-black border-none hover:bg-yellow-500 mx-2" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/groups/_group.html.erb
+++ b/app/views/groups/_group.html.erb
@@ -1,5 +1,11 @@
-<div id="<%= dom_id group %>">
-  <%= group.name %>
-  <%= link_to "編集", edit_group_path(group), data: { turbo_stream: true}  %>
-  <%= link_to "削除", group_path(group), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } %>
+<div id="<%= dom_id group %>" class="flex justify-between my-2">
+  <div class="font-bold"><%= group.name %></div>
+  <div class="px-2">
+    <%= link_to edit_group_path(group), data: { turbo_stream: true}  do %>
+      <i class="fa-solid fa-pen-to-square"></i>
+    <% end %>
+    <%= link_to  group_path(group), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } do %>
+      <i class="fa-solid fa-trash"></i>
+    <% end %>
+  </div>
 </div>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,9 +1,13 @@
-<%= render "form", group: @group, group_form_id: 'group_form' %>
-
-<div id="groups">
-  <% @groups.each do |group| %>
-    <% if group.persisted?%>
-      <%= render group %>
-    <% end %>
-  <% end %>
+<div class="flex flex-col items-center">
+  <div class="text-center md:text-xl border rounded-3xl border-slate-100 p-8 md:p-10 mb-20 md:mb-10 mt-5 md:mt-10 bg-opacity-10 shadow-2xl max-w-full">
+      <h1 class="text-3xl font-bold pt-10 md:pt-0 pb-10"><i class="fa-solid fa-user-group"></i>グループリスト</h1>
+    <%= render "form", group: @group, group_form_id: "group_form" %>
+    <div id="groups">
+      <% @groups.each do |group| %>
+        <% if group.persisted?%>
+          <%= render group %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -43,16 +43,6 @@
           <% end %>
 
           <div class="mb-4">
-            <%= profile_form.fields_for :group, profile.group do |group_form| %>
-              <div class="flex mb-1 items-center">
-                <i class="fa-solid fa-user-group fa-sm"></i>
-                <%= group_form.label :id, "グループ名", class: "block font-medium text-black mx-1" %>
-              </div>
-              <%= group_form.select :id, Group.pluck(:name, :id), {include_blank: "", selected: profile.group_id } , class: "w-full rounded p-2 bg-white border border-gray-400" %>
-            <% end %>
-          </div>
-
-          <div class="mb-4">
             <div class="flex mb-1 items-center">
               <i class="fa-solid fa-phone fa-sm"></i>
               <%= profile_form.label :phone, '電話番号', class: "block font-medium text-black mx-1" %>
@@ -90,6 +80,16 @@
               <%= profile_form.label :last_contacted, '最後に連絡した日', class: "block font-medium text-black mx-1" %>
             </div>
             <%= profile_form.select :last_contacted, Profile.last_contacteds_i18n.map { |key, value| [value, key] },  { include_blank: true }, class: "w-full rounded p-2 bg-white border border-gray-400" %>
+          </div>
+
+          <div class="mb-4">
+            <%= profile_form.fields_for :group, profile.group do |group_form| %>
+              <div class="flex mb-1 items-center">
+                <i class="fa-solid fa-user-group fa-sm"></i>
+                <%= group_form.label :id, "グループ名", class: "block font-medium text-black mx-1" %>
+              </div>
+              <%= group_form.select :id, Group.pluck(:name, :id), {include_blank: "", selected: profile.group_id } , class: "w-full rounded p-2 bg-white border border-gray-400" %>
+            <% end %>
           </div>
 
           <div class="mb-4">

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -42,9 +42,15 @@
             <% end %>
           <% end %>
 
-          <%= profile_form.fields_for :group, profile.group do |group_form| %>
-            <%= group_form.select :id, Group.pluck(:name, :id) %>
-          <% end %>
+          <div class="mb-4">
+            <%= profile_form.fields_for :group, profile.group do |group_form| %>
+              <div class="flex mb-1 items-center">
+                <i class="fa-solid fa-user-group fa-sm"></i>
+                <%= group_form.label :id, "グループ名", class: "block font-medium text-black mx-1" %>
+              </div>
+              <%= group_form.select :id, Group.pluck(:name, :id), {include_blank: "", selected: profile.group_id } , class: "w-full rounded p-2 bg-white border border-gray-400" %>
+            <% end %>
+          </div>
 
           <div class="mb-4">
             <div class="flex mb-1 items-center">

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -63,7 +63,7 @@
                 </div>
               <% end %>
           </div>
-          <div class="flex">
+          <div id="button" class="flex">
             <div class="flex justify-center px-4 py-2">
               <%= link_to new_profile_path, class: "btn bg-golden text-black border-none hover:bg-yellow-500" do %>
                 <button>連絡先を作成</button>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -63,10 +63,17 @@
                 </div>
               <% end %>
           </div>
-          <div class="flex justify-center px-4 py-2">
-            <%= link_to new_profile_path, class: "btn bg-golden text-black border-none hover:bg-yellow-500" do %>
-              <button>連絡先を作成</button>
-            <% end %>
+          <div class="flex">
+            <div class="flex justify-center px-4 py-2">
+              <%= link_to new_profile_path, class: "btn bg-golden text-black border-none hover:bg-yellow-500" do %>
+                <button>連絡先を作成</button>
+              <% end %>
+            </div>
+            <div class="flex justify-center px-4 py-2">
+              <%= link_to groups_path, class: "btn bg-almond text-black border-none hover:bg-yellow-500" do %>
+                <button>グループを作成</button>
+              <% end %>
+            </div>
           </div>
       </div>
       <table class="w-full text-sm text-left rtl:text-right text-gray-500">

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -216,19 +216,26 @@
     <div class="w-11/12 shadow-lg border rounded-3xl border-slate-100 mt-8">
       <div class="flex items-center justify-center flex-column flex-wrap md:flex-row md:space-y-0 py-2 bg-white">
           <div class="relative">
-              <%= search_form_for @q, url: profiles_path, class: "flex items-center space-x-2" do |f| %>
-                <div>
-                  <%= f.search_field :name_cont, placeholder: "名前", class: "block p-2 text-sm text-gray-900 border border-gray-300 rounded-lg w-32 bg-gray-50 focus:ring-blue-500 focus:border-blue-500" %>
+              <%= search_form_for @q, url: profiles_path do |f| %>
+                <div id="search_field" class="flex space-x-2 w-full mb-2">
+                  <div>
+                    <%= f.search_field :name_cont, placeholder: "名前", class: "block p-2 text-sm text-gray-900 border border-gray-300 rounded-lg w-32 bg-gray-50 focus:ring-blue-500 focus:border-blue-500" %>
+                  </div>
+                  <div>
+                    <%= f.search_field :furigana_cont, placeholder: "ふりがな", class: "block p-2 text-sm text-gray-900 border border-gray-300 rounded-lg w-32 bg-gray-50 focus:ring-blue-500 focus:border-blue-500" %>
+                  </div>
                 </div>
-                <div>
-                  <%= f.search_field :furigana_cont, placeholder: "ふりがな", class: "block p-2 text-sm text-gray-900 border border-gray-300 rounded-lg w-32 bg-gray-50 focus:ring-blue-500 focus:border-blue-500" %>
-                </div>
-                <div>
-                  <button type="submit" class="p-2.5 text-sm font-medium text-white bg-gray-600 rounded-lg border border-gray-600 hover:bg-gray-700">
-                      <svg class="w-4 h-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
-                          <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
-                      </svg>
-                  </button>
+                <div id="select_and_button" class="flex justify-between space-x-2 w-full">
+                  <div class="flex-grow">
+                    <%= f.select :group_id_eq, options_from_collection_for_select(current_user.groups, :id, :name, @q.group_id_eq), {include_blank: "グループ名"}, class: "block p-2 text-sm text-gray-900 border w-full border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500" %>
+                  </div>
+                  <div>
+                    <button type="submit" class="p-2.5 text-sm font-medium text-white bg-gray-600 rounded-lg border border-gray-600 hover:bg-gray-700">
+                        <svg class="w-4 h-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
+                        </svg>
+                    </button>
+                  </div>
                 </div>
               <% end %>
           </div>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -303,6 +303,10 @@
                           <i class="fa-solid fa-check fa-sm"></i>
                           <%= profile.last_contacted_i18n%>
                         </div>
+                        <div class="font-normal text-gray-500">
+                          <i class="fa-solid fa-user-group"></i>
+                          <%= profile.group&.name %>
+                        </div>
                     </div>
                 </th>
                 <td class="px-1 font-semibold">

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -105,6 +105,12 @@
                     </div>
                   </th>
                   <th scope="col" class="px-6 py-3">
+                    <div class="flex items-center space-x-2">
+                    <i class="fa-solid fa-user-group"></i>
+                      <div>グループ</div>
+                    </div>
+                  </th>
+                  <th scope="col" class="px-6 py-3">
                   </th>
               </tr>
           </thead>
@@ -140,6 +146,9 @@
                 </td>
                 <td class="px-6 py-4 font-semibold">
                     <%= l profile.events.last.date if profile.events.last&.date.present? %>
+                </td>
+                <td class="px-6 py-4 font-semibold">
+                    <%= profile.group.name if profile.group.present? %>
                 </td>
                 <td class="px-6 py-4 font-semibold">
                   <div class="flex justify-around">

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -234,10 +234,17 @@
           </div>
       </div>
 
-      <div class="flex justify-center px-4 py-2">
-        <%= link_to new_profile_path, class: "btn bg-golden text-black border-none hover:bg-yellow-500" do %>
-          <button>連絡先を作成</button>
-        <% end %>
+      <div id="button" class="flex justify-center">
+        <div class="flex justify-center px-4 py-2">
+          <%= link_to new_profile_path, class: "btn bg-golden text-black border-none hover:bg-yellow-500" do %>
+            <button>連絡先を作成</button>
+          <% end %>
+        </div>
+        <div class="flex justify-center px-4 py-2">
+          <%= link_to groups_path, class: "btn bg-almond text-black border-none hover:bg-yellow-500" do %>
+            <button>グループを作成</button>
+          <% end %>
+        </div>
       </div>
 
       <div id="sort" class="text-center m-4">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -68,6 +68,10 @@
               <i class="fa-solid fa-check fa-lg mr-2"></i>
               <span class="text-base md:text-lg"><%= @profile.last_contacted_i18n %></span>
             </div>
+            <div class="my-3 text-left">
+              <i class="fa-solid fa-user-group fa-lg mr-2"></i>
+              <span class="text-base md:text-lg"><%= @profile.group.name %></span>
+            </div>
             <div class="my-3 text-left w-full md:h-40 overflow-auto">
               <i class="fa-solid fa-pencil fa-lg mr-2"></i>
               <span class="text-base md:text-lg"><%= @profile.note %></span>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -41,6 +41,14 @@
         <div id="info" class="flex md:px-44 py-4 md:py-2">
           <div>
             <div class="my-3 text-left">
+              <i class="fa-solid fa-cake-candles fa-lg mr-2"></i>
+              <span class="text-base md:text-lg"><%= @profile.events.first.date %></span>
+            </div>
+            <div class="my-3 text-left">
+              <i class="fa-solid fa-calendar-check fa-lg mr-2"></i>
+              <span class="text-base md:text-lg"><%= @profile.events.last.date %></span>
+            </div>
+            <div class="my-3 text-left">
               <i class="fa-solid fa-phone fa-lg mr-2"></i>
               <span class="text-base md:text-lg"><%= @profile.phone %></span>
             </div>
@@ -59,14 +67,6 @@
             <div class="my-3 text-left">
               <i class="fa-solid fa-check fa-lg mr-2"></i>
               <span class="text-base md:text-lg"><%= @profile.last_contacted_i18n %></span>
-            </div>
-            <div class="my-3 text-left">
-              <i class="fa-solid fa-cake-candles fa-lg mr-2"></i>
-              <span class="text-base md:text-lg"><%= @profile.events.first.date %></span>
-            </div>
-            <div class="my-3 text-left">
-              <i class="fa-solid fa-calendar-check fa-lg mr-2"></i>
-              <span class="text-base md:text-lg"><%= @profile.events.last.date %></span>
             </div>
             <div class="my-3 text-left w-full md:h-40 overflow-auto">
               <i class="fa-solid fa-pencil fa-lg mr-2"></i>


### PR DESCRIPTION
### 概要
グループ関連ページのデザインを実装する

---
### 背景・目的
デザインを整えUIを改善する

---
### 内容
- [x] 連絡帳一覧
  - [x] グループ作成ページへのボタンを設置
  - [x] スマホ画面で、グループ検索フィールドを設置
  - [x] スマホ画面で、group項目を追加
  - [x] PC画面で、group列を追加
- [x] profile form
  - [x] groupセレクトボックスで、空欄を許容する
  - [x] すでにprofileに紐づいて登録されているgroupがあればそれが選択されているようにする
- [x] 連絡帳詳細ページ
  - [x] 誕生日・大切な日を一番上に移動
  - [x] group欄を追加
- [x] group formフィールド
  - [x] プレースホルダを変更（グループ名→新しいグループ名)
  
---
### 対応しないこと
- 

---
### 補足
This PR close #315 