### PR TITLE
Design/#389 header logo position

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,7 +1,7 @@
 <header class="top-0 left-0 w-full h-14 md:block flex justify-center bg-peach-light">
   <nav class="flex justify-between items-center h-14 w-full">
     <div class="flex items-center md:ml-8">
-      <%= image_tag "logo.png", class:"w-8 md:w-11 h-auto mr-2 mb-2"%>
+      <%= image_tag "logo.png", class:"w-8 ml-2 md:ml-0 md:w-11 h-auto mr-2 mb-2"%>
       <%= link_to root_path do %>
         <span class="text-lg md:text-4xl">Stay Friends</span><span class="text-xs md:text-xl"> ～友だちと再びつながるアプリ～</span>
       <% end %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,7 +1,7 @@
 <header class="top-0 left-0 w-full h-14 md:block flex justify-center bg-peach-light">
   <nav class="flex justify-between items-center h-14 w-full">
     <div class="flex items-center md:ml-8">
-      <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
+      <%= image_tag "logo.png", class:"w-8 md:w-11 h-auto mr-2 mb-2"%>
       <%= link_to root_path do %>
         <span class="text-lg md:text-4xl">Stay Friends</span><span class="text-xs md:text-xl"> ～友だちと再びつながるアプリ～</span>
       <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <header class="top-0 left-0 w-full h-14 md:block flex justify-center bg-peach-light">
   <nav class="flex justify-between items-center h-14 w-full">
     <div class="flex items-center ml-2 md:ml-8">
-      <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
+      <%= image_tag "logo.png", class:"w-8 md:w-11 h-auto mr-2 mb-2"%>
       <%= link_to root_path do %>
         <span class="text-lg md:text-4xl">Stay Friends</span><span class="text-xs md:text-xl"> ～友だちと再びつながるアプリ～</span>
       <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <header class="top-0 left-0 w-full h-14 md:block flex justify-center bg-peach-light">
   <nav class="flex justify-between items-center h-14 w-full">
     <div class="flex items-center ml-2 md:ml-8">
-      <%= image_tag "logo.png", class:"w-8 md:w-11 h-auto mr-2 mb-2"%>
+      <%= image_tag "logo.png", class:"w-8 ml-2 md:ml-0 md:w-11 h-auto mr-2 mb-2"%>
       <%= link_to root_path do %>
         <span class="text-lg md:text-4xl">Stay Friends</span><span class="text-xs md:text-xl"> ～友だちと再びつながるアプリ～</span>
       <% end %>


### PR DESCRIPTION
### 概要
ヘッダーのロゴの位置を微修正

---
### 背景・目的
体裁を整え、見栄えを良くする

---
### 内容
- [x] ヘッダーのロゴの位置を、アプリ名と下揃えする
- before
[![Image from Gyazo](https://i.gyazo.com/3b45641fdcfe642ccaa120f23d0ec171.png)](https://gyazo.com/3b45641fdcfe642ccaa120f23d0ec171)
- after
[![Image from Gyazo](https://i.gyazo.com/438d7725fc2da147c8b9e768286626d7.png)](https://gyazo.com/438d7725fc2da147c8b9e768286626d7)
- [x] md幅以下の場合は、ヘッダーのロゴの左側にマージンを追加し余白をつくる
- before
[![Image from Gyazo](https://i.gyazo.com/64175065282c934ccaa7699d279dd178.png)](https://gyazo.com/64175065282c934ccaa7699d279dd178)
- after
[![Image from Gyazo](https://i.gyazo.com/37ea49f6c955c50c10d1bef6dae988e8.png)](https://gyazo.com/37ea49f6c955c50c10d1bef6dae988e8)



---
### 対応しないこと
- 

---
### 補足