### PR TITLE
Test/#347 user

### DIFF
--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -1,9 +1,10 @@
 module LoginMacros
   def login_as(user)
-    visit root_path
-    click_link "ログイン", match: :first
+    visit login_path
     fill_in "メールアドレス", with: user.email
     fill_in "パスワード", with: "password"
     click_button "ログイン"
+    # ログイン処理が完了することを担保する
+    expect(page).to have_current_path(root_path)
   end
 end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -151,6 +151,14 @@ RSpec.describe "UserSessions", type: :system do
           expect(page).to have_content "更新に失敗しました"
         end
       end
+
+      context "リンクの遷移" do
+        it "パスワードリセットページへの遷移" do
+          visit edit_user_path(user)
+          click_link "こちら"
+          expect(page).to have_current_path(new_password_reset_path)
+        end
+      end
     end
   end
 end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "UserSessions", type: :system do
+  include LoginMacros
+  let(:user) { create(:user) }
+
+  describe "ログイン前" do
+    describe "ユーザー新規登録" do
+      context "フォームの入力値が正常" do
+        it "ユーザーの新規作成が成功する" do
+          visit new_user_path
+          fill_in "名前", with: "テスト"
+          fill_in "メールアドレス", with: "email@example.com"
+          fill_in "パスワード", with: "password"
+          fill_in "パスワード再入力", with: "password"
+          click_button "登録"
+          expect(page).to have_content "ユーザー登録が完了しました"
+          expect(page).to have_current_path(root_path)
+        end
+      end
+    end
+  end
+end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -140,6 +140,17 @@ RSpec.describe "UserSessions", type: :system do
           expect(page).to have_content "OFF"
         end
       end
+
+      context "名前が空欄" do
+        it "ユーザーの編集が失敗する" do
+          visit edit_user_path(user)
+          fill_in "名前", with: ""
+          select "OFF", from: "LINE通知"
+          click_button "更新"
+          expect(page).to have_current_path(user_path(user))
+          expect(page).to have_content "更新に失敗しました"
+        end
+      end
     end
   end
 end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -31,6 +31,23 @@ RSpec.describe "UserSessions", type: :system do
           expect(page).to have_current_path(new_user_path)
         end
       end
+
+      context "登録済のメールアドレスを使用" do
+        it "ユーザーの新規作成が失敗する" do
+          existed_user = create(:user)
+          visit new_user_path
+          fill_in "名前", with: "テスト"
+          fill_in "メールアドレス", with: existed_user.email
+          fill_in "パスワード", with: "password"
+          fill_in "パスワード再入力", with: "password"
+          click_button "登録"
+          expect(page).to have_content "このメールアドレスはすでに存在します"
+          expect(page).to have_content "ユーザー登録に失敗しました"
+          expect(page).to have_current_path(new_user_path)
+          expect(page).to have_field "名前", with: "テスト"
+          expect(page).to have_field "メールアドレス", with: existed_user.email
+        end
+      end
     end
   end
 end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -18,6 +18,19 @@ RSpec.describe "UserSessions", type: :system do
           expect(page).to have_current_path(root_path)
         end
       end
+
+      context "メールアドレスが未入力" do
+        it "ユーザーの新規作成が失敗する" do
+          visit new_user_path
+          fill_in "名前", with: "テスト"
+          fill_in "メールアドレス", with: ""
+          fill_in "パスワード", with: "password"
+          fill_in "パスワード再入力", with: "password"
+          click_button "登録"
+          expect(page).to have_content "ユーザー登録に失敗しました"
+          expect(page).to have_current_path(new_user_path)
+        end
+      end
     end
   end
 end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -124,4 +124,22 @@ RSpec.describe "UserSessions", type: :system do
       end
     end
   end
+
+  describe "ログイン後" do
+    before { login_as(user) }
+
+    describe "ユーザー編集" do
+      context "フォームの入力値が正常" do
+        it "ユーザーの編集が成功する" do
+          visit edit_user_path(user)
+          fill_in "名前", with: "new_user_name"
+          select "OFF", from: "LINE通知"
+          click_button "更新"
+          expect(page).to have_current_path(user_path(user))
+          expect(page).to have_content "new_user_name"
+          expect(page).to have_content "OFF"
+        end
+      end
+    end
+  end
 end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -151,12 +151,20 @@ RSpec.describe "UserSessions", type: :system do
           expect(page).to have_content "更新に失敗しました"
         end
       end
+    end
 
-      context "リンクの遷移" do
+    describe "リンクの遷移" do
+      context "ユーザー編集ページ" do
         it "パスワードリセットページへの遷移" do
           visit edit_user_path(user)
           click_link "こちら"
           expect(page).to have_current_path(new_password_reset_path)
+        end
+
+        it "LINE友達登録ページへの遷移" do
+          visit edit_user_path(user)
+          click_link "LINE友達登録"
+          expect(page).to have_current_path(line_qr_code_path)
         end
       end
     end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -87,6 +87,19 @@ RSpec.describe "UserSessions", type: :system do
           expect(page).to have_current_path(new_user_path)
         end
       end
+
+      context "確認用パスワードが空欄" do
+        it "ユーザーの新規作成が失敗する" do
+          visit new_user_path
+          fill_in "名前", with: "テスト"
+          fill_in "メールアドレス", with: "email@example.com"
+          fill_in "パスワード", with: "password"
+          fill_in "パスワード再入力", with: ""
+          click_button "登録"
+          expect(page).to have_content "ユーザー登録に失敗しました"
+          expect(page).to have_current_path(new_user_path)
+        end
+      end
     end
   end
 end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -61,6 +61,19 @@ RSpec.describe "UserSessions", type: :system do
           expect(page).to have_current_path(new_user_path)
         end
       end
