### PR TITLE
【テスト】before login header

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -22,7 +22,7 @@
       <input id="my-drawer-4" type="checkbox" class="drawer-toggle" />
       <div class="drawer-content">
         <!-- Page content here -->
-        <label for="my-drawer-4" class="drawer-button btn btn-ghost">
+        <label id="open-drawer" for="my-drawer-4" class="drawer-button btn btn-ghost">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="black" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 12.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 18.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5Z" /></svg>  
         </label>
       </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -6,7 +6,7 @@
         <span class="text-lg md:text-4xl">Stay Friends</span><span class="text-xs md:text-xl"> ～友だちと再びつながるアプリ～</span>
       <% end %>
     </div>
-    <div class="font-bold space-x-5 mr-5 hidden lg:block md:text-sm lg:text-md xl:text-base">
+    <div id="pc-nav" class="font-bold space-x-5 mr-5 hidden lg:block md:text-sm lg:text-md xl:text-base">
       <%= link_to "AIメッセージ作成", introduction_path(1) %>
       <%= link_to "連絡帳", profiles_path %>
       <%= link_to how_to_use_path do %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -18,7 +18,7 @@
         <button class="btn bg-ivory-white text-black border-none hover:bg-peach-red <%= "hover:bg-slate-300" if current_page?(root_path) %>">新規登録</button>
       <% end %>
     </div>
-    <div class="navbar-end drawer-end w-fit lg:hidden">
+    <div id="mobile-nav" class="navbar-end drawer-end w-fit lg:hidden">
       <input id="my-drawer-4" type="checkbox" class="drawer-toggle" />
       <div class="drawer-content">
         <!-- Page content here -->

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -92,4 +92,9 @@ RSpec.configure do |config|
     Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
     Capybara.ignore_hidden_elements = false
   end
+
+  # テスト実行前に前回テストのscreenshotを削除する
+  config.before(:all) do
+    FileUtils.rm_rf(Dir[Rails.root.join("tmp", "capybara", "*")], secure: true)
+  end
 end

--- a/spec/system/before_login_header_spec.rb
+++ b/spec/system/before_login_header_spec.rb
@@ -115,6 +115,15 @@ RSpec.describe "before_login_header", type: :system do
           expect(page).to have_current_path(new_user_path)
         end
       end
+
+      context "利用規約ボタンをクリック" do
+        it "利用規約ページに遷移する" do
+          within("#mobile-nav") do
+            click_link "利用規約"
+          end
+          expect(page).to have_current_path(terms_path)
+        end
+      end
     end
   end
 end

--- a/spec/system/before_login_header_spec.rb
+++ b/spec/system/before_login_header_spec.rb
@@ -44,12 +44,14 @@ RSpec.describe "before_login_header", type: :system do
         end
       end
 
-#       context "ログインリンクをクリック" do
-#         it "ログインページに遷移する" do
-#           click_link "ログイン"
-#           expect(page).to have_current_path(login_path)
-#         end
-#       end
+      context "ログインリンクをクリック" do
+        it "ログイン画面に遷移する" do
+          within("#pc-nav") do
+            click_link "ログイン"
+          end
+          expect(page).to have_current_path(login_path)
+        end
+      end
 
 #       context "新規登録ボタンをクリック" do
 #         it "新規登録ページに遷移する" do

--- a/spec/system/before_login_header_spec.rb
+++ b/spec/system/before_login_header_spec.rb
@@ -2,12 +2,12 @@ require "rails_helper"
 
 RSpec.describe "before_login_header", type: :system do
   let(:user) { create(:user) }
+  before { visit root_path }
 
   describe "PC・スマホ画面共通" do
     describe "ページ遷移確認" do
       context "アプリ名をクリック" do
         it "rootページに遷移する" do
-          visit root_path
           click_link "Stay Friends ～友だちと再びつながるアプリ～"
           expect(page).to have_current_path(root_path)
         end
@@ -19,7 +19,6 @@ RSpec.describe "before_login_header", type: :system do
     describe "ページ遷移確認" do
       context "AIメッセージ作成リンクをクリック" do
         it "AIメッセージページに遷移する" do
-          visit root_path
           within("#pc-nav") do
             click_link "AIメッセージ作成"
           end

--- a/spec/system/before_login_header_spec.rb
+++ b/spec/system/before_login_header_spec.rb
@@ -26,12 +26,14 @@ RSpec.describe "before_login_header", type: :system do
         end
       end
 
-#       context "連絡帳リンクをクリック" do
-#         it "連絡帳ページに遷移する" do
-#           click_link "連絡帳"
-#           expect(page).to have_current_path(profiles_path)
-#         end
-#       end
+      context "連絡帳リンクをクリック" do
+        it "ログイン画面に遷移する" do
+          within("#pc-nav") do
+            click_link "連絡帳"
+          end
+          expect(page).to have_current_path(login_path)
+        end
+      end
 
 #       context "ログインリンクをクリック" do
 #         it "ログインページに遷移する" do

--- a/spec/system/before_login_header_spec.rb
+++ b/spec/system/before_login_header_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "before_login_header", type: :system do
   let(:user) { create(:user) }
 
