### PR TITLE
【テスト】連絡先

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,5 +31,13 @@ Metrics/BlockLength:
   Exclude:
     - "spec/**/*"
 
+Metrics/AbcSize:
+  Exclude:
+    - "spec/**/*"
+
+Metrics/MethodLength:
+  Exclude:
+    - "spec/**/*"
+
 Style/BlockComments:
   Enabled: false

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -30,7 +30,7 @@ class ProfilesController < ApplicationController
   def edit; end
 
   def update
-    @profile.group = profile_params[:group][:id].present? ? Group.find(profile_params[:group][:id]) : nil
+    update_group
     if @profile.update(profile_params.except(:group))
       update_success
     else
@@ -57,6 +57,12 @@ class ProfilesController < ApplicationController
 
   def profile_params
     params.require(:profile).permit(:avatar, :name, :furigana, :phone, :email, :line_name, :address, :last_contacted, :note, group: %i[id], events_attributes: %i[name date id])
+  end
+
+  def update_group
+    return if @profile.group.nil?
+
+    @profile.group = profile_params[:group].present? ? Group.find(profile_params[:group][:id]) : nil
   end
 
   def update_success

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:tab_title, "連絡帳") %>
 
 <!---PC画面用--->
-<div class="hidden xl:block">
+<div id="pc-profiles" class="hidden xl:block">
   <div id="sticky-banner-pc" data-controller="banner" data-banner-target="banner" tabindex="-1" class="start-0 flex justify-between w-full p-4 border-b border-gray-200 bg-yellow-50 <%= "hidden" if @profiles_birthdays_this_month.empty? && @profiles_special_day_this_month.empty? %>">
       <div class="flex items-center mx-auto">
           <p class="flex items-center text-sm">
@@ -176,7 +176,7 @@
 </div>
 
 <!---スマホ画面用--->
-<div class="xl:hidden mb-20 flex flex-col items-center">
+<div id="mobile-profiles" class="xl:hidden mb-20 flex flex-col items-center">
   <div id="sticky-banner-mb" tabindex="-1" data-controller="banner" data-banner-target="banner" class="start-0 flex justify-between w-full p-4 border-b border-gray-200 bg-yellow-50 xl:hidden <%= "hidden" if @profiles_birthdays_this_month.empty? && @profiles_special_day_this_month.empty? %>">
       <div class="flex items-center mx-auto">
         <p class="flex items-center text-sm">

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -148,21 +148,21 @@
                 </td>
                 <td class="text-center">
                   <div>
-                    <%= link_to profile_path(profile) do %>
+                    <%= link_to profile_path(profile), id: "pc-profile-#{profile.id}" do %>
                       <i class="fa-solid fa-circle-info fa-lg"></i>
                     <% end %>
                   </div>
                 </td>
                 <td class="text-center">
                     <div>
-                      <%= link_to edit_profile_path(profile) do %>
+                      <%= link_to edit_profile_path(profile), id: "pc-edit-profile-#{profile.id}" do %>
                         <i class="fa-solid fa-pen-to-square fa-lg"></i>
                       <% end %>
                     </div>
                 </td>
                 <td class="text-center">
                     <div>
-                      <%= link_to profile_path(profile), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } do %>
+                      <%= link_to profile_path(profile), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete }, id: "pc-delete-profile-#{profile.id}" do %>
                         <i class="fa-solid fa-trash fa-lg"></i>
                       <% end %>
                     </div>
@@ -312,17 +312,17 @@
                 <td class="pr-5 md:pr-2 lg:px-3 font-semibold">
                   <div class="flex justify-center items-center space-y-4 md:space-y-0 md:space-x-4 flex-col md:flex-row md:min-w-[80px] lg:min-w-[110px]">
                     <div>
-                      <%= link_to profile_path(profile) do %>
+                      <%= link_to profile_path(profile), id: "mobile-profile-#{profile.id}" do %>
                         <i class="fa-solid fa-circle-info fa-lg"></i>
                       <% end %>
                     </div>
                     <div>
-                      <%= link_to edit_profile_path(profile) do %>
+                      <%= link_to edit_profile_path(profile), id: "mobile-edit-profile-#{profile.id}" do %>
                         <i class="fa-solid fa-pen-to-square fa-lg"></i>
                       <% end %>
                     </div>
                     <div>
-                      <%= link_to profile_path(profile), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete } do %>
+                      <%= link_to profile_path(profile), data: { turbo_confirm: "本当に削除しますか？", turbo_method: :delete }, id: "mobile-delete-profile-#{profile.id}" do %>
                         <i class="fa-solid fa-trash fa-lg"></i>
                       <% end %>
                     </div>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <aside id="default-sidebar" class="w-64 h-full transition-transform -translate-x-full sm:translate-x-0 hidden md:block" aria-label="Sidebar">
   <div class="h-full px-4  overflow-y-auto bg-stone-200 text-gray-900">
       <div class="flex items-center justify-center mt-4 mb-20">
-        <% if profile.avatar.attached? && profile.avatar.content_type.in?(%w[image/jpeg image/png]) %>
+        <% if profile.avatar.persisted? && profile.avatar.attached? && profile.avatar.content_type.in?(%w[image/jpeg image/png]) %>
           <%= image_tag profile.avatar.variant(resize_to_limit: [50, 50]) %>
         <% else %>
           <%= image_tag "default_avatar.png", style: "width: 50px; height: 50px;" %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <aside id="default-sidebar" class="w-64 h-full transition-transform -translate-x-full sm:translate-x-0 hidden md:block" aria-label="Sidebar">
   <div class="h-full px-4  overflow-y-auto bg-stone-200 text-gray-900">
       <div class="flex items-center justify-center mt-4 mb-20">
-        <% if profile.avatar.attached? %>
+        <% if profile.avatar.attached? && profile.avatar.content_type.in?(%w[image/jpeg image/png]) %>
           <%= image_tag profile.avatar.variant(resize_to_limit: [50, 50]) %>
         <% else %>
           <%= image_tag "default_avatar.png", style: "width: 50px; height: 50px;" %>

--- a/app/views/shared/_top_tab.html.erb
+++ b/app/views/shared/_top_tab.html.erb
@@ -1,4 +1,4 @@
-<div role="tablist" class="tabs tabs-bordered mt-3 px-1 md:hidden">
+<div id="top-tab" role="tablist" class="tabs tabs-bordered mt-3 px-1 md:hidden">
   <%= link_to "基本情報",
               profile_path(profile),
               role: "tab",

--- a/spec/support/create_group_macros.rb
+++ b/spec/support/create_group_macros.rb
@@ -1,5 +1,5 @@
 module CreateGroupMacros
-  def create_group_1
+  def create_group_one
     visit profiles_path
     page.driver.browser.manage.window.resize_to(1280, 900)
     within("#pc-profiles") do
@@ -10,7 +10,7 @@ module CreateGroupMacros
     expect(page).to have_content("グループ1")
   end
 
-  def create_group_2
+  def create_group_two
     visit profiles_path
     within("#pc-profiles") do
       click_button "グループを作成"

--- a/spec/support/create_group_macros.rb
+++ b/spec/support/create_group_macros.rb
@@ -1,0 +1,22 @@
+module CreateGroupMacros
+  def create_group_1
+    visit profiles_path
+    page.driver.browser.manage.window.resize_to(1280, 900)
+    within("#pc-profiles") do
+      click_button "グループを作成"
+    end
+    fill_in "新しいグループ名", with: "グループ1"
+    click_button "保存"
+    expect(page).to have_content("グループ1")
+  end
+
+  def create_group_2
+    visit profiles_path
+    within("#pc-profiles") do
+      click_button "グループを作成"
+    end
+    fill_in "新しいグループ名", with: "グループ2"
+    click_button "保存"
+    expect(page).to have_content("グループ2")
+  end
+end

--- a/spec/support/create_profile_macros.rb
+++ b/spec/support/create_profile_macros.rb
@@ -1,7 +1,7 @@
 module CreateProfileMacros
-  def create_profile
-    page.driver.browser.manage.window.resize_to(1280, 900)
+  def create_profile_1
     visit profiles_path
+    page.driver.browser.manage.window.resize_to(1280, 900)
     within("#pc-profiles") do
       click_button "連絡先を作成"
     end
@@ -16,6 +16,27 @@ module CreateProfileMacros
     fill_in "LINEの名前", with: "やまだ"
     select "１年前", from: "最後に連絡した日"
     fill_in "メモ", with: "メモテスト"
+    attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/valid_image.jpg")
+    click_button "登録する"
+    expect(page).to have_content "連絡先を登録しました"
+    expect(page).to have_current_path(profile_path(Profile.last))
+  end
+
+  def create_profile_2
+    visit profiles_path
+    page.driver.browser.manage.window.resize_to(1280, 900)
+    within("#pc-profiles") do
+      click_button "連絡先を作成"
+    end
+    fill_in "名前", with: "佐藤一郎"
+    fill_in "フリガナ", with: "サトウイチロウ"
+    fill_in "誕生日", with: "01-15-1990"
+    fill_in "大切な日", with: "入社記念日"
+    find_all("input[type='date']")[1].set("5-10-2015")
+    fill_in "電話番号", with: "090-1234-5678"
+    fill_in "メールアドレス", with: "ichiro.sato@example.com"
+    fill_in "住所", with: "大阪府大阪市北区梅田1-1-1"
+    fill_in "LINEの名前", with: "いちろう"
     attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/valid_image.jpg")
     click_button "登録する"
     expect(page).to have_content "連絡先を登録しました"

--- a/spec/support/create_profile_macros.rb
+++ b/spec/support/create_profile_macros.rb
@@ -12,7 +12,7 @@ module CreateProfileMacros
     find_all("input[type='date']")[1].set("2020-10-25")
     fill_in "電話番号", with: "000-0000-0000"
     fill_in "メールアドレス", with: "email@example.com"
-    fill_in "住所", with: ""
+    fill_in "住所", with: "東京都新宿区西新宿2-8-1"
     fill_in "LINEの名前", with: "やまだ"
     select "１年前", from: "最後に連絡した日"
     fill_in "メモ", with: "メモテスト"

