### PR TITLE
スマホ画面では非同期で連絡先を一覧から削除できなかったバグを修正

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -44,7 +44,12 @@ class ProfilesController < ApplicationController
 
     respond_to do |format|
       format.html { redirect_to profiles_path, status: :see_other }
-      format.turbo_stream { render turbo_stream: turbo_stream.remove("profile_#{@profile.id}") }
+      format.turbo_stream do
+        render turbo_stream: [
+          turbo_stream.remove("profile_pc_#{@profile.id}"),
+          turbo_stream.remove("profile_mobile_#{@profile.id}")
+        ]
+      end
     end
   end
 

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -116,7 +116,7 @@
           </thead>
           <tbody>
             <% @profiles.each do |profile| %>
-              <tr id="profile_<%= profile.id %>" class="bg-white border-b hover:bg-gray-50">
+              <tr id="profile_pc_<%= profile.id %>" class="bg-white border-b hover:bg-gray-50">
                 <td class="font-semibold">
                     <div class="flex justify-center items-center">
                         <%= form_with model: profile, data: { controller: "form" } do |f|%>
@@ -271,7 +271,7 @@
       <table class="w-full text-sm text-left rtl:text-right text-gray-500">
           <tbody>
             <% @profiles.each do |profile| %>
-              <tr class="bg-white border-b hover:bg-gray-50 ">
+              <tr id="profile_mobile_<%= profile.id %>" class="bg-white border-b hover:bg-gray-50">
                 <th scope="row" class="flex items-center p-1 text-gray-900">
                     <div id="avatar" class="w-50 h-50">
                       <% if profile.avatar.attached? %>


### PR DESCRIPTION
### 概要
連絡帳一覧で、非同期で削除できないバグを解消する

---
### 背景・目的
スマホ画面上にて、連絡帳一覧から連絡先を削除すると、DBでの削除は行われるが、表示画面からは消えない

---
### 内容
- [x] PCとスマホのビューファイルで、それぞれ別の一意のIDを設定する
- [x] コントローラーのdestroyアクションで、二つのidをturbo removeするようにする

---
### 対応しないこと
- 

---
### 補足
This PR close #328 