### PR TITLE
【テスト】アルバム

### DIFF
--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -16,10 +16,10 @@
               <div class="flex justify-between">
                 <div><%= album.date %></div>
                 <div class="flex justify-end space-x-3 md:space-x-5">
-                  <%= link_to profile_album_path(@profile, album) do %>
+                  <%= link_to profile_album_path(@profile, album), id: "album-#{album.id}" do %>
                     <i class="fa-solid fa-circle-info fa-lg"></i>
                   <% end %>
-                  <%= link_to edit_profile_album_path(@profile, album) do %>
+                  <%= link_to edit_profile_album_path(@profile, album), id: "edit-album-#{album.id}" do %>
                     <i class="fa-solid fa-pen-to-square fa-lg"></i>
                   <% end %>
                 </div>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -10,10 +10,10 @@
         <div class="text-center w-full"><%= @album.date %></div>
       </div>
       <div id="icon" class="flex justify-center space-x-5">
-        <%= link_to edit_profile_album_path(@profile, @album) do %>
+        <%= link_to edit_profile_album_path(@profile, @album), id: "edit-album-#{@album.id}" do %>
           <i class="fa-solid fa-pen-to-square fa-lg"></i>
         <% end %>
-        <%= link_to profile_album_path(@profile, @album), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
+        <%= link_to profile_album_path(@profile, @album), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' }, id: "delete-album-#{@album.id}" do %>
           <i class="fa-solid fa-trash fa-lg"></i>
         <% end %>
       </div>

--- a/spec/support/create_album_macros.rb
+++ b/spec/support/create_album_macros.rb
@@ -1,10 +1,22 @@
 module CreateAlbumMacros
-  def create_album
+  def create_album_one
     visit profile_albums_path(Profile.last)
     click_button "アルバムを作成"
     fill_in "日付", with: "05-09-2023"
     fill_in "タイトル", with: "海外旅行"
     fill_in "ノート", with: "楽しかった！"
+    attach_file "album_images", Rails.root.join("spec/fixtures/files/valid_image.jpg")
+    click_button "保存する"
+    expect(page).to have_content "アルバムを登録しました"
+    expect(page).to have_current_path(profile_albums_path(Profile.last))
+  end
+
+  def create_album_two
+    visit profile_albums_path(Profile.last)
+    click_button "アルバムを作成"
+    fill_in "日付", with: "05-07-2014"
+    fill_in "タイトル", with: "祭り"
+    fill_in "ノート", with: "盛り上がった！"
     attach_file "album_images", Rails.root.join("spec/fixtures/files/valid_image.jpg")
     click_button "保存する"
     expect(page).to have_content "アルバムを登録しました"

--- a/spec/support/create_album_macros.rb
+++ b/spec/support/create_album_macros.rb
@@ -1,0 +1,13 @@
+module CreateAlbumMacros
+  def create_album
+    visit profile_albums_path(Profile.last)
+    click_button "アルバムを作成"
+    fill_in "日付", with: "05-09-2023"
+    fill_in "タイトル", with: "海外旅行"
+    fill_in "ノート", with: "楽しかった！"
+    attach_file "album_images", Rails.root.join("spec/fixtures/files/valid_image.jpg")
+    click_button "保存する"
+    expect(page).to have_content "アルバムを登録しました"
+    expect(page).to have_current_path(profile_albums_path(Profile.last))
+  end
+end

--- a/spec/system/albums_spec.rb
+++ b/spec/system/albums_spec.rb
@@ -137,4 +137,19 @@ RSpec.describe "profiles", type: :system do
       end
     end
   end
+
+  describe "アルバム削除" do
+    before do
+      login_as(user)
+      create_profile_one
+      create_album
+      visit profile_album_path(Profile.last, Profile.last.albums.last)
+    end
+
+    it "アルバム詳細ページでアルバムを削除できる" do
+      find("#delete-album-#{Album.last.id}").click
+      expect(page.accept_confirm).to eq "削除しますか？"
+      expect(page).not_to have_css("#album-#{Album.last.id}")
+    end
+  end
 end