-  describe "ログイン前" do
+  describe "PC・スマホ画面共通" do
     describe "ページ遷移確認" do
       context "アプリ名をクリック" do
         it "rootページに遷移する" do
@@ -12,13 +12,20 @@ RSpec.describe "before_login_header", type: :system do
           expect(page).to have_current_path(root_path)
         end
       end
+    end
+  end
 
-#       context "AIメッセージ作成リンクをクリック" do
-#         it "AIメッセージページに遷移する" do
-#           click_link "AIメッセージ作成"
-#           expect(page).to have_current_path(introduction_path(1))
-#         end
-#       end
+  describe "PC画面" do
+    describe "ページ遷移確認" do
+      context "AIメッセージ作成リンクをクリック" do
+        it "AIメッセージページに遷移する" do
+          visit root_path
+          within("#pc-nav") do
+            click_link "AIメッセージ作成"
+          end
+          expect(page).to have_current_path(introduction_path(1))
+        end
+      end
 
 #       context "連絡帳リンクをクリック" do
 #         it "連絡帳ページに遷移する" do

--- a/spec/system/before_login_header_spec.rb
+++ b/spec/system/before_login_header_spec.rb
@@ -87,6 +87,14 @@ RSpec.describe "before_login_header", type: :system do
           expect(page).to have_current_path(login_path)
         end
       end
+      context "使い方リンクをクリック" do
+        it "使い方ページに遷移する" do
+          within("#mobile-nav") do
+            click_link "使い方"
+          end
+          expect(page).to have_current_path(how_to_use_path)
+        end
+      end
     end
   end
 end

--- a/spec/system/before_login_header_spec.rb
+++ b/spec/system/before_login_header_spec.rb
@@ -53,12 +53,14 @@ RSpec.describe "before_login_header", type: :system do
         end
       end
 
-#       context "新規登録ボタンをクリック" do
-#         it "新規登録ページに遷移する" do
-#           click_link "新規登録"
-#           expect(page).to have_current_path(new_user_path)
-#         end
-#       end
+      context "新規登録ボタンをクリック" do
+        it "新規登録ページに遷移する" do
+          within("#pc-nav") do
+            click_link "新規登録"
+          end
+          expect(page).to have_current_path(new_user_path)
+        end
+      end
     end
   end
 end

--- a/spec/system/before_login_header_spec.rb
+++ b/spec/system/before_login_header_spec.rb
@@ -106,6 +106,15 @@ RSpec.describe "before_login_header", type: :system do
           expect(page).to have_current_path(login_path)
         end
       end
+
+      context "新規登録ボタンをクリック" do
+        it "新規登録ページに遷移する" do
+          within("#mobile-nav") do
+            click_link "新規登録"
+          end
+          expect(page).to have_current_path(new_user_path)
+        end
+      end
     end
   end
 end

--- a/spec/system/before_login_header_spec.rb
+++ b/spec/system/before_login_header_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe "before_login_header", type: :system do
           expect(page).to have_current_path(introduction_path(1))
         end
       end
+
       context "連絡帳リンクをクリック" do
         it "ログイン画面に遷移する" do
           within("#mobile-nav") do
@@ -87,12 +88,22 @@ RSpec.describe "before_login_header", type: :system do
           expect(page).to have_current_path(login_path)
         end
       end
+
       context "使い方リンクをクリック" do
         it "使い方ページに遷移する" do
           within("#mobile-nav") do
             click_link "使い方"
           end
           expect(page).to have_current_path(how_to_use_path)
+        end
+      end
+
+      context "ログインリンクをクリック" do
+        it "ログイン画面に遷移する" do
+          within("#mobile-nav") do
+            click_link "ログイン"
+          end
+          expect(page).to have_current_path(login_path)
         end
       end
     end

--- a/spec/system/before_login_header_spec.rb
+++ b/spec/system/before_login_header_spec.rb
@@ -133,6 +133,15 @@ RSpec.describe "before_login_header", type: :system do
           expect(page).to have_current_path(privacy_policy_path)
         end
       end
+
+      context "お問い合わせボタンをクリック" do
+        it "お問い合わせページに遷移する" do
+          within("#mobile-nav") do
+            click_link "お問い合わせ"
+          end
+          expect(page).to have_current_path("https://docs.google.com/forms/d/e/1FAIpQLScyntUUOKze4OmcuIShk5VLcZu-8JEHIAqB6GCKeti32fG6vg/viewform")
+        end
+      end
     end
   end
 end

--- a/spec/system/before_login_header_spec.rb
+++ b/spec/system/before_login_header_spec.rb
@@ -1,14 +1,17 @@
-# require "rails_helper"
+require "rails_helper"
 
-# RSpec.describe "before_login_header", type: :system do
-#   describe "ログイン前" do
-#     describe "ページ遷移確認" do
-#       context "アプリ名をクリック" do
-#         it "rootページに遷移する" do
-#           click_link "Reconnect　～ともだちと再びつながるアプリ～"
-#           expect(page).to have_current_path(root_path)
-#         end
-#       end
+RSpec.describe "before_login_header", type: :system do
+  let(:user) { create(:user) }
+
+  describe "ログイン前" do
+    describe "ページ遷移確認" do
+      context "アプリ名をクリック" do
+        it "rootページに遷移する" do
+          visit root_path
+          click_link "Stay Friends ～友だちと再びつながるアプリ～"
+          expect(page).to have_current_path(root_path)
+        end
+      end
 
 #       context "AIメッセージ作成リンクをクリック" do
 #         it "AIメッセージページに遷移する" do