--- a/spec/support/create_profile_macros.rb
+++ b/spec/support/create_profile_macros.rb
@@ -1,8 +1,8 @@
 module CreateProfileMacros
   include CreateGroupMacros
 
-  def create_profile_1
-    create_group_1
+  def create_profile_one
+    create_group_one
     visit profiles_path
     page.driver.browser.manage.window.resize_to(1280, 900)
     within("#pc-profiles") do
@@ -26,8 +26,8 @@ module CreateProfileMacros
     expect(page).to have_current_path(profile_path(Profile.last))
   end
 
-  def create_profile_2
-    create_group_2
+  def create_profile_two
+    create_group_two
     visit profiles_path
     page.driver.browser.manage.window.resize_to(1280, 900)
     within("#pc-profiles") do

--- a/spec/support/create_profile_macros.rb
+++ b/spec/support/create_profile_macros.rb
@@ -1,5 +1,8 @@
 module CreateProfileMacros
+  include CreateGroupMacros
+
   def create_profile_1
+    create_group_1
     visit profiles_path
     page.driver.browser.manage.window.resize_to(1280, 900)
     within("#pc-profiles") do
@@ -15,6 +18,7 @@ module CreateProfileMacros
     fill_in "住所", with: "東京都新宿区西新宿2-8-1"
     fill_in "LINEの名前", with: "やまだ"
     select "１年前", from: "最後に連絡した日"
+    select "グループ1", from: "グループ名"
     fill_in "メモ", with: "メモテスト"
     attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/valid_image.jpg")
     click_button "登録する"
@@ -23,6 +27,7 @@ module CreateProfileMacros
   end
 
   def create_profile_2
+    create_group_2
     visit profiles_path
     page.driver.browser.manage.window.resize_to(1280, 900)
     within("#pc-profiles") do
@@ -37,6 +42,9 @@ module CreateProfileMacros
     fill_in "メールアドレス", with: "ichiro.sato@example.com"
     fill_in "住所", with: "大阪府大阪市北区梅田1-1-1"
     fill_in "LINEの名前", with: "いちろう"
+    select "３年前", from: "最後に連絡した日"
+    select "グループ2", from: "グループ名"
+    fill_in "メモ", with: "メモテスト"
     attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/valid_image.jpg")
     click_button "登録する"
     expect(page).to have_content "連絡先を登録しました"

--- a/spec/support/create_profile_macros.rb
+++ b/spec/support/create_profile_macros.rb
@@ -35,9 +35,9 @@ module CreateProfileMacros
     end
     fill_in "名前", with: "佐藤一郎"
     fill_in "フリガナ", with: "サトウイチロウ"
-    fill_in "誕生日", with: "01-15-1990"
+    fill_in "誕生日", with: "#{Date.today.month}-15-1990"
     fill_in "大切な日", with: "入社記念日"
-    find_all("input[type='date']")[1].set("5-10-2015")
+    find_all("input[type='date']")[1].set("3-10-2015")
     fill_in "電話番号", with: "090-1234-5678"
     fill_in "メールアドレス", with: "ichiro.sato@example.com"
     fill_in "住所", with: "大阪府大阪市北区梅田1-1-1"

--- a/spec/support/create_profile_macros.rb
+++ b/spec/support/create_profile_macros.rb
@@ -1,0 +1,26 @@
+module CreateProfileMacros
+  def create_profile
+    page.driver.browser.manage.window.resize_to(1280, 900)
+    visit profiles_path
+    within("#pc-profiles") do
+      click_button "連絡先を作成"
+    end
+    fill_in "名前", with: "山田太郎"
+    fill_in "フリガナ", with: "ヤマダタロウ"
+    fill_in "誕生日", with: "2000-2-3"
+    fill_in "大切な日", with: "卒業記念日"
+    find_all("input[type='date']")[1].set("2020-10-25")
+    fill_in "電話番号", with: "000-0000-0000"
+    fill_in "メールアドレス", with: "email@example.com"
+    fill_in "住所", with: ""
+    fill_in "LINEの名前", with: "やまだ"
+    select "１年前", from: "最後に連絡した日"
+    fill_in "メモ", with: "メモテスト"
+    attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/valid_image.jpg")
+    click_button "登録する"
+    expect(page).to have_content "連絡先を登録しました"
+    expect(page).to have_current_path(profile_path(Profile.last))
+  end
+end
+
+

--- a/spec/support/create_profile_macros.rb
+++ b/spec/support/create_profile_macros.rb
@@ -7,9 +7,9 @@ module CreateProfileMacros
     end
     fill_in "名前", with: "山田太郎"
     fill_in "フリガナ", with: "ヤマダタロウ"
-    fill_in "誕生日", with: "2000-2-3"
+    fill_in "誕生日", with: "02-03-2003"
     fill_in "大切な日", with: "卒業記念日"
-    find_all("input[type='date']")[1].set("2020-10-25")
+    find_all("input[type='date']")[1].set("2-5-2020")
     fill_in "電話番号", with: "000-0000-0000"
     fill_in "メールアドレス", with: "email@example.com"
     fill_in "住所", with: "東京都新宿区西新宿2-8-1"
@@ -22,5 +22,3 @@ module CreateProfileMacros
     expect(page).to have_current_path(profile_path(Profile.last))
   end
 end
-
-

--- a/spec/system/footer_spec.rb
+++ b/spec/system/footer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "before_login_header", type: :system do
+RSpec.describe "footer", type: :system do
   include LoginMacros
   let(:user) { create(:user) }
 

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "profiles", type: :system do
   let(:user) { create(:user) }
 
   before { login_as(user) }
-
+  after { page.save_screenshot }
   describe "PC画面" do
 
     describe "連絡先作成" do
@@ -22,9 +22,9 @@ RSpec.describe "profiles", type: :system do
           end
           fill_in "名前", with: "山田太郎"
           fill_in "フリガナ", with: "ヤマダタロウ"
-          fill_in "誕生日", with: "2000-2-3"
+          fill_in "誕生日", with: "02-03-2003"
           fill_in "大切な日", with: "卒業記念日"
-          find_all("input[type='date']")[1].set("2020-10-25")
+          find_all("input[type='date']")[1].set("2-5-2020")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
           fill_in "住所", with: "東京都新宿区西新宿2-8-1"
@@ -45,9 +45,9 @@ RSpec.describe "profiles", type: :system do
           end
           fill_in "名前", with: "山田太郎"
           fill_in "フリガナ", with: "ヤマダタロウ"
-          fill_in "誕生日", with: "2000-2-3"
+          fill_in "誕生日", with: "02-03-2003"
           fill_in "大切な日", with: "卒業記念日"
-          find_all("input[type='date']")[1].set("2020-10-25")
+          find_all("input[type='date']")[1].set("2-5-2020")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
           fill_in "住所", with: "東京都新宿区西新宿2-8-1"
@@ -67,9 +67,9 @@ RSpec.describe "profiles", type: :system do
           end
           fill_in "名前", with: "山田太郎"
           fill_in "フリガナ", with: "ヤマダタロウ"
-          fill_in "誕生日", with: "2000-2-3"
+          fill_in "誕生日", with: "02-03-2003"
           fill_in "大切な日", with: "卒業記念日"
-          find_all("input[type='date']")[1].set("2020-10-25")
+          find_all("input[type='date']")[1].set("2-5-2020")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
           fill_in "住所", with: "東京都新宿区西新宿2-8-1"
@@ -97,9 +97,9 @@ RSpec.describe "profiles", type: :system do
           end
           fill_in "名前", with: "鈴木次郎"
           fill_in "フリガナ", with: "スズキジロウ"
-          fill_in "誕生日", with: "1997-2-3"
+          fill_in "誕生日", with: "02-03-2001"
           fill_in "卒業記念日", with: "優勝記念日"
-          find_all("input[type='date']")[1].set("2010-10-25")
+          find_all("input[type='date']")[1].set("2-5-2019")
           fill_in "電話番号", with: "111-1111-1111"
           fill_in "メールアドレス", with: "email_2@example.com"
           fill_in "住所", with: "大阪府大阪市北区梅田3-1-1"
@@ -120,9 +120,9 @@ RSpec.describe "profiles", type: :system do
           end
           fill_in "名前", with: "鈴木次郎"
           fill_in "フリガナ", with: "スズキジロウ"
-          fill_in "誕生日", with: "1997-2-3"
+          fill_in "誕生日", with: "02-03-2001"
           fill_in "卒業記念日", with: "優勝記念日"
-          find_all("input[type='date']")[1].set("2010-10-25")
+          find_all("input[type='date']")[1].set("2-5-2019")
           fill_in "電話番号", with: "111-1111-1111"
           fill_in "メールアドレス", with: "email_2@example.com"
           fill_in "住所", with: "大阪府大阪市北区梅田3-1-1"
@@ -142,9 +142,9 @@ RSpec.describe "profiles", type: :system do
           end
           fill_in "名前", with: "鈴木次郎"
           fill_in "フリガナ", with: "スズキジロウ"
-          fill_in "誕生日", with: "1997-2-3"
+          fill_in "誕生日", with: "02-03-2001"
           fill_in "卒業記念日", with: "優勝記念日"
-          find_all("input[type='date']")[1].set("2010-10-25")
+          find_all("input[type='date']")[1].set("2-5-2019")
           fill_in "電話番号", with: "111-1111-1111"
           fill_in "メールアドレス", with: "email_2@example.com"
           fill_in "住所", with: "大阪府大阪市北区梅田3-1-1"
@@ -189,9 +189,9 @@ RSpec.describe "profiles", type: :system do
           end
           fill_in "名前", with: "山田太郎"
           fill_in "フリガナ", with: "ヤマダタロウ"
-          fill_in "誕生日", with: "2000-2-3"
+          fill_in "誕生日", with: "02-03-2003"
           fill_in "大切な日", with: "卒業記念日"
