### PR TITLE
Herokuメモリエラー（R14）の解消

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,8 @@ gem 'enum_help'
 # calendar
 gem 'simple_calendar'
 
+gem 'scout_apm'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,6 +368,8 @@ GEM
       ffi (~> 1.12)
       logger
     rubyzip (2.3.2)
+    scout_apm (5.4.0)
+      parser
     selenium-webdriver (4.22.0)
       base64 (~> 0.2)
       logger (~> 1.4)
@@ -460,6 +462,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   ruby-openai
+  scout_apm
   selenium-webdriver
   simple_calendar
   sorcery

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -12,11 +12,13 @@ min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies that the worker count should equal the number of processors in production.
-if ENV["RAILS_ENV"] == "production"
-  require "concurrent-ruby"
-  worker_count = Integer(ENV.fetch("WEB_CONCURRENCY") { Concurrent.physical_processor_count })
-  workers worker_count if worker_count > 1
-end
+# if ENV["RAILS_ENV"] == "production"
+#   require "concurrent-ruby"
+#   worker_count = Integer(ENV.fetch("WEB_CONCURRENCY") { Concurrent.physical_processor_count })
+#   workers worker_count if worker_count > 1
+# end
+
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
 
 # Specifies the `worker_timeout` threshold that Puma will use to wait before
 # terminating a worker in development environments.


### PR DESCRIPTION
### 概要
Herokuメモリエラー（R14）の解消

---
### 背景・目的
Herokuメモリエラー（R14）が発生したため

---
### 内容
- [x] heroku scout add-onのインストール（メモリ消費の推移を確認するため）
- [x] 本番環境でのpumaのworker数を1に設定する
config/puma.rb
```
# Specifies that the worker count should equal the number of processors in production.
# if ENV["RAILS_ENV"] == "production"
#   require "concurrent-ruby"
#   worker_count = Integer(ENV.fetch("WEB_CONCURRENCY") { Concurrent.physical_processor_count })
#   workers worker_count if worker_count > 1
# end

workers Integer(ENV['WEB_CONCURRENCY'] || 2)
```

---
### 対応しないこと
- 

---
### 補足