--- a/spec/system/albums_spec.rb
+++ b/spec/system/albums_spec.rb
@@ -176,9 +176,70 @@ RSpec.describe "profiles", type: :system do
         find("#album-#{Profile.last.albums.last.id}").click
         expect(page).to have_current_path(profile_album_path(Profile.last, Profile.last.albums.last))
       end
+
       it "編集アイコンをクリックすると、編集ページに遷移する" do
         find("#edit-album-#{Profile.last.albums.last.id}").click
         expect(page).to have_current_path(edit_profile_album_path(Profile.last, Profile.last.albums.last))
+      end
+
+      it "サイドバーにプロフィールの画像と名前が表示される" do
+        within("#default-sidebar") do
+          expect(page).to have_content("山田太郎")
+          expect(page).to have_css("img[src*='valid_image.jpg']")
+        end
+      end
+
+      it "サイドバーからプロフィール詳細に遷移できること" do
+        within("#default-sidebar") do
+          click_link "基本情報"
+        end
+        expect(page).to have_current_path(profile_path(Profile.last))
+      end
+
+      it "サイドバーからアルバム一覧に遷移できること" do
+        within("#default-sidebar") do
+          click_link "アルバム"
+        end
+        expect(page).to have_current_path(profile_albums_path(Profile.last))
+      end
+
+      it "サイドバーから通知設定に遷移できること" do
+        within("#default-sidebar") do
+          click_link "通知設定"
+        end
+        expect(page).to have_current_path(profile_events_path(Profile.last))
+      end
+
+      it "サイドバーから連絡先一覧に遷移できること" do
+        within("#default-sidebar") do
+          click_link "連絡先一覧"
+        end
+        expect(page).to have_current_path(profiles_path)
+      end
+
+      describe "スマホ画面" do
+        before { page.driver.browser.manage.window.resize_to(767, 900) }
+
+        it "トップタブからプロフィール詳細に遷移できること" do
+          within("#top-tab") do
+            click_link "基本情報"
+          end
+          expect(page).to have_current_path(profile_path(Profile.last))
+        end
+
+        it "トップタブからアルバム一覧に遷移できること" do
+          within("#top-tab") do
+            click_link "アルバム"
+          end
+          expect(page).to have_current_path(profile_albums_path(Profile.last))
+        end
+
+        it "トップタブから通知設定に遷移できること" do
+          within("#top-tab") do
+            click_link "通知設定"
+          end
+          expect(page).to have_current_path(profile_events_path(Profile.last))
+        end
       end
     end
 

--- a/spec/system/albums_spec.rb
+++ b/spec/system/albums_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "profiles", type: :system do
         fill_in "ノート", with: "また行きたい"
         attach_file "album_images", [
           Rails.root.join("spec/fixtures/files/valid_image.jpg"),
-          Rails.root.join("spec/fixtures/files/valid_image.jpg"),
+          Rails.root.join("spec/fixtures/files/valid_image.jpg")
         ], multiple: true
         click_button "保存する"
         expect(page).to have_content "更新に失敗しました"

--- a/spec/system/albums_spec.rb
+++ b/spec/system/albums_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "profiles", type: :system do
     before do
       login_as(user)
       create_profile_one
-      create_album
+      create_album_one
       visit profile_albums_path(Profile.last)
     end
 
@@ -142,7 +142,7 @@ RSpec.describe "profiles", type: :system do
     before do
       login_as(user)
       create_profile_one
-      create_album
+      create_album_one
       visit profile_album_path(Profile.last, Profile.last.albums.last)
     end
 
@@ -162,11 +162,39 @@ RSpec.describe "profiles", type: :system do
     end
   end
 