-          find_all("input[type='date']")[1].set("2020-10-25")
+          find_all("input[type='date']")[1].set("2-5-2020")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
           fill_in "住所", with: "東京都新宿区西新宿2-8-1"
@@ -212,9 +212,9 @@ RSpec.describe "profiles", type: :system do
           end
           fill_in "名前", with: "山田太郎"
           fill_in "フリガナ", with: "ヤマダタロウ"
-          fill_in "誕生日", with: "2000-2-3"
+          fill_in "誕生日", with: "02-03-2003"
           fill_in "大切な日", with: "卒業記念日"
-          find_all("input[type='date']")[1].set("2020-10-25")
+          find_all("input[type='date']")[1].set("2-5-2020")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
           fill_in "住所", with: "東京都新宿区西新宿2-8-1"
@@ -234,9 +234,9 @@ RSpec.describe "profiles", type: :system do
           end
           fill_in "名前", with: "山田太郎"
           fill_in "フリガナ", with: "ヤマダタロウ"
-          fill_in "誕生日", with: "2000-2-3"
+          fill_in "誕生日", with: "02-03-2003"
           fill_in "大切な日", with: "卒業記念日"
-          find_all("input[type='date']")[1].set("2020-10-25")
+          find_all("input[type='date']")[1].set("2-5-2020")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
           fill_in "住所", with: "東京都新宿区西新宿2-8-1"
@@ -264,9 +264,9 @@ RSpec.describe "profiles", type: :system do
           end
           fill_in "名前", with: "鈴木次郎"
           fill_in "フリガナ", with: "スズキジロウ"
-          fill_in "誕生日", with: "1997-2-3"
+          fill_in "誕生日", with: "02-03-2001"
           fill_in "卒業記念日", with: "優勝記念日"
-          find_all("input[type='date']")[1].set("2010-10-25")
+          find_all("input[type='date']")[1].set("2-5-2019")
           fill_in "電話番号", with: "111-1111-1111"
           fill_in "メールアドレス", with: "email_2@example.com"
           fill_in "住所", with: "大阪府大阪市北区梅田3-1-1"
@@ -287,9 +287,9 @@ RSpec.describe "profiles", type: :system do
           end
           fill_in "名前", with: "鈴木次郎"
           fill_in "フリガナ", with: "スズキジロウ"
-          fill_in "誕生日", with: "1997-2-3"
+          fill_in "誕生日", with: "02-03-2001"
           fill_in "卒業記念日", with: "優勝記念日"
-          find_all("input[type='date']")[1].set("2010-10-25")
+          find_all("input[type='date']")[1].set("2-5-2019")
           fill_in "電話番号", with: "111-1111-1111"
           fill_in "メールアドレス", with: "email_2@example.com"
           fill_in "住所", with: "大阪府大阪市北区梅田3-1-1"
@@ -309,9 +309,9 @@ RSpec.describe "profiles", type: :system do
           end
           fill_in "名前", with: "鈴木次郎"
           fill_in "フリガナ", with: "スズキジロウ"
-          fill_in "誕生日", with: "1997-2-3"
+          fill_in "誕生日", with: "02-03-2001"
           fill_in "卒業記念日", with: "優勝記念日"
-          find_all("input[type='date']")[1].set("2010-10-25")
+          find_all("input[type='date']")[1].set("2-5-2019")
           fill_in "電話番号", with: "111-1111-1111"
           fill_in "メールアドレス", with: "email_2@example.com"
           fill_in "住所", with: "大阪府大阪市北区梅田3-1-1"

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -189,6 +189,15 @@ RSpec.describe "profiles", type: :system do
             end
           end
         end
+
+        it "「最後に連絡した日」を一覧から変更できること" do
+          within("#pc-profiles") do
+            select "１ヵ月以内", from: "profile_last_contacted", match: :first
+          end
+          expect(page).to have_content("１ヵ月以内")
+          expect(Profile.last.last_contacted).to eq("within_one_month")
+        end
+
       end
 
       describe "検索" do

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -212,13 +212,22 @@ RSpec.describe "profiles", type: :system do
       end
 
       describe "バナー" do
-        it "今月イベントをもつprofilesの名前が表示されること" do
+        before do
           create_profile_one
           create_profile_two
           visit profiles_path
           page.driver.browser.manage.window.resize_to(1280, 900)
+        end
+
+        it "今月イベントをもつprofilesの名前が表示されること" do
           within("#sticky-banner-pc") do
             expect(page).to have_content("佐藤")
+          end
+        end
+        it "バナーを削除できること" do
+          within("#sticky-banner-pc") do
+            find("#close-banner-btn-pc").click
+            expect(page).not_to have_css("#sticky-banner-pc")
           end
         end
       end
@@ -431,13 +440,23 @@ RSpec.describe "profiles", type: :system do
       end
 
       describe "バナー" do
-        it "今月イベントをもつprofilesの名前が表示されること" do
+        before do
           create_profile_one
           create_profile_two
           visit profiles_path
           page.driver.browser.manage.window.resize_to(1279, 900)
+        end
+
+        it "今月イベントをもつprofilesの名前が表示されること" do
           within("#sticky-banner-mb") do
             expect(page).to have_content("佐藤")
+          end
+        end
+
+        it "バナーを削除できること" do
+          within("#sticky-banner-mb") do
+            find("#close-banner-btn-mb").click
+            expect(page).not_to have_css("#sticky-banner-mb")
           end
         end
       end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -183,7 +183,20 @@ RSpec.describe "profiles", type: :system do
           fill_in "名前", with: "佐藤"
           find("button[type='submit']").click
           end
+          expect(page).to have_current_path(profiles_path)
+          expect(page).to have_content("佐藤")
+          expect(page).not_to have_content("山田")
+        end
+
+        it "ふりがなで検索ができる" do
+          create_profile_1
+          create_profile_2
+          visit profiles_path
           page.driver.browser.manage.window.resize_to(1280, 900)
+          within("#pc-profiles") do
+          fill_in "ふりがな", with: "サトウ"
+          find("button[type='submit']").click
+          end
           expect(page).to have_current_path(profiles_path)
           expect(page).to have_content("佐藤")
           expect(page).not_to have_content("山田")

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "profiles", type: :system do
 
     describe "連絡先編集" do
       before do
-        create_profile
+        create_profile_1
         visit profiles_path
         page.driver.browser.manage.window.resize_to(1280, 900)
       end
@@ -158,7 +158,7 @@ RSpec.describe "profiles", type: :system do
 
     describe "連絡先削除" do
       before do
-        create_profile
+        create_profile_1
         visit profiles_path
         page.driver.browser.manage.window.resize_to(1280, 900)
       end
@@ -169,6 +169,25 @@ RSpec.describe "profiles", type: :system do
         end
         expect(page.accept_confirm).to eq "本当に削除しますか？"
         expect(page).not_to have_css("#pc-profile-#{Profile.last.id}")
+      end
+    end
+
+    describe "連絡先一覧" do
+      describe "検索" do
+        it "名前で検索ができる" do
+          create_profile_1
+          create_profile_2
+          visit profiles_path
+          page.driver.browser.manage.window.resize_to(1280, 900)
+          within("#pc-profiles") do
+          fill_in "名前", with: "佐藤"
+          find("button[type='submit']").click
+          end
+          page.driver.browser.manage.window.resize_to(1280, 900)
+          expect(page).to have_current_path(profiles_path)
+          expect(page).to have_content("佐藤")
+          expect(page).not_to have_content("山田")
+        end
       end
     end
   end
@@ -250,7 +269,7 @@ RSpec.describe "profiles", type: :system do
 
     describe "連絡先編集" do
       before do
-        create_profile
+        create_profile_1
         visit profiles_path
         page.driver.browser.manage.window.resize_to(1279, 900)
       end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -180,8 +180,8 @@ RSpec.describe "profiles", type: :system do
           visit profiles_path
           page.driver.browser.manage.window.resize_to(1280, 900)
           within("#pc-profiles") do
-          fill_in "名前", with: "佐藤"
-          find("button[type='submit']").click
+            fill_in "名前", with: "佐藤"
+            find("button[type='submit']").click
           end
           expect(page).to have_current_path(profiles_path)
           expect(page).to have_content("佐藤")
@@ -194,8 +194,22 @@ RSpec.describe "profiles", type: :system do
           visit profiles_path
           page.driver.browser.manage.window.resize_to(1280, 900)
           within("#pc-profiles") do
-          fill_in "ふりがな", with: "サトウ"
-          find("button[type='submit']").click
+            fill_in "ふりがな", with: "サトウ"
+            find("button[type='submit']").click
+          end
+          expect(page).to have_current_path(profiles_path)
+          expect(page).to have_content("佐藤")
+          expect(page).not_to have_content("山田")
+        end
+
+        it "グループでフィルタリングができる" do
+          create_profile_1
+          create_profile_2
+          visit profiles_path
+          page.driver.browser.manage.window.resize_to(1280, 900)
+          within("#pc-profiles") do
+            select "グループ2", from: "q_group_id_eq"
+            find("button[type='submit']").click
           end
           expect(page).to have_current_path(profiles_path)
           expect(page).to have_content("佐藤")

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe "profiles", type: :system do
           click_button "登録する"
           expect(page).to have_content "連絡先を登録しました"
           expect(page).to have_current_path(profile_path(Profile.last))
+          expect(page).to have_content("山田太郎")
         end
       end
 
@@ -275,6 +276,7 @@ RSpec.describe "profiles", type: :system do
           click_button "登録する"
           expect(page).to have_content "連絡先を登録しました"
           expect(page).to have_current_path(profile_path(Profile.last))
+          expect(page).to have_content("山田太郎")
         end
       end
 

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -247,6 +247,44 @@ RSpec.describe "profiles", type: :system do
         end
       end
     end
