### PR TITLE
カレンダー　レスポンシブデザイン

### DIFF
--- a/app/assets/stylesheets/simple_calendar.scss
+++ b/app/assets/stylesheets/simple_calendar.scss
@@ -104,3 +104,17 @@
 
   .has-events {}
 }
+
+#pc-table {
+  @media (max-width: 768px) {
+    display: none;
+  }
+}
+
+#mobile-table {
+  display: none;
+
+  @media (max-width: 768px) {
+    display: table;
+  }
+}

--- a/app/assets/stylesheets/simple_calendar.scss
+++ b/app/assets/stylesheets/simple_calendar.scss
@@ -18,7 +18,6 @@
     box-sizing: border-box;
     max-width: 100%;
     width: 100%;
-    min-width: 1000px;
     table-layout: fixed;
   }
 

--- a/app/views/calendars/_month_calendar.html.erb
+++ b/app/views/calendars/_month_calendar.html.erb
@@ -1,0 +1,33 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></time>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/calendars/index.html.erb
+++ b/app/views/calendars/index.html.erb
@@ -1,4 +1,4 @@
-<div class="table-container">
+<div class="table-container mb-20 md:mb-0 overflow-auto">
   <%= month_calendar(events: @events_this_year, attribute: :date) do |date, events_on_calendar| %>
     <%= date.day %>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -70,7 +70,7 @@
             </div>
             <div class="my-3 text-left">
               <i class="fa-solid fa-user-group fa-lg mr-2"></i>
-              <span class="text-base md:text-lg"><%= @profile.group.name %></span>
+              <span class="text-base md:text-lg"><%= @profile.group&.name %></span>
             </div>
             <div class="my-3 text-left w-full md:h-40 overflow-auto">
               <i class="fa-solid fa-pencil fa-lg mr-2"></i>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,0 +1,47 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></time>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+
+  <table id="pc-table" class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <table id="mobile-table" class="table table-striped">
+    <tbody>
+      <% date_range.each_slice(1) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
### 概要
カレンダーにレスポンシブデザインを実装する

---
### 背景・目的
スマホ画面だと、カレンダーの横幅が広すぎるので、縦にリスト形式にする

---
### 内容
- [x] スマホ画面にはmb-20を設置し、フッターと被らないようにする
- [x] simpleカレンダー（月別）のパーシャルをソースコードからコピーし、ビューディレクトリに配置
- [x] カレンダーから、min-widthを削除
- [x] pc用テーブルはmd幅以下は非表示にする。スマホ用テーブルは、md幅以上では非表示にする

---
### 対応しないこと
- 

---
### 補足
- profile showビューで、`@profile.group.name`でnameメソッドがnilクラスから呼び出すケースがあった為、`@profile.group&.name`に変更

This PR close #310 