+  describe "アルバム一覧" do
+    before do
+      login_as(user)
+      create_profile_one
+      create_album_one
+      create_album_two
+      visit profile_albums_path(Profile.last)
+    end
+
+    describe "画面遷移" do
+      it "詳細アイコンをクリックすると、詳細ページに遷移する" do
+        find("#album-#{Profile.last.albums.last.id}").click
+        expect(page).to have_current_path(profile_album_path(Profile.last, Profile.last.albums.last))
+      end
+      it "編集アイコンをクリックすると、編集ページに遷移する" do
+        find("#edit-album-#{Profile.last.albums.last.id}").click
+        expect(page).to have_current_path(edit_profile_album_path(Profile.last, Profile.last.albums.last))
+      end
+    end
+
+    describe "表示" do
+      it "作成されたアルバムが表示される" do
+        expect(page).to have_content("海外旅行")
+        expect(page).to have_content("祭り")
+      end
+    end
+  end
+
   describe "アルバム削除" do
     before do
       login_as(user)
       create_profile_one
-      create_album
+      create_album_one
       visit profile_album_path(Profile.last, Profile.last.albums.last)
     end
 

--- a/spec/system/albums_spec.rb
+++ b/spec/system/albums_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe "profiles", type: :system do
+  include LoginMacros
+  include CreateProfileMacros
+  let(:user) { create(:user) }
+
+
+  before do
+    login_as(user)
+    create_profile_one
+    visit profile_albums_path(Profile.last)
+  end
+
+  describe "アルバム作成" do
+    context "フォームの入力値が正常" do
+      it "アルバムの作成が成功する" do
+        click_button "アルバムを作成"
+        fill_in "日付", with: "05-09-2023"
+        fill_in "タイトル", with: "海外旅行"
+        fill_in "ノート", with: "楽しかった！"
+        attach_file "album_images", [
+          Rails.root.join("spec/fixtures/files/valid_image.jpg"),
+          Rails.root.join("spec/fixtures/files/valid_image.jpg")
+        ], multiple: true
+        click_button "保存する"
+        expect(page).to have_content "アルバムを登録しました"
+        expect(page).to have_current_path(profile_albums_path(Profile.last))
+      end
+    end
+
+    context "プロフィール画像がpng, jpeg以外のファイル形式の場合" do
+      it "アルバムの作成が失敗する" do
+        click_button "アルバムを作成"
+        fill_in "日付", with: "05-09-2023"
+        fill_in "タイトル", with: "海外旅行"
+        fill_in "ノート", with: "楽しかった！"
+        attach_file "album_images", Rails.root.join("spec/fixtures/files/invalid_content_type.xlsx")
+        click_button "保存する"
+        expect(page).to have_content "登録に失敗しました"
+        expect(page).to have_current_path(new_profile_album_path(Profile.last))
+      end
+    end
+
+    context "プロフィール画像が3MB以上の場合" do
+      it "アルバムの作成が失敗する" do
+        click_button "アルバムを作成"
+        fill_in "日付", with: "05-09-2023"
+        fill_in "タイトル", with: "海外旅行"
+        fill_in "ノート", with: "楽しかった！"
+        attach_file "album_images", Rails.root.join("spec/fixtures/files/large_image.jpg")
+        click_button "保存する"
+        expect(page).to have_content "登録に失敗しました"
+        expect(page).to have_current_path(new_profile_album_path(Profile.last))
+      end
+    end
+
+    context "プロフィール画像を3枚以上保存する場合" do
+      it "アルバムの作成が失敗する" do
+        click_button "アルバムを作成"
+        fill_in "日付", with: "05-09-2023"
+        fill_in "タイトル", with: "海外旅行"
+        fill_in "ノート", with: "楽しかった！"
+        attach_file "album_images", [
+          Rails.root.join("spec/fixtures/files/valid_image.jpg"),
+          Rails.root.join("spec/fixtures/files/valid_image.jpg"),
+          Rails.root.join("spec/fixtures/files/valid_image.jpg")
+        ], multiple: true
+        click_button "保存する"
+        expect(page).to have_content "登録に失敗しました"
+        expect(page).to have_current_path(new_profile_album_path(Profile.last))
+      end
+    end
+  end
+end

