### PR TITLE
アルバムにアップロードする画像枚数・サイズを変更する

### DIFF
--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -5,6 +5,6 @@ class Album < ApplicationRecord
 
   validates :images, processable_image: true,
                      content_type: %i[png jpeg],
-                     size: { less_than: 5.megabytes, message: "is too large" },
-                     limit: { max: 3 }
+                     size: { less_than: 3.megabytes, message: "is too large" },
+                     limit: { max: 2 }
 end

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -42,7 +42,7 @@
           <!--DBに保存済みの写真を表示する-->
           <div class="flex justify-center space-x-4 mb-4">
             <% if album.images.attached? && album.persisted? %>
-              <% album.images.with_all_variant_records.each do |image| %>
+              <% album.images.each do |image| %>
                 <div id="<%= "#{dom_id(album)}-#{image.id}" %>">
                   <% if image.persisted? %>
                     <div class="flex flex-col text-center">

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -36,7 +36,7 @@
               <% end %>
             </turbo-frame>
             <%= form.file_field :images, multiple: true, data: { previews_target: "input", action: "change->previews#preview" } %>
-            <p class="text-center p-4">※写真は３枚まで保存できます</p>
+            <p class="text-center p-4">※写真は２枚まで保存できます</p>
           </div>
 
           <!--DBに保存済みの写真を表示する-->

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -17,7 +17,7 @@
           <i class="fa-solid fa-trash fa-lg"></i>
         <% end %>
       </div>
-      <div id="grid" class="h-2/3 grid grid-cols-1 md:grid-cols-3 gap-4 w-full p-5 overflow-auto">
+      <div id="grid" class="h-2/3 grid grid-cols-1 md:grid-cols-2 gap-4 w-full p-5 overflow-auto">
         <% @album.images.with_all_variant_records.each do |image| %>
           <div class="h-fit rounded-lg shadow">
             <%= image_tag image.variant(resize_to_fill: [400, 300]), class: "object-cover rounded-lg" %>

--- a/spec/models/album_spec.rb
+++ b/spec/models/album_spec.rb
@@ -22,19 +22,19 @@ RSpec.describe Album, type: :model do
         album.images.attach(invalide_content_type)
         expect(album).to be_invalid
       end
-      it "５MB以上のファイルはアップロードできない" do
+      it "3MB以上のファイルはアップロードできない" do
         album.images.attach(large_image)
         expect(album).to be_invalid
       end
-      it "画像は４枚以上アップロードできない" do
-        4.times { album.images.attach(valid_image) }
+      it "画像は3枚以上アップロードできない" do
+        3.times { album.images.attach(valid_image) }
         expect(album).to be_invalid
       end
     end
 
     context "有効なデータの場合" do
       it "正常に画像が保存される" do
-        3.times { album.images.attach(valid_image) }
+        2.times { album.images.attach(valid_image) }
         expect(album).to be_valid
       end
     end


### PR DESCRIPTION
### 概要
アルバムにアップロードする画像枚数を変更する3→2枚

---
### 背景・目的
Herokuサーバーのメモリが不足する可能性がある為

---
### 内容
- [x] albumモデルでのバリエーションを変更する
  - [x] 上限枚数　3枚→2枚
  - [x] 画像サイズ　5MB→3MB
- [x] albumモデルテストも上記に合わせて変更する
- [x] formの文言を変更する
- [x] album showのグリッドを3⇒2列に変更する
---
### 対応しないこと
- 

---
### 補足
This PR close #330 