### PR TITLE
Test/#371 ai message

### DIFF
--- a/app/controllers/openai_api_controller.rb
+++ b/app/controllers/openai_api_controller.rb
@@ -1,18 +1,9 @@
 class OpenaiApiController < ApplicationController
   skip_before_action :require_login
-  before_action :set_client
 
   def show
-    ai_suggest_service = AiSuggestionService.new(@client, session)
-
+    ai_suggest_service = AiSuggestionService.new(session)
     @message = ai_suggest_service.suggest
     @last_question = Question.order(number: :desc).first
-  end
-
-  private
-
-  # config/initializerにAPI Keyを設定しているので、新しいインスタンスをつくるだけでKeyを読み込んでくれる
-  def set_client
-    @client = OpenAI::Client.new
   end
 end

--- a/app/services/ai_suggestion_service.rb
+++ b/app/services/ai_suggestion_service.rb
@@ -1,12 +1,11 @@
 class AiSuggestionService
-  def initialize(client, session)
-    @openai = client
+  def initialize(session)
     @session = session
   end
 
   # レスポンスを返すメソッド
   def suggest
-    response = @openai.chat(
+    response = openai_client.chat(
       parameters: {
         model: "gpt-4o-mini",
         messages: set_prompt
@@ -69,5 +68,9 @@ class AiSuggestionService
 
   def format_answer_content(answer)
     answer.is_a?(Array) ? answer.join(", ") : answer.to_s
+  end
+
+  def openai_client
+    OpenAI::Client.new
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,35 +26,35 @@ answers_data.each do |answer_data|
   Answer.find_or_create_by!(answer_data)
 end
 
-user = User.create!(
-  email: "seed@example.com",
-  name: "Seed User",
-  password: "password123",
-  password_confirmation: "password123",
-  notification_enabled: true
-)
-
-10.times do |n|
-  profile = user.profiles.create!(
-      name: Faker::Name.unique.name,
-      furigana: "てすと",
-      phone: Faker::PhoneNumber.unique.phone_number,
-      email: Faker::Internet.unique.email,
-      line_name: "てすと",
-      address: "東京都中央区123-456",
-      last_contacted: Profile.last_contacteds.keys.sample,
-      note: "久しぶりに連絡を取った！元気そうでよかった！"
-    )
-  profile.events.create!(
-    name: "誕生日",
-    date: Faker::Date.backward(days: 30),
-    notification_timing: [0,1,3,7,14,30,60].sample,
-    notification_enabled: true
-  )
-  profile.events.create!(
-    name: "大切な日",
-    date: Faker::Date.backward(days: 30),
-    notification_timing: [0,1,3,7,14,30,60].sample,
-    notification_enabled: true
-  )
-end
+# user = User.create!(
+#   email: "seed@example.com",
+#   name: "Seed User",
+#   password: "password123",
+#   password_confirmation: "password123",
+#   notification_enabled: true
+# )
+#
+# 10.times do |n|
+#   profile = user.profiles.create!(
+#       name: Faker::Name.unique.name,
+#       furigana: "てすと",
+#       phone: Faker::PhoneNumber.unique.phone_number,
+#       email: Faker::Internet.unique.email,
+#       line_name: "てすと",
+#       address: "東京都中央区123-456",
+#       last_contacted: Profile.last_contacteds.keys.sample,
+#       note: "久しぶりに連絡を取った！元気そうでよかった！"
+#     )
+#   profile.events.create!(
+#     name: "誕生日",
+#     date: Faker::Date.backward(days: 30),
+#     notification_timing: [0,1,3,7,14,30,60].sample,
+#     notification_enabled: true
+#   )
+#   profile.events.create!(
+#     name: "大切な日",
+#     date: Faker::Date.backward(days: 30),
+#     notification_timing: [0,1,3,7,14,30,60].sample,
+#     notification_enabled: true
+#   )
+# end

--- a/spec/system/ai_messages_spec.rb
+++ b/spec/system/ai_messages_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe "ai_messages", type: :system do
+  before do
+    Rails.application.load_seed
+  end
+
+  context "回答が正常の場合" do
+    it "メッセージを提案すること" do
+
+      # OpenAI Clientのモックをつくる
+      openai_client_mock = double("OpenAI client")
+
+      #OpenAI Clientからchatメソッドが呼び出され、レスポンスを設定。レスポンスからdigメソッドが呼び出されるのでハッシュにする
+      allow(openai_client_mock).to receive(:chat).and_return(
+        {
+          "choices" => [
+            { "message" => { "content" => "AIが提案したメッセージです！" } }
+          ]
+        }
+      )
+
+      # 実際に回答する
+      visit introduction_path(1)
+      click_button "質問にすすむ"
+      choose "answer[question1]_friend"
+      click_button "次へ"
+      check "answer[question2]_life"
+      click_button "次へ"
+      choose "answer[question3]_male"
+      expect(page).to have_current_path(question_path(3))
+
+      session = {
+        question1: "friend",
+        question2: "['life']",
+        question3: "male"
+      }
+
+      # 本物のサービスインスタンスをつくり、仮のセッションを渡す
+      ai_suggest_service = AiSuggestionService.new(session)
+
+      # oepnai_clientが呼び出されたとき、APIのインスタンスではなく、mockを渡す
+      allow(ai_suggest_service).to receive(:openai_client).and_return(openai_client_mock)
+
+      # 本物のサービスインスタンスからメソッドを呼び出す。ただし、実際に呼び出されるのはmock
+      expect(ai_suggest_service.suggest).to eq("AIが提案したメッセージです！")
+    end
+  end
+end

--- a/spec/system/ai_messages_spec.rb
+++ b/spec/system/ai_messages_spec.rb
@@ -46,37 +46,177 @@ RSpec.describe "ai_messages", type: :system do
     end
   end
 
-  context "質問1の回答が未選択の場合" do
-    it "質問2に遷移できない" do
-      visit introduction_path(1)
-      click_button "質問にすすむ"
-      click_button "次へ"
-      expect(page).to have_current_path(question_path(1))
+  context "回答未選択" do
+    context "質問1の回答が未選択の場合" do
+      it "質問2に遷移できない" do
+        visit introduction_path(1)
+        click_button "質問にすすむ"
+        click_button "次へ"
+        expect(page).to have_current_path(question_path(1))
+      end
+    end
+
+    context "質問2の回答が未選択の場合" do
+      it "質問3に遷移できない" do
+        visit introduction_path(1)
+        click_button "質問にすすむ"
+        choose "answer[question1]_friend"
+        click_button "次へ"
+        click_button "次へ"
+        alert = page.driver.browser.switch_to.alert
+        expect(alert.text).to eq("少なくとも1つ選択してください。")
+      end
+    end
+
+    context "質問3の回答が未選択の場合" do
+      it "AIメッセージ提案ページに遷移できない" do
+        visit introduction_path(1)
+        click_button "質問にすすむ"
+        choose "answer[question1]_friend"
+        click_button "次へ"
+        check "answer[question2]_life"
+        click_button "次へ"
+        click_button "次へ"
+        expect(page).to have_current_path(question_path(3))
+      end
     end
   end
 
-  context "質問2の回答が未選択の場合" do
-    it "質問3に遷移できない" do
-      visit introduction_path(1)
-      click_button "質問にすすむ"
-      choose "answer[question1]_friend"
-      click_button "次へ"
-      click_button "次へ"
-      alert = page.driver.browser.switch_to.alert
-      expect(alert.text).to eq("少なくとも1つ選択してください。")
-    end
-  end
+  describe "パンくず" do
+    context "イントロページ上" do
+      before { visit introduction_path(1) }
 
-  context "質問3の回答が未選択の場合" do
-    it "AIメッセージ提案ページに遷移できない" do
-      visit introduction_path(1)
-      click_button "質問にすすむ"
-      choose "answer[question1]_friend"
-      click_button "次へ"
-      check "answer[question2]_life"
-      click_button "次へ"
-      click_button "次へ"
-      expect(page).to have_current_path(question_path(3))
+      it "Topとイントロが表示される" do
+        within(".breadcrumbs") do
+          expect(page).to have_content("Top")
+          expect(page).to have_content("イントロ")
+        end
+      end
+
+      it "Topページに遷移できる" do
+        within(".breadcrumbs") do
+          click_link "Top"
+        end
+        expect(page).to have_current_path(root_path)
+      end
+    end
+
+    context "質問1ページ上" do
+      before do
+        visit introduction_path(1)
+        click_button "質問にすすむ"
+        choose "answer[question1]_friend"
+      end
+
+      it "Top、イントロ、質問1が表示される" do
+        within(".breadcrumbs") do
+          expect(page).to have_content("Top")
+          expect(page).to have_content("イントロ")
+          expect(page).to have_content("質問1")
+        end
+      end
+
+      it "Topページに遷移できる" do
+        within(".breadcrumbs") do
+          click_link "Top"
+        end
+        expect(page).to have_current_path(root_path)
+      end
+
+      it "イントロページに遷移できる" do
+        within(".breadcrumbs") do
+          click_link "イントロ"
+        end
+        expect(page).to have_current_path(introduction_path(1))
+      end
+    end
+
+    context "質問2ページ上" do
+      before do
+        visit introduction_path(1)
+        click_button "質問にすすむ"
+        choose "answer[question1]_friend"
+        click_button "次へ"
+      end
+
+      it "Top、イントロ、質問1、質問2が表示される" do
+        within(".breadcrumbs") do
+          expect(page).to have_content("Top")
+          expect(page).to have_content("イントロ")
+          expect(page).to have_content("質問1")
+          expect(page).to have_content("質問2")
+        end
+      end
+
+      it "Topページに遷移できる" do
+        within(".breadcrumbs") do
+          click_link "Top"
+        end
+        expect(page).to have_current_path(root_path)
+      end
+
+      it "イントロページに遷移できる" do
+        within(".breadcrumbs") do
+          click_link "イントロ"
+        end
+        expect(page).to have_current_path(introduction_path(1))
+      end
+
+      it "質問1ページに遷移できる" do
+        within(".breadcrumbs") do
+          click_link "質問1"
+        end
+        expect(page).to have_current_path(question_path(1))
+      end
+    end
+
+    context "質問3ページ上" do
+      before do
+        visit introduction_path(1)
+        click_button "質問にすすむ"
+        choose "answer[question1]_friend"
+        click_button "次へ"
+        check "answer[question2]_life"
+        click_button "次へ"
+      end
+
+      it "Top、イントロ、質問1、質問2、質問3が表示される" do
+        within(".breadcrumbs") do
+          expect(page).to have_content("Top")
+          expect(page).to have_content("イントロ")
+          expect(page).to have_content("質問1")
+          expect(page).to have_content("質問2")
+          expect(page).to have_content("質問3")
+        end
+      end
+
+      it "Topページに遷移できる" do
+        within(".breadcrumbs") do
+          click_link "Top"
+        end
+        expect(page).to have_current_path(root_path)
+      end
+
+      it "イントロページに遷移できる" do
+        within(".breadcrumbs") do
+          click_link "イントロ"
+        end
+        expect(page).to have_current_path(introduction_path(1))
+      end
+
+      it "質問1ページに遷移できる" do
+        within(".breadcrumbs") do
+          click_link "質問1"
+        end
+        expect(page).to have_current_path(question_path(1))
+      end
+
+      it "質問2ページに遷移できる" do
+        within(".breadcrumbs") do
+          click_link "質問2"
+        end
+        expect(page).to have_current_path(question_path(2))
+      end
     end
   end
 end

--- a/spec/system/ai_messages_spec.rb
+++ b/spec/system/ai_messages_spec.rb
@@ -7,11 +7,10 @@ RSpec.describe "ai_messages", type: :system do
 
   context "回答が正常の場合" do
     it "メッセージを提案すること" do
-
       # OpenAI Clientのモックをつくる
       openai_client_mock = double("OpenAI client")
 
-      #OpenAI Clientからchatメソッドが呼び出され、レスポンスを設定。レスポンスからdigメソッドが呼び出されるのでハッシュにする
+      # OpenAI Clientからchatメソッドが呼び出され、レスポンスを設定。レスポンスからdigメソッドが呼び出されるのでハッシュにする
       allow(openai_client_mock).to receive(:chat).and_return(
         {
           "choices" => [
@@ -44,6 +43,40 @@ RSpec.describe "ai_messages", type: :system do
 
       # 本物のサービスインスタンスからメソッドを呼び出す。ただし、実際に呼び出されるのはmock
       expect(ai_suggest_service.suggest).to eq("AIが提案したメッセージです！")
+    end
+  end
+
+  context "質問1の回答が未選択の場合" do
+    it "質問2に遷移できない" do
+      visit introduction_path(1)
+      click_button "質問にすすむ"
+      click_button "次へ"
+      expect(page).to have_current_path(question_path(1))
+    end
+  end
+
+  context "質問2の回答が未選択の場合" do
+    it "質問3に遷移できない" do
+      visit introduction_path(1)
+      click_button "質問にすすむ"
+      choose "answer[question1]_friend"
+      click_button "次へ"
+      click_button "次へ"
+      alert = page.driver.browser.switch_to.alert
+      expect(alert.text).to eq("少なくとも1つ選択してください。")
+    end
+  end
+
+  context "質問3の回答が未選択の場合" do
+    it "AIメッセージ提案ページに遷移できない" do
+      visit introduction_path(1)
+      click_button "質問にすすむ"
+      choose "answer[question1]_friend"
+      click_button "次へ"
+      check "answer[question2]_life"
+      click_button "次へ"
+      click_button "次へ"
+      expect(page).to have_current_path(question_path(3))
     end
   end
 end


### PR DESCRIPTION
### 概要
AIメッセージのシステムテストを実装する

---
### 背景・目的
動作確認の自動化

---
### 内容
### AIメッセージ提案機能のテスト

- [x] **回答が正常の場合**
  - メッセージを提案すること。

- [x] **回答未選択の場合**
  - **質問1の回答が未選択の場合**
    - 質問2に遷移できないこと。
  - **質問2の回答が未選択の場合**
    - 「少なくとも1つ選択してください」というアラートが表示され、質問3に遷移できないこと。
  - **質問3の回答が未選択の場合**
    - AIメッセージ提案ページに遷移できないこと。

### パンくずリストのテスト

- [x] **イントロページ上**
  - `Top`と`イントロ`が表示されること。
  - `Top`ページに遷移できること。

- [x] **質問1ページ上**
  - `Top`、`イントロ`、`質問1`が表示されること。
  - `Top`ページに遷移できること。
  - `イントロ`ページに遷移できること。

- [x] **質問2ページ上**
  - `Top`、`イントロ`、`質問1`、`質問2`が表示されること。
  - `Top`ページに遷移できること。
  - `イントロ`ページに遷移できること。
  - `質問1`ページに遷移できること。

- [x] **質問3ページ上**
  - `Top`、`イントロ`、`質問1`、`質問2`、`質問3`が表示されること。
  - `Top`ページに遷移できること。
  - `イントロ`ページに遷移できること。
  - `質問1`ページに遷移できること。
  - `質問2`ページに遷移できること。

---
### 対応しないこと
- 

---
### 補足
This PR close #371 