### PR TITLE
Test/#352 logout error

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -78,6 +78,13 @@ jobs:
       - name: Run rspec
         run: bundle exec rspec
 
+      - name: Archive Capybara screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: capybara-screenshots
+          path: tmp/capybara
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -95,8 +95,6 @@ RSpec.configure do |config|
 
   # テスト実行前に前回テストのscreenshotを削除する
   config.before(:all) do
-    unless ENV["CI"]
-      FileUtils.rm_rf(Dir[Rails.root.join("tmp", "capybara", "*")], secure: true)
-    end
+    FileUtils.rm_rf(Dir[Rails.root.join("tmp", "capybara", "*")], secure: true) unless ENV["CI"]
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -94,7 +94,7 @@ RSpec.configure do |config|
   end
 
   # テスト実行前に前回テストのscreenshotを削除する
-  config.before(:all) do
-    FileUtils.rm_rf(Dir[Rails.root.join("tmp", "capybara", "*")], secure: true)
-  end
+  # config.before(:all) do
+  #   FileUtils.rm_rf(Dir[Rails.root.join("tmp", "capybara", "*")], secure: true)
+  # end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -94,7 +94,9 @@ RSpec.configure do |config|
   end
 
   # テスト実行前に前回テストのscreenshotを削除する
-  # config.before(:all) do
-  #   FileUtils.rm_rf(Dir[Rails.root.join("tmp", "capybara", "*")], secure: true)
-  # end
+  config.before(:all) do
+    unless ENV["CI"]
+      FileUtils.rm_rf(Dir[Rails.root.join("tmp", "capybara", "*")], secure: true)
+    end
+  end
 end

--- a/spec/system/user_session_spec.rb
+++ b/spec/system/user_session_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe "UserSessions", type: :system do
       it "ログアウト処理が成功する" do
         login_as(user)
         visit root_path
+        page.driver.browser.manage.window.resize_to(1024, 900)
         expect(page).to have_content("ログアウト")
         click_link "ログアウト", match: :first
         expect(page).to have_content "ログアウトしました"


### PR DESCRIPTION
### 概要
ログアウト処理エラー対処（CI上）

---
### 背景・目的
ログアウト処理でエラーが起きた為（ローカルでは成功、CI上でエラー）

```
Failures:
  1) UserSessions ログアウト ログアウトボタンをクリック ログアウト処理が成功する
     Failure/Error: click_link "ログアウト", match: :first
     Selenium::WebDriver::Error::ElementNotInteractableError:
       element not interactable
         (Session info: chrome-headless-shell=124.0.6367.78)
     [Screenshot Image]: /home/runner/work/RUNTEQ_portfolio/RUNTEQ_portfolio/tmp/capybara/failures_r_spec_example_groups_user_sessions_nested_2_nested_-_271.png
```
---
### 内容
- [x] スクリーンショットをGitHub上に保存するステップを追加
- [x] テストごとに過去のスクリーンショットを削除する処理を、CI上では無効にする
- [x] ログアウト処理直前に、スクリーン幅を1024pxに指定する
- 原因
画面幅が狭く、drawerにログアウトリンクが隠れていた為、アクセスできていなかった
[![Image from Gyazo](https://i.gyazo.com/1495245398458c59d41ae5071de89c3f.png)](https://gyazo.com/1495245398458c59d41ae5071de89c3f)

---
### 対応しないこと
- 

---
### 補足
This PR close #352 