--- a/spec/system/albums_spec.rb
+++ b/spec/system/albums_spec.rb
@@ -3,16 +3,17 @@ require "rails_helper"
 RSpec.describe "profiles", type: :system do
   include LoginMacros
   include CreateProfileMacros
+  include CreateAlbumMacros
+
   let(:user) { create(:user) }
 
-
-  before do
-    login_as(user)
-    create_profile_one
-    visit profile_albums_path(Profile.last)
-  end
-
   describe "アルバム作成" do
+    before do
+      login_as(user)
+      create_profile_one
+      visit profile_albums_path(Profile.last)
+    end
+
     context "フォームの入力値が正常" do
       it "アルバムの作成が成功する" do
         click_button "アルバムを作成"
@@ -69,6 +70,70 @@ RSpec.describe "profiles", type: :system do
         click_button "保存する"
         expect(page).to have_content "登録に失敗しました"
         expect(page).to have_current_path(new_profile_album_path(Profile.last))
+      end
+    end
+  end
+
+  describe "アルバム編集" do
+    before do
+      login_as(user)
+      create_profile_one
+      create_album
+      visit profile_albums_path(Profile.last)
+    end
+
+    context "フォームの入力値が正常" do
+      it "アルバムの更新が成功する" do
+        find("#edit-album-#{Album.last.id}").click
+        fill_in "日付", with: "05-10-2023"
+        fill_in "タイトル", with: "海"
+        fill_in "ノート", with: "また行きたい"
+        attach_file "album_images", Rails.root.join("spec/fixtures/files/valid_image.jpg")
+        click_button "保存する"
+        expect(page).to have_content "アルバムを更新しました"
+        expect(page).to have_current_path(profile_albums_path(Profile.last))
+      end
+    end
+
+    context "プロフィール画像がpng, jpeg以外のファイル形式の場合" do
+      it "アルバムの更新が失敗する" do
+        find("#edit-album-#{Album.last.id}").click
+        fill_in "日付", with: "05-10-2023"
+        fill_in "タイトル", with: "海"
+        fill_in "ノート", with: "また行きたい"
+        attach_file "album_images", Rails.root.join("spec/fixtures/files/invalid_content_type.xlsx")
+        click_button "保存する"
+        expect(page).to have_content "更新に失敗しました"
+        expect(page).to have_current_path(edit_profile_album_path(Profile.last, Album.last))
+      end
+    end
+
+    context "プロフィール画像が3MB以上の場合" do
+      it "アルバムの更新が失敗する" do
+        find("#edit-album-#{Album.last.id}").click
+        fill_in "日付", with: "05-10-2023"
+        fill_in "タイトル", with: "海"
+        fill_in "ノート", with: "また行きたい"
+        attach_file "album_images", Rails.root.join("spec/fixtures/files/large_image.jpg")
+        click_button "保存する"
+        expect(page).to have_content "更新に失敗しました"
+        expect(page).to have_current_path(edit_profile_album_path(Profile.last, Album.last))
+      end
+    end
+
+    context "プロフィール画像を3枚以上保存する場合" do
+      it "アルバムの更新が失敗する" do
+        find("#edit-album-#{Album.last.id}").click
+        fill_in "日付", with: "05-10-2023"
+        fill_in "タイトル", with: "海"
+        fill_in "ノート", with: "また行きたい"
+        attach_file "album_images", [
+          Rails.root.join("spec/fixtures/files/valid_image.jpg"),
+          Rails.root.join("spec/fixtures/files/valid_image.jpg"),
+        ], multiple: true
+        click_button "保存する"
+        expect(page).to have_content "更新に失敗しました"
+        expect(page).to have_current_path(edit_profile_album_path(Profile.last, Album.last))
       end
     end
   end

--- a/spec/system/albums_spec.rb
+++ b/spec/system/albums_spec.rb
@@ -138,6 +138,30 @@ RSpec.describe "profiles", type: :system do
     end
   end
 
