### PR TITLE
avatarプレビュー表示させる

### DIFF
--- a/app/javascript/controllers/previews_controller.js
+++ b/app/javascript/controllers/previews_controller.js
@@ -1,29 +1,39 @@
+//HotwireStimulusから、コントローラー機能を読み込む（手元にもってくる）
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="previews"
+//クラスを作り、コントローラー機能を継承する。また、当クラスを他のファイルがimportできるようにする。
 export default class extends Controller {
+  // コントローラーがアクセスする要素を宣言
   static targets = ["input", "previewContainer"]
 
+  // アクションを定義
   preview() {
-    let input = this.inputTarget;
-    let previewContainer = this.previewContainerTarget;
+    //要素を取得する
+    let input = this.inputTarget; //クラス内のインスタンス（this）の内、targetに入っている"input"要素を取得する
+    let previewContainer = this.previewContainerTarget; //同上
 
     // プレビューコンテナをクリア
     previewContainer.innerHTML = "";
 
-    // すべてのファイルをループで処理
+    // input要素のファイルを配列に入れ、一つずつ取り出し、fileという変数に入れる
     Array.from(input.files).forEach(file => {
+      //readerという変数にファイルを読み取る機能を入れる
       let reader = new FileReader();
 
+      //ファイルの読み込みが終わった時、以下の処理を実行する
       reader.onloadend = function() {
-        // 新しい画像要素を作成してプレビューコンテナに追加
+        // img要素を生成し、imgに代入。document=当該HTMLのDOM
         let img = document.createElement("img");
+        // ファイルの読み込み結果を、img要素のsrcに入れる
         img.src = reader.result;
+        // 幅を指定する
         img.style.width = "100px";
-        // img.style.marginRight = "10px";
+        // previewContainer要素に上から順番に差し込む
         previewContainer.appendChild(img);
       };
 
+      //ファイルのURLを読み込む（非同期で行われ、完了後、上記のonloadend内の処理が始まる）
+      //onloadは先に定義するのがベストプラクティス
       if(file) {
         reader.readAsDataURL(file);
       }

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -9,7 +9,7 @@
       <div>
         <h1 class="text-3xl font-bold pt-10 md:pt-0 pb-10">連絡先フォーム</h1>
       </div>
-      <div>
+      <div data-controller="previews">
         <%= form_with model: profile, data: { turbo: false } do |profile_form| %>
           <%= render 'shared/error_messages', model: profile_form.object %>
 
@@ -100,12 +100,14 @@
             <%= profile_form.text_area :note, class: "w-full rounded p-2 bg-white border border-gray-400" %>
           </div>
 
+          <div data-previews-target="previewContainer" class="flex justify-center space-x-4 mb-4" ></div>
+
           <div class="mb-4">
             <div class="flex mb-1 items-center">
               <i class="fa-regular fa-image fa-sm"></i>
               <%= profile_form.label :avatar, 'プロフィール画像', class: "block font-medium text-black mx-1" %>
             </div>
-            <%= profile_form.file_field :avatar, class: "rounded p-2" %>
+            <%= profile_form.file_field :avatar, data: { previews_target: "input", action: "change->previews#preview" }, class: "rounded p-2" %>
           </div>
 
           <div class="flex justify-center mb-20 md:mb-0">


### PR DESCRIPTION
### 概要
プロフィール画像（avatar）をプレビュー表示させる

---
### 背景・目的
アルバム画像はプレビューが表示されるので、同じようにavatarもプレビューを表示させる
[![Image from Gyazo](https://i.gyazo.com/5f50bc0dcc6eafc91d2f80dfd347ad3f.png)](https://gyazo.com/5f50bc0dcc6eafc91d2f80dfd347ad3f)
---

### 内容
- [x] profileのformビューファイルに、HotwireStimulusのターゲットを設置する
（HotwireStimulusコントローラーは、アルバム画像のプレビュー表示と同じ`previews_controller.js`を使う

---
### 対応しないこと
- 

---
### 補足
This PR close #303 