@@ -37,6 +40,6 @@
 #           expect(page).to have_current_path(new_user_path)
 #         end
 #       end
-#     end
-#   end
-# end
+    end
+  end
+end

--- a/spec/system/before_login_header_spec.rb
+++ b/spec/system/before_login_header_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe "before_login_header", type: :system do
           expect(page).to have_current_path(introduction_path(1))
         end
       end
+      context "連絡帳リンクをクリック" do
+        it "ログイン画面に遷移する" do
+          within("#mobile-nav") do
+            click_link "連絡帳"
+          end
+          expect(page).to have_current_path(login_path)
+        end
+      end
     end
   end
 end

--- a/spec/system/before_login_header_spec.rb
+++ b/spec/system/before_login_header_spec.rb
@@ -124,6 +124,15 @@ RSpec.describe "before_login_header", type: :system do
           expect(page).to have_current_path(terms_path)
         end
       end
+
+      context "プライバシーポリシーボタンをクリック" do
+        it "プライバシーポリシーページに遷移する" do
+          within("#mobile-nav") do
+            click_link "プライバシーポリシー"
+          end
+          expect(page).to have_current_path(privacy_policy_path)
+        end
+      end
     end
   end
 end

--- a/spec/system/before_login_header_spec.rb
+++ b/spec/system/before_login_header_spec.rb
@@ -63,4 +63,22 @@ RSpec.describe "before_login_header", type: :system do
       end
     end
   end
+
+  describe "スマホ画面" do
+    before do
+      page.driver.browser.manage.window.resize_to(1023, 900)
+      find("#open-drawer").click
+    end
+
+    describe "ページ遷移確認" do
+      context "AIメッセージ作成リンクをクリック" do
+        it "AIメッセージページに遷移する" do
+          within("#mobile-nav") do
+            click_link "AIメッセージ作成"
+          end
+          expect(page).to have_current_path(introduction_path(1))
+        end
+      end
+    end
+  end
 end

--- a/spec/system/before_login_header_spec.rb
+++ b/spec/system/before_login_header_spec.rb
@@ -35,6 +35,15 @@ RSpec.describe "before_login_header", type: :system do
         end
       end
 
+      context "使い方リンクをクリック" do
+        it "使い方ページに遷移する" do
+          within("#pc-nav") do
+            click_link "使い方"
+          end
+          expect(page).to have_current_path(how_to_use_path)
+        end
+      end
+
 #       context "ログインリンクをクリック" do
 #         it "ログインページに遷移する" do
 #           click_link "ログイン"

--- a/spec/system/user_session_spec.rb
+++ b/spec/system/user_session_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe "UserSessions", type: :system do
       it "ログアウト処理が成功する" do
         login_as(user)
         visit root_path
+        expect(page).to have_content("ログアウト")
         click_link "ログアウト", match: :first
         expect(page).to have_content "ログアウトしました"
         expect(page).to have_current_path(root_path)

--- a/spec/system/user_session_spec.rb
+++ b/spec/system/user_session_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe "UserSessions", type: :system do
     context "ログアウトボタンをクリック" do
       it "ログアウト処理が成功する" do
         login_as(user)
+        visit root_path
         click_link "ログアウト", match: :first
         expect(page).to have_content "ログアウトしました"
         expect(page).to have_current_path(root_path)


### PR DESCRIPTION
### 概要
before login headerのシステムテスト実装

---
### 背景・目的
動作確認、及び自動テストによる効率化UP

---
### 内容
#### 共通
- [x] アプリ名をクリックすると、トップページに遷移する
#### PC画面
- [x] AIメッセージリンクをクリックすると、AIメッセージのイントロページに遷移する
- [x] 未ログイン状態で連絡帳リンクをクリックすると、ログインページに遷移する
- [x] 使い方リンクをクリックすると、使い方ページに遷移する
- [x] ログインリンクをクリックすると、ログインページに遷移する
- [x] 新規登録リンクをクリックすると、新規登録ページに遷移する
- [x] スマホ画面幅でのAIメッセージリンクをクリックすると、AIメッセージのイントロページに遷移する
#### スマホ画面
- [x] 連絡帳リンクをクリックすると、未ログインの場合ログインページに遷移する
- [x] 使い方リンクをクリックすると、使い方ページに遷移する
- [x] ログインリンクをクリックすると、ログインページに遷移する
- [x] 新規登録リンクをクリックすると、新規登録ページに遷移する
- [x] 利用規約リンクをクリックすると、利用規約ページに遷移する
- [x] プライバシーポリシーリンクをクリックすると、プライバシーページに遷移する
- [x] お問い合わせリンクをクリックすると、お問い合わせページに遷移する


---
### 対応しないこと
- 

---
### 補足