+
+    describe "連絡先詳細" do
+      before do
+        create_profile_one
+        visit profile_path(Profile.last)
+        page.driver.browser.manage.window.resize_to(768, 900)
+      end
+
+      describe "画面遷移" do
+        it "サイドバーからプロフィール詳細に遷移できること" do
+          within("#default-sidebar") do
+            click_link "基本情報"
+          end
+          expect(page).to have_current_path(profile_path(Profile.last))
+        end
+
+        it "サイドバーからアルバム一覧に遷移できること" do
+          within("#default-sidebar") do
+            click_link "アルバム"
+          end
+          expect(page).to have_current_path(profile_albums_path(Profile.last))
+        end
+
+        it "サイドバーから通知設定に遷移できること" do
+          within("#default-sidebar") do
+            click_link "通知設定"
+          end
+          expect(page).to have_current_path(profile_events_path(Profile.last))
+        end
+
+        it "サイドバーから連絡先一覧に遷移できること" do
+          within("#default-sidebar") do
+            click_link "連絡先一覧"
+          end
+          expect(page).to have_current_path(profiles_path)
+        end
+      end
+    end
   end
 
   describe "スマホ画面" do
@@ -479,6 +517,37 @@ RSpec.describe "profiles", type: :system do
             find("#close-banner-btn-mb").click
             expect(page).not_to have_css("#sticky-banner-mb")
           end
+        end
+      end
+    end
+
+    describe "連絡先詳細" do
+      before do
+        create_profile_one
+        visit profile_path(Profile.last)
+        page.driver.browser.manage.window.resize_to(767, 900)
+      end
+
+      describe "画面遷移" do
+        it "トップバーからプロフィール詳細に遷移できること" do
+          within("#top-tab") do
+            click_link "基本情報"
+          end
+          expect(page).to have_current_path(profile_path(Profile.last))
+        end
+
+        it "トップバーからアルバム一覧に遷移できること" do
+          within("#top-tab") do
+            click_link "アルバム"
+          end
+          expect(page).to have_current_path(profile_albums_path(Profile.last))
+        end
+
+        it "トップバーから通知設定に遷移できること" do
+          within("#top-tab") do
+            click_link "通知設定"
+          end
+          expect(page).to have_current_path(profile_events_path(Profile.last))
         end
       end
     end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -363,6 +363,22 @@ RSpec.describe "profiles", type: :system do
       end
     end
 
+    describe "連絡先削除" do
+      before do
+        create_profile_1
+        visit profiles_path
+        page.driver.browser.manage.window.resize_to(1279, 900)
+      end
+
+      it "連絡先の削除が成功する" do
+        within("#mobile-profiles") do
+          find("#mobile-delete-profile-#{Profile.last.id}").click
+        end
+        expect(page.accept_confirm).to eq "本当に削除しますか？"
+        expect(page).not_to have_css("#mobile-profile-#{Profile.last.id}")
+      end
+    end
+
     describe "連絡先一覧" do
       describe "検索" do
         before do

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -425,7 +425,6 @@ RSpec.describe "profiles", type: :system do
       end
 
       describe "検索" do
-
         it "名前で検索ができる" do
           within("#mobile-profiles") do
             fill_in "名前", with: "佐藤"

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe "profiles", type: :system do
   let(:user) { create(:user) }
 
   before { login_as(user) }
-  after { page.save_screenshot }
   describe "PC画面" do
-
     describe "連絡先作成" do
       before do
         visit profiles_path

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -8,14 +8,15 @@ RSpec.describe "profiles", type: :system do
   before { login_as(user) }
 
   describe "PC画面" do
-    before do
-      page.driver.browser.manage.window.resize_to(1280, 900)
-    end
 
     describe "連絡先作成" do
+      before do
+        visit profiles_path
+        page.driver.browser.manage.window.resize_to(1280, 900)
+      end
+
       context "フォームの入力値が正常" do
         it "連絡先の新規作成が成功する" do
-          visit profiles_path
           within("#pc-profiles") do
             click_button "連絡先を作成"
           end
@@ -39,7 +40,6 @@ RSpec.describe "profiles", type: :system do
 
       context "プロフィール画像がpng, jpeg以外のファイル形式の場合" do
         it "連絡先の新規作成が失敗する" do
-          visit profiles_path
           within("#pc-profiles") do
             click_button "連絡先を作成"
           end
@@ -62,7 +62,6 @@ RSpec.describe "profiles", type: :system do
 
       context "プロフィール画像が1MB以上の場合" do
         it "連絡先の新規作成が失敗する" do
-          visit profiles_path
           within("#pc-profiles") do
             click_button "連絡先を作成"
           end
@@ -85,10 +84,14 @@ RSpec.describe "profiles", type: :system do
     end
 
     describe "連絡先編集" do
+      before do
+        create_profile
+        visit profiles_path
+        page.driver.browser.manage.window.resize_to(1280, 900)
+      end
+
       context "フォームの入力値が正常" do
         it "連絡先の更新が成功する" do
-          create_profile
-          visit profiles_path
           within("#pc-profiles") do
             find("#pc-edit-profile-#{Profile.last.id}").click
           end
@@ -112,8 +115,6 @@ RSpec.describe "profiles", type: :system do
 
       context "プロフィール画像がpng, jpeg以外のファイル形式の場合" do
         it "連絡先の更新が失敗する" do
-          create_profile
-          visit profiles_path
           within("#pc-profiles") do
             find("#pc-edit-profile-#{Profile.last.id}").click
           end
@@ -136,8 +137,6 @@ RSpec.describe "profiles", type: :system do
 
       context "プロフィール画像が1MB以上の場合" do
         it "連絡先の更新が失敗する" do
-          create_profile
-          visit profiles_path
           within("#pc-profiles") do
             find("#pc-edit-profile-#{Profile.last.id}").click
           end
@@ -160,9 +159,13 @@ RSpec.describe "profiles", type: :system do
     end
 
     describe "連絡先削除" do
-      it "連絡先の削除が成功する" do
+      before do
         create_profile
         visit profiles_path
+        page.driver.browser.manage.window.resize_to(1280, 900)
+      end
+
+      it "連絡先の削除が成功する" do
         within("#pc-profiles") do
           find("#pc-delete-profile-#{Profile.last.id}").click
         end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -84,91 +84,91 @@ RSpec.describe "profiles", type: :system do
       end
     end
 
+    describe "連絡先編集" do
+      context "フォームの入力値が正常" do
+        it "連絡先の更新が成功する" do
+          create_profile
+          visit profiles_path
+          within("#pc-profiles") do
+            find("#pc-edit-profile-#{Profile.last.id}").click
+          end
+          fill_in "名前", with: "鈴木次郎"
+          fill_in "フリガナ", with: "スズキジロウ"
+          fill_in "誕生日", with: "1997-2-3"
+          fill_in "卒業記念日", with: "優勝記念日"
+          find_all("input[type='date']")[1].set("2010-10-25")
+          fill_in "電話番号", with: "111-1111-1111"
+          fill_in "メールアドレス", with: "email_2@example.com"
+          fill_in "住所", with: "大阪府大阪市北区梅田3-1-1"
+          fill_in "LINEの名前", with: "すずき"
+          select "３年前", from: "最後に連絡した日"
+          fill_in "メモ", with: "メモテスト_2"
+          attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/valid_image.jpg")
+          click_button "登録する"
+          expect(page).to have_content "連絡先を更新しました"
+          expect(page).to have_current_path(profile_path(Profile.last))
+        end
+      end
 
+      context "プロフィール画像がpng, jpeg以外のファイル形式の場合" do
+        it "連絡先の更新が失敗する" do
+          create_profile
+          visit profiles_path
+          within("#pc-profiles") do
+            find("#pc-edit-profile-#{Profile.last.id}").click
+          end
+          fill_in "名前", with: "鈴木次郎"
+          fill_in "フリガナ", with: "スズキジロウ"
+          fill_in "誕生日", with: "1997-2-3"
+          fill_in "卒業記念日", with: "優勝記念日"
+          find_all("input[type='date']")[1].set("2010-10-25")
+          fill_in "電話番号", with: "111-1111-1111"
+          fill_in "メールアドレス", with: "email_2@example.com"
+          fill_in "住所", with: "大阪府大阪市北区梅田3-1-1"
+          fill_in "LINEの名前", with: "すずき"
+          select "３年前", from: "最後に連絡した日"
+          fill_in "メモ", with: "メモテスト_2"
+          attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/invalid_content_type.xlsx")
+          click_button "登録する"
+          expect(page).to have_content "連絡先を更新できませんでした"
+        end
+      end
 