+
+      context "名前が256文字以上" do
+        it "ユーザーの新規作成が失敗する" do
+          visit new_user_path
+          fill_in "名前", with: "テ" * 256
+          fill_in "メールアドレス", with: "email@example.com"
+          fill_in "パスワード", with: "password"
+          fill_in "パスワード再入力", with: "password"
+          click_button "登録"
+          expect(page).to have_content "ユーザー登録に失敗しました"
+          expect(page).to have_current_path(new_user_path)
+        end
+      end
     end
   end
 end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -114,5 +114,14 @@ RSpec.describe "UserSessions", type: :system do
         end
       end
     end
+
+    describe "マイページ" do
+      context "ログインしていない状態" do
+        it "マイページへのアクセスが失敗する" do
+          visit user_path(user)
+          expect(page).to have_current_path(login_path)
+        end
+      end
+    end
   end
 end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -100,6 +100,19 @@ RSpec.describe "UserSessions", type: :system do
           expect(page).to have_current_path(new_user_path)
         end
       end
+
+      context "パスワードとパスワードリセットが一致しない" do
+        it "ユーザーの新規作成が失敗する" do
+          visit new_user_path
+          fill_in "名前", with: "テスト"
+          fill_in "メールアドレス", with: "email@example.com"
+          fill_in "パスワード", with: "password_1"
+          fill_in "パスワード再入力", with: "password_2"
+          click_button "登録"
+          expect(page).to have_content "ユーザー登録に失敗しました"
+          expect(page).to have_current_path(new_user_path)
+        end
+      end
     end
   end
 end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -19,6 +19,19 @@ RSpec.describe "UserSessions", type: :system do
         end
       end
 
+      context "名前が256文字以上" do
+        it "ユーザーの新規作成が失敗する" do
+          visit new_user_path
+          fill_in "名前", with: "テ" * 256
+          fill_in "メールアドレス", with: "email@example.com"
+          fill_in "パスワード", with: "password"
+          fill_in "パスワード再入力", with: "password"
+          click_button "登録"
+          expect(page).to have_content "ユーザー登録に失敗しました"
+          expect(page).to have_current_path(new_user_path)
+        end
+      end
+
       context "メールアドレスが未入力" do
         it "ユーザーの新規作成が失敗する" do
           visit new_user_path
@@ -62,13 +75,13 @@ RSpec.describe "UserSessions", type: :system do
         end
       end
 
-      context "名前が256文字以上" do
+      context "パスワードが空欄" do
         it "ユーザーの新規作成が失敗する" do
           visit new_user_path
-          fill_in "名前", with: "テ" * 256
+          fill_in "名前", with: "テスト"
           fill_in "メールアドレス", with: "email@example.com"
-          fill_in "パスワード", with: "password"
-          fill_in "パスワード再入力", with: "password"
+          fill_in "パスワード", with: ""
+          fill_in "パスワード再入力", with: ""
           click_button "登録"
           expect(page).to have_content "ユーザー登録に失敗しました"
           expect(page).to have_current_path(new_user_path)

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -48,6 +48,19 @@ RSpec.describe "UserSessions", type: :system do
           expect(page).to have_field "メールアドレス", with: existed_user.email
         end
       end
+
+      context "パスワードが2文字以下" do
+        it "ユーザーの新規作成が失敗する" do
+          visit new_user_path
+          fill_in "名前", with: "テスト"
+          fill_in "メールアドレス", with: "email@example.com"
+          fill_in "パスワード", with: "ab"
+          fill_in "パスワード再入力", with: "ab"
+          click_button "登録"
+          expect(page).to have_content "ユーザー登録に失敗しました"
+          expect(page).to have_current_path(new_user_path)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### 概要
ユーザー登録のテストを実装する

---
### 背景・目的
テストの自動化による効率UPのため

---
### 内容
#### ログイン前
##### ユーザー新規登録
- [x] フォームの入力値が正常の場合、ユーザー登録に成功するテストを実装
- [x] メールアドレスが未入力の場合、ユーザーの新規作成が失敗するテストを実装
- [x] 登録済のメールアドレスを使用した場合、ユーザーの新規作成が失敗するテストを実装
- [x] パスワードが2文字以下の場合、ユーザーの新規作成が失敗するテストを実装
- [x] 名前が256文字以上の場合、ユーザーの新規作成が失敗するテストを実装
- [x] パスワードが空欄の場合、ユーザーの新規作成が失敗するテストを実装
- [x] 確認用パスワードが空欄の場合、ユーザーの新規作成が失敗するテストを実装
- [x] パスワードと確認用パスワードが不一致の場合、ユーザーの新規作成が失敗するテストを実装

##### マイページ
- [x] 未ログインの場合、マイページにアクセスができない

#### ログイン後
##### ユーザー編集
- [x] ログイン後、フォームの入力値が正常の場合、ユーザーの編集が成功するテストを実装
- [x] 名前が空欄の場合、ユーザーの更新が失敗するテストを実装

##### リンク遷移
- [x] ユーザー編集ページから、パスワードリセットページへ遷移できるテストを実装
- [x] ユーザー編集ページから、LINE友達登録ページへ遷移できるテストを実装

---
### 対応しないこと
- 

---
### 補足
This PR close #347 