### PR TITLE
アルバム画像大きさ調整

### DIFF
--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -9,7 +9,7 @@
       <% @albums.each do |album| %>
         <div class="h-44 md:h-72 bg-white border border-gray-200 rounded-lg shadow">
           <% if album.images.attached? %>
-            <%= image_tag album.images.first.variant(resize_to_fill: [446, 192]), class: "rounded-t-lg" %>
+            <%= image_tag album.images.first.variant(resize_to_fill: [550, 192]), class: "rounded-t-lg" %>
           <% end %>
             <div class="flex flex-col p-2">
               <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 truncate ..."><%= album.title %></h5>

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -7,9 +7,9 @@
   <div id="right-section" class="flex w-full items-center flex-col">
     <div class="grid grid-cols-2 md:grid-cols-3 gap-4 w-full overflow-auto p-5 flex-grow">
       <% @albums.each do |album| %>
-        <div class="h-44 md:h-72 bg-white border border-gray-200 rounded-lg shadow">
+        <div class="h-44 md:h-72 bg-white border border-gray-200 rounded-lg shadow flex flex-col">
           <% if album.images.attached? %>
-            <%= image_tag album.images.first.variant(resize_to_fill: [550, 192]), class: "rounded-t-lg" %>
+            <%= image_tag album.images.first.variant(resize_to_fill: [550, 192]), class: "rounded-t-lg flex-grow" %>
           <% end %>
             <div class="flex flex-col p-2">
               <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 truncate ..."><%= album.title %></h5>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -20,7 +20,7 @@
       <div id="grid" class="h-2/3 grid grid-cols-1 md:grid-cols-3 gap-4 w-full p-5 overflow-auto">
         <% @album.images.each do |image| %>
           <div class="h-fit rounded-lg shadow">
-            <%= image_tag image.variant(resize_to_fit: [400, 300]), class: "object-cover rounded-lg" %>
+            <%= image_tag image.variant(resize_to_fill: [400, 300]), class: "object-cover rounded-lg" %>
           </div>
         <% end %>
       </div>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -20,7 +20,7 @@
       <div id="grid" class="h-2/3 grid grid-cols-1 md:grid-cols-3 gap-4 w-full p-5 overflow-auto">
         <% @album.images.each do |image| %>
           <div class="h-fit rounded-lg shadow">
-            <%= image_tag image.variant(resize_to_fit: [300, 300]), class: "object-cover rounded-lg" %>
+            <%= image_tag image.variant(resize_to_fit: [400, 300]), class: "object-cover rounded-lg" %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
### 概要
アルバムの画像の大きさを調整する

---
### 背景・目的
PC画面上で表示されるアルバム画像が、枠とずれている為修正
[![Image from Gyazo](https://i.gyazo.com/f42be169f979782c97108f8bf97435f4.png)](https://gyazo.com/f42be169f979782c97108f8bf97435f4)

---

### 内容
- [x] 写真とアルバムの枠の間に余白がでないようにする
  - [x] album index ファイル
  - [x] album show ファイル
- [x] albumの詳細画面で、画像のバリアントをfit -> fillに変更
- [x] アルバム一覧の表示画像の高さをflex-growで拡大

---
### 対応しないこと
- 

---
### 補足
This PR close #302 