### PR TITLE
Test/#358 footer

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,5 @@
 <!---スマホ画面用のフッター--->
-<footer class="fixed bottom-0 flex items-center justify-center h-12 bg-zinc-600 w-full md:hidden">
+<footer id="mobile-footer" class="fixed bottom-0 flex items-center justify-center h-12 bg-zinc-600 w-full md:hidden">
   <div class="flex justify-around text-white text-xs w-full">
     <div class="flex flex-col justify-center text-center">
       <div>
@@ -44,7 +44,7 @@
 
 
 <!---PC画面用のフッター--->
-<footer class="bottom-0 bg-cream-pink <%= "bg-gray-950 text-white" if current_page?(root_path) %> w-full left-0 hidden md:block min-h-10">
+<footer id="pc-footer" class="bottom-0 bg-cream-pink <%= "bg-gray-950 text-white" if current_page?(root_path) %> w-full left-0 hidden md:block min-h-10">
   <div class="flex justify-center items-center space-x-20 h-full">
     <%= link_to "利用規約", terms_path %>
     <%= link_to "プライバシーポリシー", privacy_policy_path %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -5,39 +5,39 @@
       <div>
         <%= link_to introduction_path(1) do %>
           <i class="fa-regular fa-message fa-lg"></i>
+          <p>AIメッセージ</p>
         <% end %>
       </div>
-      <div>AIメッセージ</div>
     </div>
     <div class="flex flex-col justify-center text-center">
       <div>
         <%= link_to profiles_path do %>
           <i class="fa-regular fa-address-book fa-lg"></i>
+          <p>連絡帳</p>
         <% end %>
       </div>
-      <div>連絡帳</div>
     </div>
     <div class="flex flex-col justify-center text-center">
       <div>
         <%= link_to user_path(current_user) do %>
           <i class="fa-regular fa-user fa-lg"></i>
+          <p>マイページ</p>
         <% end %>
       </div>
-      <div>マイページ</div>
     </div>
     <div class="flex flex-col justify-center text-center">
       <%= link_to how_to_use_path do %>
         <i class="fa-regular fa-circle-question fa-lg"></i>
+        <p>使い方</p>
       <% end %>
-      <div>使い方</div>
     </div>
     <div class="flex flex-col justify-center text-center">
       <div>
         <%= link_to logout_path, data: { turbo_method: :delete } do %>
           <i class="fa-solid fa-arrow-right-from-bracket fa-lg"></i>
+          <p>ログアウト</p>
         <% end %>
       </div>
-      <div>ログアウト</div>
     </div>
   </div>
 </footer>

--- a/spec/system/before_login_footer_spec.rb
+++ b/spec/system/before_login_footer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "before_login_header", type: :system do
+RSpec.describe "before_login_footer", type: :system do
   let(:user) { create(:user) }
 
   describe "PC画面" do

--- a/spec/system/footer_spec.rb
+++ b/spec/system/footer_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+RSpec.describe "before_login_header", type: :system do
+  include LoginMacros
+  let(:user) { create(:user) }
+
+  before { login_as(user) }
+
+  describe "PC画面" do
+    before do
+      visit root_path
+      page.driver.browser.manage.window.resize_to(768, 900)
+    end
+
+    describe "ページ遷移確認" do
+      context "利用規約ボタンをクリック" do
+        it "利用規約ページに遷移する" do
+          within("#pc-footer") do
+            click_link "利用規約"
+          end
+          expect(page).to have_current_path(terms_path)
+        end
+      end
+
+      context "プライバシーポリシーボタンをクリック" do
+        it "プライバシーポリシーページに遷移する" do
+          within("#pc-footer") do
+            click_link "プライバシーポリシー"
+          end
+          expect(page).to have_current_path(privacy_policy_path)
+        end
+      end
+
+      context "お問い合わせボタンをクリック" do
+        it "お問い合わせページに遷移する" do
+          within("#pc-footer") do
+            click_link "お問い合わせ"
+          end
+          expect(page).to have_current_path("https://docs.google.com/forms/d/e/1FAIpQLScyntUUOKze4OmcuIShk5VLcZu-8JEHIAqB6GCKeti32fG6vg/viewform")
+        end
+      end
+    end
+  end
+
+  describe "スマホ画面" do
+    before do
+      visit root_path
+      page.driver.browser.manage.window.resize_to(767, 900)
+    end
+
+    describe "ページ遷移確認" do
+      context "AIメッセージ作成リンクをクリック" do
+        it "AIメッセージページに遷移する" do
+          within("#mobile-footer") do
+            click_link "AIメッセージ"
+          end
+          expect(page).to have_current_path(introduction_path(1))
+        end
+      end
+
+      context "連絡帳リンクをクリック" do
+        it "連絡帳一覧ページに遷移する" do
+          within("#mobile-footer") do
+            click_link "連絡帳"
+          end
+          expect(page).to have_current_path(profiles_path)
+        end
+      end
+
+      context "マイページリンクをクリック" do
+        it "マイページに遷移する" do
+          within("#mobile-footer") do
+            click_link "マイページ"
+          end
+          expect(page).to have_current_path(user_path(user))
+        end
+      end
+
+      context "使い方リンクをクリック" do
+        it "使い方ページに遷移する" do
+          within("#mobile-footer") do
+            click_link "使い方"
+          end
+          expect(page).to have_current_path(how_to_use_path)
+        end
+      end
+
+      context "ログアウトリンクをクリック" do
+        it "ログアウト処理が成功する" do
+          within("#mobile-footer") do
+            click_link "ログアウト"
+          end
+          expect(page).to have_current_path(root_path)
+          expect(page).to have_content("ログイン")
+        end
+      end
+    end
+  end
+end

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -70,7 +70,6 @@ RSpec.describe "header", type: :system do
 
       context "ログアウトリンクをクリック" do
         it "ログアウト処理が成功する" do
-          page.driver.browser.manage.window.resize_to(1024, 900)
           within("#pc-nav") do
             click_link "ログアウト"
           end


### PR DESCRIPTION
### 概要
ログイン後フッターのテストを実装

---
### 背景・目的
動作確認のため

---
### 内容
- [x] ログイン後のフッターのリンク遷移テストを実装
- [x] フッターの文字列をリンクの中に含める（view/shared/_footer.html.erbファイル）
- [x] PC用、スマホ用footerにそれぞれIDを付与（view/shared/_footer.html.erbファイル）

---
### 対応しないこと
- 

---
### 補足
This PR close #358 