### PR TITLE
Test/#377 rspec coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+# Ignore RSpec coverage directory
+/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,9 @@ group :development, :test do
   # To find bug
   gem 'pry-rails'
   gem 'pry-byebug'
+
+  # Analyse RSpec coverage
+  gem 'simplecov'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,7 @@ GEM
       reline (>= 0.3.8)
     deep_merge (1.2.2)
     diff-lcs (1.5.1)
+    docile (1.4.1)
     dotenv (3.1.4)
     drb (2.2.1)
     enum_help (0.0.19)
@@ -381,6 +382,12 @@ GEM
       websocket (~> 1.0)
     simple_calendar (3.0.4)
       rails (>= 6.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -473,6 +480,7 @@ DEPENDENCIES
   scout_apm
   selenium-webdriver
   simple_calendar
+  simplecov
   sorcery
   sprockets-rails
   stimulus-rails

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -97,4 +97,12 @@ RSpec.configure do |config|
   config.before(:all) do
     FileUtils.rm_rf(Dir[Rails.root.join("tmp", "capybara", "*")], secure: true) unless ENV["CI"]
   end
+
+  # RSpecのカバー率を計算する
+  if ENV["CIRCLE_ARTIFACTS"]
+    dir = File.join(ENV["CIRCLE_ARTIFACTS"], "coverage")
+    SimpleCov.coverage_dir(dir)
+  end
+
+  SimpleCov.start
 end

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -5,6 +5,6 @@ module LoginMacros
     fill_in "パスワード", with: "password"
     click_button "ログイン"
     # ログイン処理が完了することを担保する
-    expect(page).to have_current_path(root_path)
+    expect(page).to have_content("ログインしました")
   end
 end


### PR DESCRIPTION
### 概要
RSpecテストのカバー率を確認するGemをインストール

---
### 背景・目的
RSpecテストのカバー率を確認する

---
### 内容
- [x] SimpleCovをインストール
- [x] SimpleCovをRSpec時に実行するよう設定
- [x] SimpleCovで生成されたディレクトリ（/coverage）はgitの追跡から除外する
- [x] ログインマクロモジュールでログイン後「ログインしました」の表示が出ることを確認する

---
### 対応しないこと
- 

---
### 補足
#### カバー率計算の結果
[![Image from Gyazo](https://i.gyazo.com/eec0f22284313c1a03841b738581c069.png)](https://gyazo.com/eec0f22284313c1a03841b738581c069)

This PR close #377 