+  describe "アルバム詳細" do
+    before do
+      login_as(user)
+      create_profile_one
+      create_album
+      visit profile_album_path(Profile.last, Profile.last.albums.last)
+    end
+
+    describe "画面遷移" do
+      it "編集アイコンをクリックすると、編集ページに遷移する" do
+        find("#edit-album-#{Profile.last.albums.last.id}").click
+        expect(page).to have_current_path(edit_profile_album_path(Profile.last, Profile.last.albums.last))
+      end
+    end
+
+    describe "表示" do
+      it "アルバム詳細情報が表示されている" do
+        expect(page).to have_content("海外旅行")
+        expect(page).to have_content("楽しかった！")
+        expect(page).to have_css("img[src*='valid_image.jpg']")
+      end
+    end
+  end
+
   describe "アルバム削除" do
     before do
       login_as(user)

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -255,6 +255,13 @@ RSpec.describe "profiles", type: :system do
       end
 
       describe "画面遷移" do
+        it "サイドバーにプロフィールの画像と名前が表示される" do
+          within("#default-sidebar") do
+            expect(page).to have_content("山田太郎")
+            expect(page).to have_css("img[src*='valid_image.jpg']")
+          end
+        end
+
         it "サイドバーからプロフィール詳細に遷移できること" do
           within("#default-sidebar") do
             click_link "基本情報"

--- a/spec/system/profiles_spec.rb
+++ b/spec/system/profiles_spec.rb
@@ -535,21 +535,21 @@ RSpec.describe "profiles", type: :system do
       end
 
       describe "画面遷移" do
-        it "トップバーからプロフィール詳細に遷移できること" do
+        it "トップタブからプロフィール詳細に遷移できること" do
           within("#top-tab") do
             click_link "基本情報"
           end
           expect(page).to have_current_path(profile_path(Profile.last))
         end
 
-        it "トップバーからアルバム一覧に遷移できること" do
+        it "トップタブからアルバム一覧に遷移できること" do
           within("#top-tab") do
             click_link "アルバム"
           end
           expect(page).to have_current_path(profile_albums_path(Profile.last))
         end
 
-        it "トップバーから通知設定に遷移できること" do
+        it "トップタブから通知設定に遷移できること" do
           within("#top-tab") do
             click_link "通知設定"
           end


### PR DESCRIPTION
### 概要
アルバムに関するシステムテストを実装する

---
### 背景・目的
アプリの動作確認

---
### 内容
#### アルバム作成
- [x] アルバム作成ボタンをクリックし、フォームに正常な値を入力してアルバムを作成できること
- [x] png, jpeg以外のファイル形式でアルバム作成が失敗すること
- [x] 3MB以上の画像ファイルでアルバム作成が失敗すること
- [x] 3枚以上の画像ファイルでアルバム作成が失敗すること
#### アルバム編集
- [x] 正常な入力でアルバムを編集し、更新できること
- [x] png, jpeg以外のファイル形式でアルバムの更新が失敗すること
- [x] 3MB以上の画像ファイルでアルバムの更新が失敗すること
- [x] 3枚以上の画像ファイルでアルバムの更新が失敗すること
#### アルバム詳細
- [x] 編集アイコンをクリックしてアルバム編集ページに遷移できること
- [x] アルバム詳細情報が表示されること
#### アルバム一覧
- [x] 詳細アイコンをクリックしてアルバム詳細ページに遷移できること
- [x] 編集アイコンをクリックしてアルバム編集ページに遷移できること
- [x] サイドバーにプロフィールの画像と名前が表示されること
- [x] サイドバーからプロフィール詳細に遷移できること
- [x] サイドバーからアルバム一覧に遷移できること
- [x] サイドバーから通知設定に遷移できること
- [x] サイドバーから連絡先一覧に遷移できること
- [x] スマホ画面のトップタブからプロフィール詳細に遷移できること
- [x] スマホ画面のトップタブからアルバム一覧に遷移できること
- [x] スマホ画面のトップタブから通知設定に遷移できること
#### アルバム削除
- [x] 作成されたアルバムが一覧に表示されること
- [x] アルバム詳細ページでアルバムを削除できること

---
### 対応しないこと
- 

---
### 補足
This PR close #362 