-
-
-  #   describe "連絡先編集" do
-  #     context "フォームの入力値が正常" do
-  #       it "連絡先の編集が成功する" do
-  #         create_profile
-  #         visit profiles_path
-  #         within("#pc-profiles") do
-  #           find("#pc-edit-profile-#{Profile.last.id}").click
-  #         end
-  #         fill_in "名前", with: "鈴木次郎"
-  #         fill_in "フリガナ", with: "スズキジロウ"
-  #         fill_in "誕生日", with: "1997-2-3"
-  #         fill_in "卒業記念日", with: "優勝記念日"
-  #         find_all("input[type='date']")[1].set("2010-10-25")
-  #         fill_in "電話番号", with: "111-1111-1111"
-  #         fill_in "メールアドレス", with: "email_2@example.com"
-  #         fill_in "住所", with: "東京都新宿区西新宿2-8-1"
-  #         fill_in "LINEの名前", with: "すずき"
-  #         select "３年前", from: "最後に連絡した日"
-  #         fill_in "メモ", with: "メモテスト_2"
-  #         attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/valid_image.jpg")
-  #         click_button "登録する"
-  #         expect(page).to have_content "連絡先を更新しました"
-  #         expect(page).to have_current_path(profile_path(Profile.last))
-  #       end
-  #     end
-
-  #     context "プロフィール画像がpng, jpeg以外のファイル形式の場合" do
-  #       it "連絡先の新規作成が失敗する" do
-  #         visit profiles_path
-  #         within("#pc-profiles") do
-  #           click_button "連絡先を作成"
-  #         end
-  #         fill_in "名前", with: "山田太郎"
-  #         fill_in "フリガナ", with: "ヤマダタロウ"
-  #         fill_in "誕生日", with: "2000-2-3"
-  #         fill_in "大切な日", with: "2020-10-4"
-  #         fill_in "電話番号", with: "000-0000-0000"
-  #         fill_in "メールアドレス", with: "email@example.com"
-  #         fill_in "住所", with: "東京都新宿区西新宿2-8-1"
-  #         fill_in "LINEの名前", with: "やまだ"
-  #         select "１年前", from: "最後に連絡した日"
-  #         fill_in "メモ", with: "メモテスト"
-  #         attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/invalid_content_type.xlsx")
-  #         click_button "登録する"
-  #         expect(page).to have_content "連絡先を登録できませんでした"
-  #       end
-  #     end
-
-  #     context "プロフィール画像が1MB以上の場合" do
-  #       it "連絡先の新規作成が失敗する" do
-  #         visit profiles_path
-  #         within("#pc-profiles") do
-  #           click_button "連絡先を作成"
-  #         end
-  #         fill_in "名前", with: "山田太郎"
-  #         fill_in "フリガナ", with: "ヤマダタロウ"
-  #         fill_in "誕生日", with: "2000-2-3"
-  #         fill_in "大切な日", with: "2020-10-4"
-  #         fill_in "電話番号", with: "000-0000-0000"
-  #         fill_in "メールアドレス", with: "email@example.com"
-  #         fill_in "住所", with: "東京都新宿区西新宿2-8-1"
-  #         fill_in "LINEの名前", with: "やまだ"
-  #         select "１年前", from: "最後に連絡した日"
-  #         fill_in "メモ", with: "メモテスト"
-  #         attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/large_image.jpg")
-  #         click_button "登録する"
-  #         expect(page).to have_content "連絡先を登録できませんでした"
-  #       end
-  #     end
-  #   end
-  # end
+      context "プロフィール画像が1MB以上の場合" do
+        it "連絡先の更新が失敗する" do
+          create_profile
+          visit profiles_path
+          within("#pc-profiles") do
+            find("#pc-edit-profile-#{Profile.last.id}").click
+          end
+          fill_in "名前", with: "鈴木次郎"
+          fill_in "フリガナ", with: "スズキジロウ"
+          fill_in "誕生日", with: "1997-2-3"
+          fill_in "卒業記念日", with: "優勝記念日"
+          find_all("input[type='date']")[1].set("2010-10-25")
+          fill_in "電話番号", with: "111-1111-1111"
+          fill_in "メールアドレス", with: "email_2@example.com"
+          fill_in "住所", with: "大阪府大阪市北区梅田3-1-1"
+          fill_in "LINEの名前", with: "すずき"
+          select "３年前", from: "最後に連絡した日"
+          fill_in "メモ", with: "メモテスト_2"
+          attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/large_image.jpg")
+          click_button "登録する"
+          expect(page).to have_content "連絡先を更新できませんでした"
+        end
+      end
+    end
+  end
 
   describe "スマホ画面" do
-    before do
-      page.driver.browser.manage.window.resize_to(1279, 900)
-    end
-
     describe "連絡先作成" do
+      before do
+        visit profiles_path
+        page.driver.browser.manage.window.resize_to(1279, 900)
+      end
+
       context "フォームの入力値が正常" do
         it "連絡先の新規作成が成功する" do
-          visit profiles_path
           within("#mobile-profiles") do
             click_button "連絡先を作成"
           end
@@ -192,7 +192,6 @@ RSpec.describe "profiles", type: :system do
 
       context "プロフィール画像がpng, jpeg以外のファイル形式の場合" do
         it "連絡先の新規作成が失敗する" do
-          visit profiles_path
           within("#mobile-profiles") do
             click_button "連絡先を作成"
           end
@@ -215,7 +214,6 @@ RSpec.describe "profiles", type: :system do
 
       context "プロフィール画像が1MB以上の場合" do
         it "連絡先の新規作成が失敗する" do
-          visit profiles_path
           within("#mobile-profiles") do
             click_button "連絡先を作成"
           end
@@ -233,6 +231,81 @@ RSpec.describe "profiles", type: :system do
           attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/large_image.jpg")
           click_button "登録する"
           expect(page).to have_content "連絡先を登録できませんでした"
+        end
+      end
+    end
+
+    describe "連絡先編集" do
+      before do
+        create_profile
+        visit profiles_path
+        page.driver.browser.manage.window.resize_to(1279, 900)
+      end
+
+      context "フォームの入力値が正常" do
+        it "連絡先の更新が成功する" do
+          within("#mobile-profiles") do
+            find("#mobile-edit-profile-#{Profile.last.id}").click
+          end
+          fill_in "名前", with: "鈴木次郎"
+          fill_in "フリガナ", with: "スズキジロウ"
+          fill_in "誕生日", with: "1997-2-3"
+          fill_in "卒業記念日", with: "優勝記念日"
+          find_all("input[type='date']")[1].set("2010-10-25")
+          fill_in "電話番号", with: "111-1111-1111"
+          fill_in "メールアドレス", with: "email_2@example.com"
+          fill_in "住所", with: "大阪府大阪市北区梅田3-1-1"
+          fill_in "LINEの名前", with: "すずき"
+          select "３年前", from: "最後に連絡した日"
+          fill_in "メモ", with: "メモテスト_2"
+          attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/valid_image.jpg")
+          click_button "登録する"
+          expect(page).to have_content "連絡先を更新しました"
+          expect(page).to have_current_path(profile_path(Profile.last))
+        end
+      end
+
+      context "プロフィール画像がpng, jpeg以外のファイル形式の場合" do
+        it "連絡先の更新が失敗する" do
+          within("#mobile-profiles") do
+            find("#mobile-edit-profile-#{Profile.last.id}").click
+          end
+          fill_in "名前", with: "鈴木次郎"
+          fill_in "フリガナ", with: "スズキジロウ"
+          fill_in "誕生日", with: "1997-2-3"
+          fill_in "卒業記念日", with: "優勝記念日"
+          find_all("input[type='date']")[1].set("2010-10-25")
+          fill_in "電話番号", with: "111-1111-1111"
+          fill_in "メールアドレス", with: "email_2@example.com"
+          fill_in "住所", with: "大阪府大阪市北区梅田3-1-1"
+          fill_in "LINEの名前", with: "すずき"
+          select "３年前", from: "最後に連絡した日"
+          fill_in "メモ", with: "メモテスト_2"
+          attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/invalid_content_type.xlsx")
+          click_button "登録する"
+          expect(page).to have_content "連絡先を更新できませんでした"
+        end
+      end
+
+      context "プロフィール画像が1MB以上の場合" do
+        it "連絡先の更新が失敗する" do
+          within("#mobile-profiles") do
+            find("#mobile-edit-profile-#{Profile.last.id}").click
+          end
+          fill_in "名前", with: "鈴木次郎"
+          fill_in "フリガナ", with: "スズキジロウ"
+          fill_in "誕生日", with: "1997-2-3"
+          fill_in "卒業記念日", with: "優勝記念日"
+          find_all("input[type='date']")[1].set("2010-10-25")
+          fill_in "電話番号", with: "111-1111-1111"
+          fill_in "メールアドレス", with: "email_2@example.com"
+          fill_in "住所", with: "大阪府大阪市北区梅田3-1-1"
+          fill_in "LINEの名前", with: "すずき"
+          select "３年前", from: "最後に連絡した日"
+          fill_in "メモ", with: "メモテスト_2"
+          attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/large_image.jpg")
+          click_button "登録する"
+          expect(page).to have_content "連絡先を更新できませんでした"
         end
       end
     end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -1,0 +1,158 @@
