### PR TITLE
【テスト】通知設定

### DIFF
--- a/app/views/events/_notification_off.html.erb
+++ b/app/views/events/_notification_off.html.erb
@@ -4,7 +4,7 @@
       <%= render 'shared/error_messages', model: f.object %>
 
       <%= f.fields_for :events do |i| %>
-        <div class="grid grid-cols-2 lg:grid-cols-3 items-center gap-1 mb-4 text-center">
+        <div class="grid grid-cols-2 lg:grid-cols-3 items-center gap-1 mb-4 text-center" data-index="<%= i.index %>">
           <div>
             <%= "#{i.object.name}の" %>
           </div>

--- a/app/views/events/_notification_on.html.erb
+++ b/app/views/events/_notification_on.html.erb
@@ -3,7 +3,7 @@
     <%= render 'shared/error_messages', model: f.object %>
 
     <%= f.fields_for :events do |i| %>
-      <div class="grid grid-cols-2 lg:grid-cols-3 items-center gap-1 mb-4 text-center">
+      <div class="grid grid-cols-2 lg:grid-cols-3 items-center gap-1 mb-4 text-center" data-index="<%= i.index %>">
         <div>
           <%= "#{i.object.name}の" %>
         </div>

--- a/spec/system/albums_spec.rb
+++ b/spec/system/albums_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "profiles", type: :system do
+RSpec.describe "albums", type: :system do
   include LoginMacros
   include CreateProfileMacros
   include CreateAlbumMacros

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -61,7 +61,14 @@ RSpec.describe "notifications", type: :system do
   end
 
   describe "リンク先への遷移" do
+    before do
+      login_as(user)
+      create_profile_one
+      visit profile_events_path(Profile.last)
+    end
+
     context "PC画面" do
+      before { page.driver.browser.manage.window.resize_to(768, 900) }
       it "サイドバーにプロフィールの画像と名前が表示される" do
         within("#default-sidebar") do
           expect(page).to have_content("山田太郎")
@@ -97,8 +104,14 @@ RSpec.describe "notifications", type: :system do
         expect(page).to have_current_path(profiles_path)
       end
 
+      it "LINE友達登録ページへの遷移ができること" do
+        click_link "LINE友達登録"
+        expect(page).to have_current_path(line_qr_code_path)
+      end
     end
+
     context "スマホ画面" do
+      before { page.driver.browser.manage.window.resize_to(767, 900) }
       it "トップタブからプロフィール詳細に遷移できること" do
         within("#top-tab") do
           click_link "基本情報"
@@ -120,6 +133,10 @@ RSpec.describe "notifications", type: :system do
         expect(page).to have_current_path(profile_events_path(Profile.last))
       end
 
