### PR TITLE
ヘッダーロゴの位置修正を取り消し、アプリ名と下揃えにするよう再度設定する

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,7 +1,7 @@
 <header class="top-0 left-0 w-full h-14 md:block flex justify-center bg-peach-light">
   <nav class="flex justify-between items-center h-14 w-full">
     <div class="flex items-center md:ml-8">
-      <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
+      <%= image_tag "logo.png", class:"w-10 h-auto mr-2 mb-2"%>
       <%= link_to root_path do %>
         <span class="text-lg md:text-4xl">Stay Friends</span><span class="text-xs md:text-xl"> ～友だちと再びつながるアプリ～</span>
       <% end %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,7 +1,7 @@
 <header class="top-0 left-0 w-full h-14 md:block flex justify-center bg-peach-light">
   <nav class="flex justify-between items-center h-14 w-full">
     <div class="flex items-center md:ml-8">
-      <%= image_tag "logo.png", class:"w-8 ml-2 md:ml-0 md:w-11 h-auto mr-2 mb-2"%>
+      <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>
         <span class="text-lg md:text-4xl">Stay Friends</span><span class="text-xs md:text-xl"> ～友だちと再びつながるアプリ～</span>
       <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <header class="top-0 left-0 w-full h-14 md:block flex justify-center bg-peach-light">
   <nav class="flex justify-between items-center h-14 w-full">
     <div class="flex items-center ml-2 md:ml-8">
-      <%= image_tag "logo.png", class:"w-8 ml-2 md:ml-0 md:w-11 h-auto mr-2 mb-2"%>
+      <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
       <%= link_to root_path do %>
         <span class="text-lg md:text-4xl">Stay Friends</span><span class="text-xs md:text-xl"> ～友だちと再びつながるアプリ～</span>
       <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <header class="top-0 left-0 w-full h-14 md:block flex justify-center bg-peach-light">
   <nav class="flex justify-between items-center h-14 w-full">
     <div class="flex items-center ml-2 md:ml-8">
-      <%= image_tag "logo.png", class:"w-10 h-auto mr-2"%>
+      <%= image_tag "logo.png", class:"w-10 h-auto mr-2 mb-2"%>
       <%= link_to root_path do %>
         <span class="text-lg md:text-4xl">Stay Friends</span><span class="text-xs md:text-xl"> ～友だちと再びつながるアプリ～</span>
       <% end %>


### PR DESCRIPTION
### 概要
ヘッダーロゴの位置修正を取り消し、アプリ名と下揃えにするよう再度設定する

---
### 背景・目的
下記イシューでロゴを修正した際、デプロイ後ロゴ画像表示に不具合が出たため
[画像自体の大きさを調整し、左側にマージンを追加した](https://github.com/wassupdee/RUNTEQ_portfolio/issues/389)

[![Image from Gyazo](https://i.gyazo.com/d83f00d878237cdb8dcb17e24916637b.png)](https://gyazo.com/d83f00d878237cdb8dcb17e24916637b)
---

### 内容
- [x] [イシュー](https://github.com/wassupdee/RUNTEQ_portfolio/issues/389)で設定したデザインを削除
- [x] 再度、`mb-2`のみヘッダーのロゴに付ける

---
### 対応しないこと
- 

---
### 補足
This PR close #391 