+require "rails_helper"
+
+RSpec.describe "profiles", type: :system do
+  include LoginMacros
+  let(:user) { create(:user) }
+
+  before { login_as(user) }
+
+  describe "PC画面" do
+    before do
+      page.driver.browser.manage.window.resize_to(1280, 900)
+    end
+
+    describe "連絡先作成" do
+      context "フォームの入力値が正常" do
+        it "連絡先の新規作成が成功する" do
+          visit profiles_path
+          within("#pc-profiles") do
+            click_button "連絡先を作成"
+          end
+          fill_in "名前", with: "山田太郎"
+          fill_in "フリガナ", with: "ヤマダタロウ"
+          fill_in "誕生日", with: "2000-2-3"
+          fill_in "大切な日", with: "2020-10-4"
+          fill_in "電話番号", with: "000-0000-0000"
+          fill_in "メールアドレス", with: "email@example.com"
+          fill_in "住所", with: ""
+          fill_in "LINEの名前", with: "やまだ"
+          select "１年前", from: "最後に連絡した日"
+          fill_in "メモ", with: "メモテスト"
+          attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/valid_image.jpg")
+          click_button "登録する"
+          expect(page).to have_content "連絡先を登録しました"
+          expect(page).to have_current_path(profile_path(Profile.last))
+        end
+      end
+
+      context "プロフィール画像がpng, jpeg以外のファイル形式の場合" do
+        it "連絡先の新規作成が失敗する" do
+          visit profiles_path
+          within("#pc-profiles") do
+            click_button "連絡先を作成"
+          end
+          fill_in "名前", with: "山田太郎"
+          fill_in "フリガナ", with: "ヤマダタロウ"
+          fill_in "誕生日", with: "2000-2-3"
+          fill_in "大切な日", with: "2020-10-4"
+          fill_in "電話番号", with: "000-0000-0000"
+          fill_in "メールアドレス", with: "email@example.com"
+          fill_in "住所", with: ""
+          fill_in "LINEの名前", with: "やまだ"
+          select "１年前", from: "最後に連絡した日"
+          fill_in "メモ", with: "メモテスト"
+          attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/invalid_content_type.xlsx")
+          click_button "登録する"
+          expect(page).to have_content "連絡先を登録できませんでした"
+        end
+      end
+
+      context "プロフィール画像が1MB以上の場合" do
+        it "連絡先の新規作成が失敗する" do
+          visit profiles_path
+          within("#pc-profiles") do
+            click_button "連絡先を作成"
+          end
+          fill_in "名前", with: "山田太郎"
+          fill_in "フリガナ", with: "ヤマダタロウ"
+          fill_in "誕生日", with: "2000-2-3"
+          fill_in "大切な日", with: "2020-10-4"
+          fill_in "電話番号", with: "000-0000-0000"
+          fill_in "メールアドレス", with: "email@example.com"
+          fill_in "住所", with: ""
+          fill_in "LINEの名前", with: "やまだ"
+          select "１年前", from: "最後に連絡した日"
+          fill_in "メモ", with: "メモテスト"
+          attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/large_image.jpg")
+          click_button "登録する"
+          expect(page).to have_content "連絡先を登録できませんでした"
+        end
+      end
+    end
+  end
+
+  describe "スマホ画面" do
+    before do
+      page.driver.browser.manage.window.resize_to(1279, 900)
+    end
+
+    describe "連絡先作成" do
+      context "フォームの入力値が正常" do
+        it "連絡先の新規作成が成功する" do
+          visit profiles_path
+          within("#mobile-profiles") do
+            click_button "連絡先を作成"
+          end
+          fill_in "名前", with: "山田太郎"
+          fill_in "フリガナ", with: "ヤマダタロウ"
+          fill_in "誕生日", with: "2000-2-3"
+          fill_in "大切な日", with: "2020-10-4"
+          fill_in "電話番号", with: "000-0000-0000"
+          fill_in "メールアドレス", with: "email@example.com"
+          fill_in "住所", with: ""
+          fill_in "LINEの名前", with: "やまだ"
+          select "１年前", from: "最後に連絡した日"
+          fill_in "メモ", with: "メモテスト"
+          attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/valid_image.jpg")
+          click_button "登録する"
+          expect(page).to have_content "連絡先を登録しました"
+          expect(page).to have_current_path(profile_path(Profile.last))
+        end
+      end
+
+      context "プロフィール画像がpng, jpeg以外のファイル形式の場合" do
+        it "連絡先の新規作成が失敗する" do
+          visit profiles_path
+          within("#mobile-profiles") do
+            click_button "連絡先を作成"
+          end
+          fill_in "名前", with: "山田太郎"
+          fill_in "フリガナ", with: "ヤマダタロウ"
+          fill_in "誕生日", with: "2000-2-3"
+          fill_in "大切な日", with: "2020-10-4"
+          fill_in "電話番号", with: "000-0000-0000"
+          fill_in "メールアドレス", with: "email@example.com"
+          fill_in "住所", with: ""
+          fill_in "LINEの名前", with: "やまだ"
+          select "１年前", from: "最後に連絡した日"
+          fill_in "メモ", with: "メモテスト"
+          attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/invalid_content_type.xlsx")
+          click_button "登録する"
+          expect(page).to have_content "連絡先を登録できませんでした"
+        end
+      end
+
+      context "プロフィール画像が1MB以上の場合" do
+        it "連絡先の新規作成が失敗する" do
+          visit profiles_path
+          within("#mobile-profiles") do
+            click_button "連絡先を作成"
+          end
+          fill_in "名前", with: "山田太郎"
+          fill_in "フリガナ", with: "ヤマダタロウ"
+          fill_in "誕生日", with: "2000-2-3"
+          fill_in "大切な日", with: "2020-10-4"
+          fill_in "電話番号", with: "000-0000-0000"
+          fill_in "メールアドレス", with: "email@example.com"
+          fill_in "住所", with: ""
+          fill_in "LINEの名前", with: "やまだ"
+          select "１年前", from: "最後に連絡した日"
+          fill_in "メモ", with: "メモテスト"
+          attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/large_image.jpg")
+          click_button "登録する"
+          expect(page).to have_content "連絡先を登録できませんでした"
+        end
+      end
+    end
+  end
+end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -158,6 +158,18 @@ RSpec.describe "profiles", type: :system do
         end
       end
     end
+
+    describe "連絡先削除" do
+      it "連絡先の削除が成功する" do
+        create_profile
+        visit profiles_path
+        within("#pc-profiles") do
+          find("#pc-delete-profile-#{Profile.last.id}").click
+        end
+        expect(page.accept_confirm).to eq "本当に削除しますか？"
+        expect(page).not_to have_css("#pc-profile-#{Profile.last.id}")
+      end
+    end
   end
 
   describe "スマホ画面" do

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -210,6 +210,18 @@ RSpec.describe "profiles", type: :system do
           expect(page).not_to have_content("山田")
         end
       end
+
+      describe "バナー" do
+        it "今月イベントをもつprofilesの名前が表示されること" do
+          create_profile_one
+          create_profile_two
+          visit profiles_path
+          page.driver.browser.manage.window.resize_to(1280, 900)
+          within("#sticky-banner-pc") do
+            expect(page).to have_content("佐藤")
+          end
+        end
+      end
     end
   end
 
@@ -417,6 +429,19 @@ RSpec.describe "profiles", type: :system do
           expect(page).not_to have_content("山田")
         end
       end
+
+      describe "バナー" do
+        it "今月イベントをもつprofilesの名前が表示されること" do
+          create_profile_one
+          create_profile_two
+          visit profiles_path
+          page.driver.browser.manage.window.resize_to(1279, 900)
+          within("#sticky-banner-mb") do
+            expect(page).to have_content("佐藤")
+          end
+        end
+      end
+
     end
   end
 end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -362,5 +362,45 @@ RSpec.describe "profiles", type: :system do
         end
       end
     end
+
+    describe "連絡先一覧" do
+      describe "検索" do
+        before do
+          create_profile_1
+          create_profile_2
+          visit profiles_path
+          page.driver.browser.manage.window.resize_to(1279, 900)
+        end
+        it "名前で検索ができる" do
+          within("#mobile-profiles") do
+            fill_in "名前", with: "佐藤"
+            find("button[type='submit']").click
+          end
+          expect(page).to have_current_path(profiles_path)
+          expect(page).to have_content("佐藤")
+          expect(page).not_to have_content("山田")
+        end
+
+        it "ふりがなで検索ができる" do
+          within("#mobile-profiles") do
+            fill_in "ふりがな", with: "サトウ"
+            find("button[type='submit']").click
+          end
+          expect(page).to have_current_path(profiles_path)
+          expect(page).to have_content("佐藤")
+          expect(page).not_to have_content("山田")
+        end
+
+        it "グループでフィルタリングができる" do
+          within("#mobile-profiles") do
+            select "グループ2", from: "q_group_id_eq"
+            find("button[type='submit']").click
+          end
+          expect(page).to have_current_path(profiles_path)
+          expect(page).to have_content("佐藤")
+          expect(page).not_to have_content("山田")
+        end
+      end
+    end
   end
 end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -198,7 +198,6 @@ RSpec.describe "profiles", type: :system do
           expect(page).to have_content("１ヵ月以内")
           expect(Profile.last.last_contacted).to eq("within_one_month")
         end
-
       end
 
       describe "検索" do

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -174,11 +174,13 @@ RSpec.describe "profiles", type: :system do
 
     describe "連絡先一覧" do
       describe "検索" do
-        it "名前で検索ができる" do
+        before do
           create_profile_1
           create_profile_2
           visit profiles_path
           page.driver.browser.manage.window.resize_to(1280, 900)
+        end
+        it "名前で検索ができる" do
           within("#pc-profiles") do
             fill_in "名前", with: "佐藤"
             find("button[type='submit']").click
@@ -189,10 +191,6 @@ RSpec.describe "profiles", type: :system do
         end
 
         it "ふりがなで検索ができる" do
-          create_profile_1
-          create_profile_2
-          visit profiles_path
-          page.driver.browser.manage.window.resize_to(1280, 900)
           within("#pc-profiles") do
             fill_in "ふりがな", with: "サトウ"
             find("button[type='submit']").click
@@ -203,10 +201,6 @@ RSpec.describe "profiles", type: :system do
         end
 
         it "グループでフィルタリングができる" do
-          create_profile_1
-          create_profile_2
-          visit profiles_path
-          page.driver.browser.manage.window.resize_to(1280, 900)
           within("#pc-profiles") do
             select "グループ2", from: "q_group_id_eq"
             find("button[type='submit']").click

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "profiles", type: :system do
   include LoginMacros
+  include CreateProfileMacros
   let(:user) { create(:user) }
 
   before { login_as(user) }
@@ -21,7 +22,8 @@ RSpec.describe "profiles", type: :system do
           fill_in "名前", with: "山田太郎"
           fill_in "フリガナ", with: "ヤマダタロウ"
           fill_in "誕生日", with: "2000-2-3"
-          fill_in "大切な日", with: "2020-10-4"
+          fill_in "大切な日", with: "卒業記念日"
+          find_all("input[type='date']")[1].set("2020-10-25")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
           fill_in "住所", with: ""
@@ -44,7 +46,8 @@ RSpec.describe "profiles", type: :system do
           fill_in "名前", with: "山田太郎"
           fill_in "フリガナ", with: "ヤマダタロウ"
           fill_in "誕生日", with: "2000-2-3"
-          fill_in "大切な日", with: "2020-10-4"
+          fill_in "大切な日", with: "卒業記念日"
+          find_all("input[type='date']")[1].set("2020-10-25")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
           fill_in "住所", with: ""
@@ -66,7 +69,8 @@ RSpec.describe "profiles", type: :system do
           fill_in "名前", with: "山田太郎"
           fill_in "フリガナ", with: "ヤマダタロウ"
           fill_in "誕生日", with: "2000-2-3"
-          fill_in "大切な日", with: "2020-10-4"
+          fill_in "大切な日", with: "卒業記念日"
+          find_all("input[type='date']")[1].set("2020-10-25")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
           fill_in "住所", with: ""
@@ -79,6 +83,81 @@ RSpec.describe "profiles", type: :system do
         end
       end
     end