+      it "LINE友達登録ページへの遷移ができること" do
+        click_link "LINE友達登録"
+        expect(page).to have_current_path(line_qr_code_path)
+      end
     end
   end
 end

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -1,0 +1,125 @@
+require "rails_helper"
+
+RSpec.describe "notifications", type: :system do
+  include LoginMacros
+  include CreateProfileMacros
+
+  let(:user) { create(:user) }
+
+  describe "通知設定の変更" do
+    context "マイページでの通知設定がONの場合" do
+      it "通知設定を変更できる" do
+        login_as(user)
+        create_profile_one
+        visit profile_events_path(Profile.last)
+
+        within("[data-index='0']") do
+          select "3", from: "form_event_collection_events_attributes_0_notification_timing"
+          select "する", from: "form_event_collection_events_attributes_0_notification_enabled"
+        end
+        within("[data-index='1']") do
+          select "30", from: "form_event_collection_events_attributes_1_notification_timing"
+          select "しない", from: "form_event_collection_events_attributes_1_notification_enabled"
+        end
+        click_button "登録する"
+
+        expect(page).to have_current_path(profile_events_path(Profile.last))
+        within("[data-index='0']") do
+          expect(page).to have_select("form_event_collection_events_attributes_0_notification_timing", selected: "3")
+          expect(page).to have_select("form_event_collection_events_attributes_0_notification_enabled", selected: "する")
+        end
+        within("[data-index='1']") do
+          expect(page).to have_select("form_event_collection_events_attributes_1_notification_timing", selected: "30")
+          expect(page).to have_select("form_event_collection_events_attributes_1_notification_enabled", selected: "しない")
+        end
+      end
+    end
+
+    context "マイページでの通知設定がOFFの場合" do
+      before do
+        login_as(user)
+        create_profile_one
+        visit edit_user_path(user)
+        select "OFF", from: "user_notification_enabled"
+        click_button "更新"
+        visit profile_events_path(Profile.last)
+      end
+
+      it "通知設定を変更できない" do
+        expect(page).not_to have_selector("form_event_collection_events_attributes_0_notification_timing")
+        expect(page).not_to have_selector("form_event_collection_events_attributes_0_notification_enabled")
+        expect(page).not_to have_selector("form_event_collection_events_attributes_1_notification_timing")
+        expect(page).not_to have_selector("form_event_collection_events_attributes_1_notification_enabled")
+        expect(page).not_to have_button("登録する")
+      end
+      it "通知設定変更を促すメッセージと、マイページ編集画面へのリンクを表示" do
+        expect(page).to have_content("※マイページの通知設定がOFFのため、変更できません")
+        click_link "こちら"
+        expect(page).to have_current_path(edit_user_path(user))
+      end
+    end
+  end
+
+  describe "リンク先への遷移" do
+    context "PC画面" do
+      it "サイドバーにプロフィールの画像と名前が表示される" do
+        within("#default-sidebar") do
+          expect(page).to have_content("山田太郎")
+          expect(page).to have_css("img[src*='valid_image.jpg']")
+        end
+      end
+
+      it "サイドバーからプロフィール詳細に遷移できること" do
+        within("#default-sidebar") do
+          click_link "基本情報"
+        end
+        expect(page).to have_current_path(profile_path(Profile.last))
+      end
+
+      it "サイドバーからアルバム一覧に遷移できること" do
+        within("#default-sidebar") do
+          click_link "アルバム"
+        end
+        expect(page).to have_current_path(profile_albums_path(Profile.last))
+      end
+
+      it "サイドバーから通知設定に遷移できること" do
+        within("#default-sidebar") do
+          click_link "通知設定"
+        end
+        expect(page).to have_current_path(profile_events_path(Profile.last))
+      end
+
+      it "サイドバーから連絡先一覧に遷移できること" do
+        within("#default-sidebar") do
+          click_link "連絡先一覧"
+        end
+        expect(page).to have_current_path(profiles_path)
+      end
+
+    end
+    context "スマホ画面" do
+      it "トップタブからプロフィール詳細に遷移できること" do
+        within("#top-tab") do
+          click_link "基本情報"
+        end
+        expect(page).to have_current_path(profile_path(Profile.last))
+      end
+
+      it "トップタブからアルバム一覧に遷移できること" do
+        within("#top-tab") do
+          click_link "アルバム"
+        end
+        expect(page).to have_current_path(profile_albums_path(Profile.last))
+      end
+
+      it "トップタブから通知設定に遷移できること" do
+        within("#top-tab") do
+          click_link "通知設定"
+        end
+        expect(page).to have_current_path(profile_events_path(Profile.last))
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
### 概要
通知設定のシステムテストの実装

---
### 背景・目的
動作確認の自動化

---
### 内容
#### 通知設定の変更
- [x] 通知設定がONの場合、通知設定を変更できる
- [x] 通知設定がOFFの場合、通知設定を変更できない
- [x] 通知設定がOFFの場合、通知設定変更を促すメッセージと、マイページ編集画面へのリンクを表示

#### 画面遷移
- [x] サイドバーにプロフィールの画像と名前が表示される（PC画面）
- [x] サイドバーからプロフィール詳細に遷移できること（PC画面）
- [x] サイドバーからアルバム一覧に遷移できること（PC画面）
- [x] サイドバーから通知設定に遷移できること（PC画面）
- [x] サイドバーから連絡先一覧に遷移できること（PC画面）
- [x] LINE友達登録ページへの遷移ができること（PC画面）
- [x] トップタブからプロフィール詳細に遷移できること（スマホ画面）
- [x] トップタブからアルバム一覧に遷移できること（スマホ画面）
- [x] トップタブから通知設定に遷移できること（スマホ画面）
- [x] LINE友達登録ページへの遷移ができること（スマホ画面）
---
### 対応しないこと
- 

---
### 補足
This close #364 