+
+
+
+
+
+    # describe "連絡先編集" do
+    #   context "フォームの入力値が正常" do
+    #     it "連絡先の編集が成功する" do
+    #       create_profile
+    #       visit profiles_path
+    #       within("#pc-profiles") do
+    #         find("#edit-profile-#{Profile.last.id}").click
+    #       end
+    #       fill_in "名前", with: "山田太郎"
+    #       fill_in "フリガナ", with: "ヤマダタロウ"
+    #       fill_in "誕生日", with: "2000-2-3"
+    #       fill_in "卒業記念日", with: "卒業記念日"
+    #       find_all("input[type='date']")[1].set("2020-10-25")
+    #       fill_in "電話番号", with: "000-0000-0000"
+    #       fill_in "メールアドレス", with: "email@example.com"
+    #       fill_in "住所", with: ""
+    #       fill_in "LINEの名前", with: "やまだ"
+    #       select "１年前", from: "最後に連絡した日"
+    #       fill_in "メモ", with: "メモテスト"
+    #       attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/valid_image.jpg")
+    #       click_button "登録する"
+    #       expect(page).to have_content "連絡先を更新しました"
+    #       expect(page).to have_current_path(profile_path(Profile.last))
+    #     end
+    #   end
+
+    #   context "プロフィール画像がpng, jpeg以外のファイル形式の場合" do
+    #     it "連絡先の新規作成が失敗する" do
+    #       visit profiles_path
+    #       within("#pc-profiles") do
+    #         click_button "連絡先を作成"
+    #       end
+    #       fill_in "名前", with: "山田太郎"
+    #       fill_in "フリガナ", with: "ヤマダタロウ"
+    #       fill_in "誕生日", with: "2000-2-3"
+    #       fill_in "大切な日", with: "2020-10-4"
+    #       fill_in "電話番号", with: "000-0000-0000"
+    #       fill_in "メールアドレス", with: "email@example.com"
+    #       fill_in "住所", with: ""
+    #       fill_in "LINEの名前", with: "やまだ"
+    #       select "１年前", from: "最後に連絡した日"
+    #       fill_in "メモ", with: "メモテスト"
+    #       attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/invalid_content_type.xlsx")
+    #       click_button "登録する"
+    #       expect(page).to have_content "連絡先を登録できませんでした"
+    #     end
+    #   end
+
+    #   context "プロフィール画像が1MB以上の場合" do
+    #     it "連絡先の新規作成が失敗する" do
+    #       visit profiles_path
+    #       within("#pc-profiles") do
+    #         click_button "連絡先を作成"
+    #       end
+    #       fill_in "名前", with: "山田太郎"
+    #       fill_in "フリガナ", with: "ヤマダタロウ"
+    #       fill_in "誕生日", with: "2000-2-3"
+    #       fill_in "大切な日", with: "2020-10-4"
+    #       fill_in "電話番号", with: "000-0000-0000"
+    #       fill_in "メールアドレス", with: "email@example.com"
+    #       fill_in "住所", with: ""
+    #       fill_in "LINEの名前", with: "やまだ"
+    #       select "１年前", from: "最後に連絡した日"
+    #       fill_in "メモ", with: "メモテスト"
+    #       attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/large_image.jpg")
+    #       click_button "登録する"
+    #       expect(page).to have_content "連絡先を登録できませんでした"
+    #     end
+    #   end
+    # end
   end
 
   describe "スマホ画面" do
@@ -96,7 +175,8 @@ RSpec.describe "profiles", type: :system do
           fill_in "名前", with: "山田太郎"
           fill_in "フリガナ", with: "ヤマダタロウ"
           fill_in "誕生日", with: "2000-2-3"
-          fill_in "大切な日", with: "2020-10-4"
+          fill_in "大切な日", with: "卒業記念日"
+          find_all("input[type='date']")[1].set("2020-10-25")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
           fill_in "住所", with: ""
@@ -119,7 +199,8 @@ RSpec.describe "profiles", type: :system do
           fill_in "名前", with: "山田太郎"
           fill_in "フリガナ", with: "ヤマダタロウ"
           fill_in "誕生日", with: "2000-2-3"
-          fill_in "大切な日", with: "2020-10-4"
+          fill_in "大切な日", with: "卒業記念日"
+          find_all("input[type='date']")[1].set("2020-10-25")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
           fill_in "住所", with: ""
@@ -141,7 +222,8 @@ RSpec.describe "profiles", type: :system do
           fill_in "名前", with: "山田太郎"
           fill_in "フリガナ", with: "ヤマダタロウ"
           fill_in "誕生日", with: "2000-2-3"
-          fill_in "大切な日", with: "2020-10-4"
+          fill_in "大切な日", with: "卒業記念日"
+          find_all("input[type='date']")[1].set("2020-10-25")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
           fill_in "住所", with: ""

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "profiles", type: :system do
           find_all("input[type='date']")[1].set("2020-10-25")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
-          fill_in "住所", with: ""
+          fill_in "住所", with: "東京都新宿区西新宿2-8-1"
           fill_in "LINEの名前", with: "やまだ"
           select "１年前", from: "最後に連絡した日"
           fill_in "メモ", with: "メモテスト"
@@ -50,7 +50,7 @@ RSpec.describe "profiles", type: :system do
           find_all("input[type='date']")[1].set("2020-10-25")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
-          fill_in "住所", with: ""
+          fill_in "住所", with: "東京都新宿区西新宿2-8-1"
           fill_in "LINEの名前", with: "やまだ"
           select "１年前", from: "最後に連絡した日"
           fill_in "メモ", with: "メモテスト"
@@ -73,7 +73,7 @@ RSpec.describe "profiles", type: :system do
           find_all("input[type='date']")[1].set("2020-10-25")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
-          fill_in "住所", with: ""
+          fill_in "住所", with: "東京都新宿区西新宿2-8-1"
           fill_in "LINEの名前", with: "やまだ"
           select "１年前", from: "最後に連絡した日"
           fill_in "メモ", with: "メモテスト"
@@ -88,77 +88,77 @@ RSpec.describe "profiles", type: :system do
 
 
 
-    # describe "連絡先編集" do
-    #   context "フォームの入力値が正常" do
-    #     it "連絡先の編集が成功する" do
-    #       create_profile
-    #       visit profiles_path
-    #       within("#pc-profiles") do
-    #         find("#edit-profile-#{Profile.last.id}").click
-    #       end
-    #       fill_in "名前", with: "山田太郎"
-    #       fill_in "フリガナ", with: "ヤマダタロウ"
-    #       fill_in "誕生日", with: "2000-2-3"
-    #       fill_in "卒業記念日", with: "卒業記念日"
-    #       find_all("input[type='date']")[1].set("2020-10-25")
-    #       fill_in "電話番号", with: "000-0000-0000"
-    #       fill_in "メールアドレス", with: "email@example.com"
-    #       fill_in "住所", with: ""
-    #       fill_in "LINEの名前", with: "やまだ"
-    #       select "１年前", from: "最後に連絡した日"
-    #       fill_in "メモ", with: "メモテスト"
-    #       attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/valid_image.jpg")
-    #       click_button "登録する"
-    #       expect(page).to have_content "連絡先を更新しました"
-    #       expect(page).to have_current_path(profile_path(Profile.last))
-    #     end
-    #   end
+  #   describe "連絡先編集" do
+  #     context "フォームの入力値が正常" do
+  #       it "連絡先の編集が成功する" do
+  #         create_profile
+  #         visit profiles_path
+  #         within("#pc-profiles") do
+  #           find("#pc-edit-profile-#{Profile.last.id}").click
+  #         end
+  #         fill_in "名前", with: "鈴木次郎"
+  #         fill_in "フリガナ", with: "スズキジロウ"
+  #         fill_in "誕生日", with: "1997-2-3"
+  #         fill_in "卒業記念日", with: "優勝記念日"
+  #         find_all("input[type='date']")[1].set("2010-10-25")
+  #         fill_in "電話番号", with: "111-1111-1111"
+  #         fill_in "メールアドレス", with: "email_2@example.com"
+  #         fill_in "住所", with: "東京都新宿区西新宿2-8-1"
+  #         fill_in "LINEの名前", with: "すずき"
+  #         select "３年前", from: "最後に連絡した日"
+  #         fill_in "メモ", with: "メモテスト_2"
+  #         attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/valid_image.jpg")
+  #         click_button "登録する"
+  #         expect(page).to have_content "連絡先を更新しました"
+  #         expect(page).to have_current_path(profile_path(Profile.last))
+  #       end
+  #     end
 
-    #   context "プロフィール画像がpng, jpeg以外のファイル形式の場合" do
-    #     it "連絡先の新規作成が失敗する" do
-    #       visit profiles_path
-    #       within("#pc-profiles") do
-    #         click_button "連絡先を作成"
-    #       end
-    #       fill_in "名前", with: "山田太郎"
-    #       fill_in "フリガナ", with: "ヤマダタロウ"
-    #       fill_in "誕生日", with: "2000-2-3"
-    #       fill_in "大切な日", with: "2020-10-4"
-    #       fill_in "電話番号", with: "000-0000-0000"
-    #       fill_in "メールアドレス", with: "email@example.com"
-    #       fill_in "住所", with: ""
-    #       fill_in "LINEの名前", with: "やまだ"
-    #       select "１年前", from: "最後に連絡した日"
-    #       fill_in "メモ", with: "メモテスト"
-    #       attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/invalid_content_type.xlsx")
-    #       click_button "登録する"
-    #       expect(page).to have_content "連絡先を登録できませんでした"
-    #     end
-    #   end
+  #     context "プロフィール画像がpng, jpeg以外のファイル形式の場合" do
+  #       it "連絡先の新規作成が失敗する" do
+  #         visit profiles_path
+  #         within("#pc-profiles") do
+  #           click_button "連絡先を作成"
+  #         end
+  #         fill_in "名前", with: "山田太郎"
+  #         fill_in "フリガナ", with: "ヤマダタロウ"
+  #         fill_in "誕生日", with: "2000-2-3"
+  #         fill_in "大切な日", with: "2020-10-4"
+  #         fill_in "電話番号", with: "000-0000-0000"
+  #         fill_in "メールアドレス", with: "email@example.com"
+  #         fill_in "住所", with: "東京都新宿区西新宿2-8-1"
+  #         fill_in "LINEの名前", with: "やまだ"
+  #         select "１年前", from: "最後に連絡した日"
+  #         fill_in "メモ", with: "メモテスト"
+  #         attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/invalid_content_type.xlsx")
+  #         click_button "登録する"
+  #         expect(page).to have_content "連絡先を登録できませんでした"
+  #       end
+  #     end
 
-    #   context "プロフィール画像が1MB以上の場合" do
-    #     it "連絡先の新規作成が失敗する" do
-    #       visit profiles_path
-    #       within("#pc-profiles") do
-    #         click_button "連絡先を作成"
-    #       end
-    #       fill_in "名前", with: "山田太郎"
-    #       fill_in "フリガナ", with: "ヤマダタロウ"
-    #       fill_in "誕生日", with: "2000-2-3"
-    #       fill_in "大切な日", with: "2020-10-4"
-    #       fill_in "電話番号", with: "000-0000-0000"
-    #       fill_in "メールアドレス", with: "email@example.com"
-    #       fill_in "住所", with: ""
-    #       fill_in "LINEの名前", with: "やまだ"
-    #       select "１年前", from: "最後に連絡した日"
-    #       fill_in "メモ", with: "メモテスト"
-    #       attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/large_image.jpg")
-    #       click_button "登録する"
-    #       expect(page).to have_content "連絡先を登録できませんでした"
-    #     end
-    #   end
-    # end
-  end
+  #     context "プロフィール画像が1MB以上の場合" do
+  #       it "連絡先の新規作成が失敗する" do
+  #         visit profiles_path
+  #         within("#pc-profiles") do
+  #           click_button "連絡先を作成"
+  #         end
+  #         fill_in "名前", with: "山田太郎"
+  #         fill_in "フリガナ", with: "ヤマダタロウ"
+  #         fill_in "誕生日", with: "2000-2-3"
+  #         fill_in "大切な日", with: "2020-10-4"
+  #         fill_in "電話番号", with: "000-0000-0000"
+  #         fill_in "メールアドレス", with: "email@example.com"
+  #         fill_in "住所", with: "東京都新宿区西新宿2-8-1"
+  #         fill_in "LINEの名前", with: "やまだ"
+  #         select "１年前", from: "最後に連絡した日"
+  #         fill_in "メモ", with: "メモテスト"
+  #         attach_file "プロフィール画像", Rails.root.join("spec/fixtures/files/large_image.jpg")
+  #         click_button "登録する"
+  #         expect(page).to have_content "連絡先を登録できませんでした"
+  #       end
+  #     end
+  #   end
+  # end
 
   describe "スマホ画面" do
     before do
@@ -179,7 +179,7 @@ RSpec.describe "profiles", type: :system do
           find_all("input[type='date']")[1].set("2020-10-25")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
-          fill_in "住所", with: ""
+          fill_in "住所", with: "東京都新宿区西新宿2-8-1"
           fill_in "LINEの名前", with: "やまだ"
           select "１年前", from: "最後に連絡した日"
           fill_in "メモ", with: "メモテスト"
@@ -203,7 +203,7 @@ RSpec.describe "profiles", type: :system do
           find_all("input[type='date']")[1].set("2020-10-25")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
-          fill_in "住所", with: ""
+          fill_in "住所", with: "東京都新宿区西新宿2-8-1"
           fill_in "LINEの名前", with: "やまだ"
           select "１年前", from: "最後に連絡した日"
           fill_in "メモ", with: "メモテスト"
@@ -226,7 +226,7 @@ RSpec.describe "profiles", type: :system do
           find_all("input[type='date']")[1].set("2020-10-25")
           fill_in "電話番号", with: "000-0000-0000"
           fill_in "メールアドレス", with: "email@example.com"
-          fill_in "住所", with: ""
+          fill_in "住所", with: "東京都新宿区西新宿2-8-1"
           fill_in "LINEの名前", with: "やまだ"
           select "１年前", from: "最後に連絡した日"
           fill_in "メモ", with: "メモテスト"

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "profiles", type: :system do
 
     describe "連絡先編集" do
       before do
-        create_profile_1
+        create_profile_one
         visit profiles_path
         page.driver.browser.manage.window.resize_to(1280, 900)
       end
@@ -158,7 +158,7 @@ RSpec.describe "profiles", type: :system do
 
     describe "連絡先削除" do
       before do
-        create_profile_1
+        create_profile_one
         visit profiles_path
         page.driver.browser.manage.window.resize_to(1280, 900)
       end
@@ -175,8 +175,8 @@ RSpec.describe "profiles", type: :system do
     describe "連絡先一覧" do
       describe "検索" do
         before do
-          create_profile_1
-          create_profile_2
+          create_profile_one
+          create_profile_two
           visit profiles_path
           page.driver.browser.manage.window.resize_to(1280, 900)
         end
@@ -290,7 +290,7 @@ RSpec.describe "profiles", type: :system do
 
     describe "連絡先編集" do
       before do
-        create_profile_1
+        create_profile_one
         visit profiles_path
         page.driver.browser.manage.window.resize_to(1279, 900)
       end
@@ -365,7 +365,7 @@ RSpec.describe "profiles", type: :system do
 
     describe "連絡先削除" do
       before do
-        create_profile_1
+        create_profile_one
         visit profiles_path
         page.driver.browser.manage.window.resize_to(1279, 900)
       end
@@ -382,8 +382,8 @@ RSpec.describe "profiles", type: :system do
     describe "連絡先一覧" do
       describe "検索" do
         before do
-          create_profile_1
-          create_profile_2
+          create_profile_one
+          create_profile_two
           visit profiles_path
           page.driver.browser.manage.window.resize_to(1279, 900)
         end

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -173,13 +173,25 @@ RSpec.describe "profiles", type: :system do
     end
 
     describe "連絡先一覧" do
-      describe "検索" do
-        before do
-          create_profile_one
-          create_profile_two
-          visit profiles_path
-          page.driver.browser.manage.window.resize_to(1280, 900)
+      before do
+        create_profile_one
+        create_profile_two
+        visit profiles_path
+        page.driver.browser.manage.window.resize_to(1280, 900)
+      end
+
+      describe "連絡先" do
+        it "作成した連絡先が一覧に表示されること" do
+          within("#pc-profiles") do
+            within("table") do
+              expect(page).to have_content("山田太郎")
+              expect(page).to have_content("佐藤一郎")
+            end
+          end
         end
+      end
+
+      describe "検索" do
         it "名前で検索ができる" do
           within("#pc-profiles") do
             fill_in "名前", with: "佐藤"
@@ -212,13 +224,6 @@ RSpec.describe "profiles", type: :system do
       end
 
       describe "バナー" do
-        before do
-          create_profile_one
-          create_profile_two
-          visit profiles_path
-          page.driver.browser.manage.window.resize_to(1280, 900)
-        end
-
         it "今月イベントをもつprofilesの名前が表示されること" do
           within("#sticky-banner-pc") do
             expect(page).to have_content("佐藤")
@@ -401,13 +406,26 @@ RSpec.describe "profiles", type: :system do
     end
 
     describe "連絡先一覧" do
-      describe "検索" do
-        before do
-          create_profile_one
-          create_profile_two
-          visit profiles_path
-          page.driver.browser.manage.window.resize_to(1279, 900)
+      before do
+        create_profile_one
+        create_profile_two
+        visit profiles_path
+        page.driver.browser.manage.window.resize_to(1279, 900)
+      end
+
+      describe "連絡先" do
+        it "作成した連絡先が一覧に表示されること" do
+          within("#mobile-profiles") do
+            within("table") do
+              expect(page).to have_content("山田太郎")
+              expect(page).to have_content("佐藤一郎")
+            end
+          end
         end
+      end
+
+      describe "検索" do
+
         it "名前で検索ができる" do
           within("#mobile-profiles") do
             fill_in "名前", with: "佐藤"
@@ -440,13 +458,6 @@ RSpec.describe "profiles", type: :system do
       end
 
       describe "バナー" do
-        before do
-          create_profile_one
-          create_profile_two
-          visit profiles_path
-          page.driver.browser.manage.window.resize_to(1279, 900)
-        end
-
         it "今月イベントをもつprofilesの名前が表示されること" do
           within("#sticky-banner-mb") do
             expect(page).to have_content("佐藤")
@@ -460,7 +471,6 @@ RSpec.describe "profiles", type: :system do
           end
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
### 概要
連絡先（profile）に関するテストを実装する

---
### 背景・目的
動作確認の自動化

---
### 内容
#### 連絡先作成
- [x] フォームの入力値が正常の場合、連絡先の新規作成が成功する
- [x] プロフィール画像がpng, jpeg以外のファイル形式の場合、連絡先の新規作成が失敗する
- [x] プロフィール画像が1MB以上の場合、連絡先の新規作成が失敗する

#### 連絡先作成
- [x] フォームの入力値が正常の場合、連絡先の更新が成功する
- [x] プロフィール画像がpng, jpeg以外のファイル形式の場合、連絡先の更新が失敗する
- [x] プロフィール画像が1MB以上の場合、連絡先の更新が失敗する

#### 連絡先削除
- [x] 連絡先の削除が成功する

#### 連絡先一覧
- [x] 作成した連絡先が一覧に表示されること
- [x] 「最後に連絡した日」を一覧から変更できること
- [x] 名前で検索ができる
- [x] ふりがなで検索ができる
- [x] グループでフィルタリングができる
- [x] 今月イベントをもつprofilesの名前が表示されること
- [x] バナーを削除できること

#### 連絡先詳細
- [x] サイドバーからプロフィール詳細に遷移できること
- [x] サイドバーからアルバム一覧に遷移できること
- [x] サイドバーから通知設定に遷移できること
- [x] サイドバーから連絡先一覧に遷移できること（PC画面のみ）


---
### 対応しないこと
- 

---
### 補足
This PR close #360 